### PR TITLE
Fixes entrypoint path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN poetry install --only main
 
 COPY entrypoint.py /usr/src/app/
 
-CMD [ "poetry", "run", "python", "entrypoint.py" ]
+CMD [ "poetry", "run", "python", "/usr/src/app/entrypoint.py" ]


### PR DESCRIPTION
GitHub overrides `WORKDIR` when running the Action and sets it to `/github/workspace` (rather than `/usr/src/app` as defined in `Dockerfile`. This in turn causes the run to fail.

Closes #4.