### PR TITLE
Fixes TypeError in augmentation

### DIFF
--- a/sbomify_action/augmentation.py
+++ b/sbomify_action/augmentation.py
@@ -159,6 +159,16 @@ def _add_sbomify_tool_to_cyclonedx(bom: Bom) -> None:
     Args:
         bom: The Bom object to update with tool metadata
     """
+    # Normalize existing tools to ensure vendor is properly typed
+    # This prevents comparison errors when adding new tools with OrganizationalEntity vendors
+    existing_tools = list(bom.metadata.tools.tools)
+    for tool in existing_tools:
+        if tool.vendor is not None and isinstance(tool.vendor, str):
+            # Convert string vendor to OrganizationalEntity
+            bom.metadata.tools.tools.remove(tool)
+            tool.vendor = OrganizationalEntity(name=tool.vendor)
+            bom.metadata.tools.tools.add(tool)
+
     # Create sbomify tool entry
     sbomify_vendor = OrganizationalEntity(name=SBOMIFY_VENDOR_NAME)
     sbomify_tool = Tool(vendor=sbomify_vendor, name=SBOMIFY_TOOL_NAME, version=SBOMIFY_VERSION)


### PR DESCRIPTION
Resolves issue in CI run:

```bash

  [2025-11-27 14:02:35] INFO - sbomify_action - Overriding component name: 'sbomify-github-action' -> 'sbomify-github-action'
  [2025-11-27 14:02:35] INFO - sbomify_action - Set component version from configuration: master-7f74b9412b946d90b9812964dddcdea6ea819e85
  [2025-11-27 14:02:35] ERROR - sbomify_action - Failed to augment SBOM: '<' not supported between instances of 'OrganizationalEntity' and 'str'
  Traceback (most recent call last):
    File "/opt/venv/bin/sbomify-action", line 10, in <module>
      sys.exit(main())
               ~~~~^^
    File "/opt/venv/lib/python3.13/site-packages/sbomify_action/cli/main.py", line 1111, in main
      sbom_format = augment_sbom_from_file(
          input_file=sbom_input_file,
      ...<6 lines>...
          component_version=config.component_version,
      )
    File "/opt/venv/lib/python3.13/site-packages/sbomify_action/augmentation.py", line 717, in augment_sbom_from_file
      serialized = serialize_cyclonedx_bom(bom, spec_version)
    File "/opt/venv/lib/python3.13/site-packages/sbomify_action/serialization.py", line 135, in serialize_cyclonedx_bom
      return outputter.output_as_string()
             ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
    File "/opt/venv/lib/python3.13/site-packages/cyclonedx/output/json.py", line 83, in output_as_string
      self.generate()
      ~~~~~~~~~~~~~^^
    File "/opt/venv/lib/python3.13/site-packages/cyclonedx/output/json.py", line 74, in generate
      bom.as_json(  # type:ignore[attr-defined]
      ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          view_=_view))
          ^^^^^^^^^^^^
    File "/opt/venv/lib/python3.13/site-packages/py_serializable/__init__.py", line 297, in as_json
      return json_dumps(self, cls=_SerializableJsonEncoder, view_=view_)
    File "/usr/local/lib/python3.13/json/__init__.py", line 238, in dumps
      **kw).encode(obj)
            ~~~~~~^^^^^
    File "/usr/local/lib/python3.13/json/encoder.py", line 200, in encode
      chunks = self.iterencode(o, _one_shot=True)
    File "/usr/local/lib/python3.13/json/encoder.py", line 261, in iterencode
      return _iterencode(o, 0)
    File "/opt/venv/lib/python3.13/site-packages/py_serializable/__init__.py", line 251, in default
      v = prop_info.custom_type.json_normalize(
          v, view=self._view, prop_info=prop_info, ctx=o.__class__)
    File "/opt/venv/lib/python3.13/site-packages/cyclonedx/model/tool.py", line 297, in json_normalize
      ts = cls.__all_as_tools(o)
    File "/opt/venv/lib/python3.13/site-packages/cyclonedx/model/tool.py", line 279, in __all_as_tools
      return SortedSet(chain(
          o.tools,
          map(Tool.from_component, o.components),
          map(Tool.from_service, o.services),
      ))
    File "/opt/venv/lib/python3.13/site-packages/sortedcontainers/sortedset.py", line 168, in __init__
      self._update(iterable)
      ~~~~~~~~~~~~^^^^^^^^^^
    File "/opt/venv/lib/python3.13/site-packages/sortedcontainers/sortedset.py", line 687, in update
      _list.update(_set)
      ~~~~~~~~~~~~^^^^^^
    File "/opt/venv/lib/python3.13/site-packages/sortedcontainers/sortedlist.py", line 338, in update
      values = sorted(iterable)
    File "/opt/venv/lib/python3.13/site-packages/cyclonedx/model/tool.py", line 165, in __lt__
      return self.__comparable_tuple() < other.__comparable_tuple()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/venv/lib/python3.13/site-packages/cyclonedx/_internal/compare.py", line 45, in __lt__
      return bool(s < o)
                  ^^^^^
  TypeError: '<' not supported between instances of 'OrganizationalEntity' and 'str'
  Sentry is attempting to send 3 pending events
  Waiting up to 2 seconds
  Press Ctrl-C to quit```