### PR TITLE
fix: add lazy Go installation for cdxgen Go module scanning

### DIFF
--- a/sbomify_action/_generation/generators/cdxgen.py
+++ b/sbomify_action/_generation/generators/cdxgen.py
@@ -26,6 +26,7 @@ from ..result import GenerationResult
 from ..utils import (
     CDXGEN_LOCK_FILES,
     DEFAULT_TIMEOUT,
+    ensure_go_installed,
     ensure_java_maven_installed,
     get_lock_file_ecosystem,
     run_command,
@@ -131,6 +132,10 @@ class CdxgenFsGenerator:
         # Install Java/Maven on-demand for Java/Scala ecosystems
         if ecosystem in ("java", "scala"):
             ensure_java_maven_installed()
+
+        # Install Go on-demand for Go ecosystem
+        if ecosystem == "go":
+            ensure_go_installed()
 
         cmd = [
             "cdxgen",


### PR DESCRIPTION
cdxgen requires Go to be installed to run `go list -deps` for proper dependency resolution. Without it, the --fail-on-error flag causes cdxgen to exit with status 1 when scanning go.mod files.

This adds on-demand Go installation following the existing pattern used for Java/Maven:
- Thread-safe installation with double-check locking
- Skips if Go is already available in PATH
- Installs golang package via apt-get with --no-install-recommends
- Caches installation state to avoid repeated checks

This keeps the base Docker image lean while supporting Go projects that need full dependency resolution.
