### PR TITLE
fix: handle 409 DUPLICATE_ARTIFACT as success in release tagging

### DIFF
--- a/sbomify_action/_processors/releases_api.py
+++ b/sbomify_action/_processors/releases_api.py
@@ -22,6 +22,9 @@ def _safe_json_dict(response: requests.Response) -> Optional[Dict[str, Any]]:
 
     Returns:
         Parsed JSON as dict, or None if parsing fails or result is not a dict
+
+    Note:
+        Catches ValueError which includes JSONDecodeError (its subclass in requests).
     """
     try:
         data = response.json()

--- a/tests/test_releases.py
+++ b/tests/test_releases.py
@@ -299,7 +299,7 @@ class TestReleasesApi(unittest.TestCase):
         self.assertIn("Forbidden", str(cm.exception))
 
     @patch("sbomify_action._processors.releases_api.requests.post")
-    def test_tag_sbom_with_release_duplicate_artifact_returns_success(self, mock_post):
+    def test_tag_sbom_with_release_duplicate_artifact_succeeds(self, mock_post):
         """Test SBOM tagging handles 409 DUPLICATE_ARTIFACT as success (idempotent).
 
         When the SBOM is already tagged with the release (e.g., by server auto-tag,


### PR DESCRIPTION
When tagging an SBOM with a release, the API may return 409 Conflict with DUPLICATE_ARTIFACT if the SBOM is already tagged. This can happen when:
- Server auto-tags SBOM with "latest release" on upload
- Another CI job tagged the same SBOM concurrently
- User tagged via UI while CI was running

Treat this as idempotent success since the desired state (SBOM tagged with release) is already achieved.

Companion to server-side fix that returns 409 instead of 403 for duplicate artifacts.
