### PR TITLE
Fix Tool vendor type comparison error in CycloneDX serialization

### DIFF
--- a/sbomify_action/augmentation.py
+++ b/sbomify_action/augmentation.py
@@ -162,12 +162,24 @@ def _add_sbomify_tool_to_cyclonedx(bom: Bom) -> None:
     # Normalize existing tools to ensure vendor is properly typed
     # This prevents comparison errors when adding new tools with OrganizationalEntity vendors
     existing_tools = list(bom.metadata.tools.tools)
+    normalized_tools = []
+
     for tool in existing_tools:
         if tool.vendor is not None and isinstance(tool.vendor, str):
-            # Convert string vendor to OrganizationalEntity
-            bom.metadata.tools.tools.remove(tool)
-            tool.vendor = OrganizationalEntity(name=tool.vendor)
-            bom.metadata.tools.tools.add(tool)
+            # Create a new Tool with OrganizationalEntity vendor
+            normalized_tool = Tool(vendor=OrganizationalEntity(name=tool.vendor), name=tool.name, version=tool.version)
+            # Copy external references if any
+            if tool.external_references:
+                normalized_tool.external_references = tool.external_references
+            normalized_tools.append(normalized_tool)
+        else:
+            # Keep tool as is if vendor is already OrganizationalEntity or None
+            normalized_tools.append(tool)
+
+    # Clear and rebuild the tools set with normalized tools
+    bom.metadata.tools.tools.clear()
+    for tool in normalized_tools:
+        bom.metadata.tools.tools.add(tool)
 
     # Create sbomify tool entry
     sbomify_vendor = OrganizationalEntity(name=SBOMIFY_VENDOR_NAME)


### PR DESCRIPTION
The error occurred when CycloneDX library tried to sort tools in a SortedSet during serialization. Some tools had string vendors while the sbomify tool used OrganizationalEntity, causing a TypeError during comparison.

Fixed by:
- Properly normalizing all existing tools by creating new Tool objects with OrganizationalEntity vendors instead of modifying in place
- Clearing and rebuilding the tools set to ensure consistent typing
- Preserving all tool metadata including external references

This ensures all tools have OrganizationalEntity vendors, preventing comparison errors during SBOM serialization.

Fixes: TypeError: '<' not supported between instances of 'OrganizationalEntity' and 'str'

