### PR TITLE
fix: skip redundant component name override when name already matches

### DIFF
--- a/sbomify_action/augmentation.py
+++ b/sbomify_action/augmentation.py
@@ -490,14 +490,15 @@ def augment_cyclonedx_sbom(
     if component_name:
         if hasattr(bom.metadata, "component") and bom.metadata.component:
             existing_name = bom.metadata.component.name or "unknown"
-            bom.metadata.component.name = component_name
+            if existing_name != component_name:
+                bom.metadata.component.name = component_name
+                logger.info(f"Overriding component name: '{existing_name}' -> '{component_name}'")
         else:
             # Create component if it doesn't exist
-            existing_name = "none (creating new component)"
             bom.metadata.component = Component(
                 name=component_name, type=ComponentType.APPLICATION, version=component_version or "unknown"
             )
-        logger.info(f"Overriding component name: '{existing_name}' -> '{component_name}'")
+            logger.info(f"Overriding component name: 'none (creating new component)' -> '{component_name}'")
 
     # Apply component version override if specified
     if component_version:


### PR DESCRIPTION
The component name override logic was running in both Step 1 (_apply_sbom_name_override in main.py) and Step 2 (augment_sbom in augmentation.py), causing duplicate log messages like:
  'github.com/aquasecurity/trivy' -> 'Trivy'  (Step 1)
  'Trivy' -> 'Trivy'                          (Step 2 - redundant)

Now both locations check if existing_name != component_name before applying the override and logging. Also optimized main.py to skip file serialization when no change is needed.
