### PR TITLE
fix: resolve DUPLICATE_NAME error recovery in releases API

### DIFF
--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -473,10 +473,13 @@ class TestSbomifyReleasesProcessor(unittest.TestCase):
             "error_code": "DUPLICATE_NAME",
         }
 
-        # Mock get release ID after duplicate error
+        # Mock get release ID by name after duplicate error
         get_id_response = Mock()
         get_id_response.ok = True
-        get_id_response.json.return_value = {"items": [{"id": "existing-release-id", "version": "v1.0.0"}]}
+        # Must include 'name' field since get_release_id_by_name filters by name, not version
+        get_id_response.json.return_value = {
+            "items": [{"id": "existing-release-id", "version": "v1.0.0", "name": "Release v1.0.0"}]
+        }
 
         # Mock get details (for logging)
         get_details_response = Mock()


### PR DESCRIPTION
The get-or-create pattern for releases was failing when a release with the same name already existed but had a different version field value.

Root cause: The API enforces uniqueness on the `name` field, but the recovery code was searching by `version` field, causing lookups to fail.

Changes:
- Add get_release_id_by_name() to search releases by name field
- Update DUPLICATE_NAME handler to use name-based lookup
- Extract _fetch_releases() helper to reduce code duplication (-63 lines)

The refactoring improves test coverage from 65% to 77% for releases_api.py and brings overall project coverage to 80%.
