### PR TITLE
fix(spdx): correct COMPONENT_NAME override for SPDX SBOMs

### DIFF
--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -2743,14 +2743,9 @@ def _apply_sbom_name_override(sbom_file: str, config: "Config") -> None:
                     json.dump(updated_json, f, indent=2)
 
         elif sbom_format == "spdx":
-            # For SPDX, apply name override directly to JSON
-            if "metadata" not in original_json:
-                original_json["metadata"] = {}
-            if "component" not in original_json["metadata"]:
-                original_json["metadata"]["component"] = {}
-
-            existing_name = original_json["metadata"]["component"].get("name", "unknown")
-            original_json["metadata"]["component"]["name"] = config.component_name
+            # For SPDX, apply name override to the top-level "name" field
+            existing_name = original_json.get("name", "unknown")
+            original_json["name"] = config.component_name
             logger.info(f"Overriding SPDX component name: '{existing_name}' -> '{config.component_name}'")
 
             with Path(sbom_file).open("w") as f:


### PR DESCRIPTION
SPDX SBOMs were not properly applying the COMPONENT_NAME environment variable override due to incorrect field mapping. The code was trying to set the component name at `metadata.component.name` (CycloneDX format) instead of the top-level `name` field used by SPDX format.

This fix ensures that when COMPONENT_NAME is set (e.g., to "mariadb"), SPDX SBOMs with SHA-based names like "sbom-sha256:d0eb..." are correctly overridden to use the specified component name.

Changes:
- Fix _apply_sbom_name_override() to use top-level `name` field for SPDX
- Add comprehensive test case for SPDX name override functionality
- Maintain backward compatibility with existing CycloneDX behavior

Fixes issue where SPDX enrichment was not respecting COMPONENT_NAME setting.