### PR TITLE
feat(docker): add multi-arch support and modernize base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
 RUN TRIVY_ARCH=$(case ${TARGETARCH} in \
         amd64) echo "64bit" ;; \
         arm64) echo "ARM64" ;; \
-        *) echo "64bit" ;; \
+        *) echo "Unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
     esac) && \
     curl -sL \
         -o trivy_${TRIVY_VERSION}_Linux-${TRIVY_ARCH}.tar.gz \
@@ -82,6 +82,7 @@ ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 RUN uv venv /opt/venv
+# Use --active so uv installs into the existing VIRTUAL_ENV (/opt/venv) instead of .venv
 RUN uv sync --locked --active
 RUN rm -rf dist/ && uv build
 RUN uv pip install dist/sbomify_github_action-*.whl


### PR DESCRIPTION
- Upgrade base images from python:3-slim-bullseye to python:3.13-slim-trixie
- Add TARGETARCH support for dynamic architecture detection (amd64/arm64)
- Use architecture-specific URLs for trivy, bomctl, and syft downloads
- Split bun/cdxgen into separate build stage using oven/bun:debian
- Consolidate RUN commands to reduce image layers
- Add libxml2-dev and libxslt-dev for lxml compilation
- Use uv sync --active to respect VIRTUAL_ENV
- Remove redundant pip install cyclonedx-bom (already in lockfile)

This enables multi-platform builds with:
  docker buildx build --platform linux/amd64,linux/arm64
