### PR TITLE
feat: add Java/Maven pom.xml support for SBOM generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ When uploading to Dependency Track (`UPLOAD_DESTINATIONS=dependency-track`), con
 | Ruby | `Gemfile.lock` |
 | Dart | `pubspec.lock` |
 | C++ | `conan.lock` |
+| Java | `pom.xml` |
 
 ## Additional Packages
 

--- a/sbomify_action/_generation/utils.py
+++ b/sbomify_action/_generation/utils.py
@@ -29,6 +29,7 @@ RUBY_LOCK_FILES = ["Gemfile.lock"]
 GO_LOCK_FILES = ["go.mod"]
 DART_LOCK_FILES = ["pubspec.lock"]
 CPP_LOCK_FILES = ["conan.lock"]
+JAVA_LOCK_FILES = ["pom.xml"]
 
 # All supported lock files
 ALL_LOCK_FILES = (
@@ -39,6 +40,7 @@ ALL_LOCK_FILES = (
     + GO_LOCK_FILES
     + DART_LOCK_FILES
     + CPP_LOCK_FILES
+    + JAVA_LOCK_FILES
 )
 
 # Default command timeout in seconds
@@ -126,6 +128,8 @@ def get_lock_file_ecosystem(lock_file_name: str) -> Optional[str]:
         return "dart"
     elif lock_file_name in CPP_LOCK_FILES:
         return "cpp"
+    elif lock_file_name in JAVA_LOCK_FILES:
+        return "java"
     return None
 
 

--- a/tests/test_generation_plugin.py
+++ b/tests/test_generation_plugin.py
@@ -531,6 +531,12 @@ class TestUtilsFunctions(unittest.TestCase):
         self.assertEqual(get_lock_file_ecosystem("package.json"), "javascript")
         self.assertEqual(get_lock_file_ecosystem("yarn.lock"), "javascript")
 
+    def test_get_lock_file_ecosystem_java(self):
+        """Test ecosystem detection for Java lock files."""
+        from sbomify_action._generation.utils import get_lock_file_ecosystem
+
+        self.assertEqual(get_lock_file_ecosystem("pom.xml"), "java")
+
     def test_get_lock_file_ecosystem_unknown(self):
         """Test ecosystem detection for unknown lock files."""
         from sbomify_action._generation.utils import get_lock_file_ecosystem


### PR DESCRIPTION
- Add JAVA_LOCK_FILES constant with pom.xml
- Register pom.xml in ALL_LOCK_FILES for Trivy generator
- Add java ecosystem detection in get_lock_file_ecosystem()
- Update README with Java in Supported Lockfiles table
- Add test for Java ecosystem detection
