### PR TITLE
feat: add SBOM_FORMAT env var to support SPDX output

### DIFF
--- a/.github/workflows/sbomify.yaml
+++ b/.github/workflows/sbomify.yaml
@@ -224,7 +224,7 @@ jobs:
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
           echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
 
-      - name: Upload SBOM to Staging
+      - name: Upload SBOM to Staging (CycloneDX)
         if: github.ref == 'refs/heads/master'
         uses: sbomify/github-action@master
         env:
@@ -236,12 +236,30 @@ jobs:
           COMPONENT_VERSION: ${{ steps.version.outputs.short_sha }}
           COMPONENT_PURL: 'pkg:docker/sbomifyhub/sbomify-action@${{ steps.version.outputs.short_sha }}'
           PRODUCT_RELEASE: '["Engh9j4XTTwD:${{ steps.version.outputs.short_sha }}"]'
+          SBOM_FORMAT: cyclonedx
           AUGMENT: true
           ENRICH: true
           UPLOAD: true
           OUTPUT_FILE: github-action.cdx.json
 
-      - name: Upload Container SBOM to Staging
+      - name: Generate SBOM to Staging (SPDX)
+        if: github.ref == 'refs/heads/master'
+        uses: sbomify/github-action@master
+        env:
+          TOKEN: ${{ secrets.SBOMIFY_STAGE_TOKEN }}
+          API_BASE_URL: https://stage.sbomify.com
+          COMPONENT_ID: 'XNsX40tonzvv'
+          LOCK_FILE: 'uv.lock'
+          COMPONENT_NAME: 'sbomify Action'
+          COMPONENT_VERSION: ${{ steps.version.outputs.short_sha }}
+          COMPONENT_PURL: 'pkg:docker/sbomifyhub/sbomify-action@${{ steps.version.outputs.short_sha }}'
+          SBOM_FORMAT: spdx
+          AUGMENT: true
+          ENRICH: true
+          UPLOAD: false
+          OUTPUT_FILE: github-action.spdx.json
+
+      - name: Upload Container SBOM to Staging (CycloneDX)
         if: github.ref == 'refs/heads/master'
         uses: sbomify/github-action@master
         env:
@@ -254,12 +272,31 @@ jobs:
           COMPONENT_PURL: 'pkg:docker/sbomifyhub/sbomify-action@${{ steps.version.outputs.short_sha }}'
           PRODUCT_RELEASE: '["Engh9j4XTTwD:${{ steps.version.outputs.short_sha }}"]'
           ADDITIONAL_PACKAGES_FILE: container_additional_packages.txt
+          SBOM_FORMAT: cyclonedx
           AUGMENT: true
           ENRICH: true
           UPLOAD: true
           OUTPUT_FILE: github-action-container.cdx.json
 
-      - name: Upload JavaScript Dependencies SBOM to Staging
+      - name: Generate Container SBOM to Staging (SPDX)
+        if: github.ref == 'refs/heads/master'
+        uses: sbomify/github-action@master
+        env:
+          TOKEN: ${{ secrets.SBOMIFY_STAGE_TOKEN }}
+          API_BASE_URL: https://stage.sbomify.com
+          COMPONENT_ID: 'gco2pG10whmy'
+          DOCKER_IMAGE: 'sbomifyhub/sbomify-action:latest'
+          COMPONENT_NAME: 'sbomify Action Container'
+          COMPONENT_VERSION: ${{ steps.version.outputs.short_sha }}
+          COMPONENT_PURL: 'pkg:docker/sbomifyhub/sbomify-action@${{ steps.version.outputs.short_sha }}'
+          ADDITIONAL_PACKAGES_FILE: container_additional_packages.txt
+          SBOM_FORMAT: spdx
+          AUGMENT: true
+          ENRICH: true
+          UPLOAD: false
+          OUTPUT_FILE: github-action-container.spdx.json
+
+      - name: Upload JavaScript Dependencies SBOM to Staging (CycloneDX)
         if: github.ref == 'refs/heads/master'
         uses: sbomify/github-action@master
         env:
@@ -270,12 +307,29 @@ jobs:
           COMPONENT_NAME: 'JavaScript Dependencies'
           COMPONENT_VERSION: ${{ steps.version.outputs.short_sha }}
           PRODUCT_RELEASE: '["Engh9j4XTTwD:${{ steps.version.outputs.short_sha }}"]'
+          SBOM_FORMAT: cyclonedx
           AUGMENT: true
           ENRICH: true
           UPLOAD: true
           OUTPUT_FILE: github-action-frontend.cdx.json
 
-      - name: Upload SBOM to Production
+      - name: Generate JavaScript Dependencies SBOM to Staging (SPDX)
+        if: github.ref == 'refs/heads/master'
+        uses: sbomify/github-action@master
+        env:
+          TOKEN: ${{ secrets.SBOMIFY_STAGE_TOKEN }}
+          API_BASE_URL: https://stage.sbomify.com
+          COMPONENT_ID: 'PGyKXNbQd5eq'
+          LOCK_FILE: 'bun.lock'
+          COMPONENT_NAME: 'JavaScript Dependencies'
+          COMPONENT_VERSION: ${{ steps.version.outputs.short_sha }}
+          SBOM_FORMAT: spdx
+          AUGMENT: true
+          ENRICH: true
+          UPLOAD: false
+          OUTPUT_FILE: github-action-frontend.spdx.json
+
+      - name: Upload SBOM to Production (CycloneDX)
         if: startsWith(github.ref, 'refs/tags/')
         uses: sbomify/github-action@master
         env:
@@ -286,12 +340,29 @@ jobs:
           COMPONENT_VERSION: ${{ github.ref_name }}
           COMPONENT_PURL: 'pkg:docker/sbomifyhub/sbomify-action@${{ github.ref_name }}'
           PRODUCT_RELEASE: '["IeIn1dGJXULh:${{ github.ref_name }}"]'
+          SBOM_FORMAT: cyclonedx
           AUGMENT: true
           ENRICH: true
           UPLOAD: true
           OUTPUT_FILE: github-action.cdx.json
 
-      - name: Upload Container SBOM to Production
+      - name: Generate SBOM to Production (SPDX)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: sbomify/github-action@master
+        env:
+          TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
+          COMPONENT_ID: 'Gu9wem8mkX'
+          LOCK_FILE: 'uv.lock'
+          COMPONENT_NAME: 'sbomify Action'
+          COMPONENT_VERSION: ${{ github.ref_name }}
+          COMPONENT_PURL: 'pkg:docker/sbomifyhub/sbomify-action@${{ github.ref_name }}'
+          SBOM_FORMAT: spdx
+          AUGMENT: true
+          ENRICH: true
+          UPLOAD: false
+          OUTPUT_FILE: github-action.spdx.json
+
+      - name: Upload Container SBOM to Production (CycloneDX)
         if: startsWith(github.ref, 'refs/tags/')
         uses: sbomify/github-action@master
         env:
@@ -303,12 +374,30 @@ jobs:
           COMPONENT_PURL: 'pkg:docker/sbomifyhub/sbomify-action@${{ github.ref_name }}'
           PRODUCT_RELEASE: '["IeIn1dGJXULh:${{ github.ref_name }}"]'
           ADDITIONAL_PACKAGES_FILE: container_additional_packages.txt
+          SBOM_FORMAT: cyclonedx
           AUGMENT: true
           ENRICH: true
           UPLOAD: true
           OUTPUT_FILE: github-action-container.cdx.json
 
-      - name: Upload JavaScript Dependencies SBOM to Production
+      - name: Generate Container SBOM to Production (SPDX)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: sbomify/github-action@master
+        env:
+          TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
+          COMPONENT_ID: 'ryD0Hcu4vq6y'
+          DOCKER_IMAGE: 'sbomifyhub/sbomify-action:${{ github.ref_name }}'
+          COMPONENT_NAME: 'sbomify Action Container'
+          COMPONENT_VERSION: ${{ github.ref_name }}
+          COMPONENT_PURL: 'pkg:docker/sbomifyhub/sbomify-action@${{ github.ref_name }}'
+          ADDITIONAL_PACKAGES_FILE: container_additional_packages.txt
+          SBOM_FORMAT: spdx
+          AUGMENT: true
+          ENRICH: true
+          UPLOAD: false
+          OUTPUT_FILE: github-action-container.spdx.json
+
+      - name: Upload JavaScript Dependencies SBOM to Production (CycloneDX)
         if: startsWith(github.ref, 'refs/tags/')
         uses: sbomify/github-action@master
         env:
@@ -318,22 +407,59 @@ jobs:
           COMPONENT_NAME: 'JavaScript Dependencies'
           COMPONENT_VERSION: ${{ github.ref_name }}
           PRODUCT_RELEASE: '["IeIn1dGJXULh:${{ github.ref_name }}"]'
+          SBOM_FORMAT: cyclonedx
           AUGMENT: true
           ENRICH: true
           UPLOAD: true
           OUTPUT_FILE: github-action-frontend.cdx.json
 
-      - name: Attest Source SBOM
+      - name: Generate JavaScript Dependencies SBOM to Production (SPDX)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: sbomify/github-action@master
+        env:
+          TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
+          COMPONENT_ID: 'IxwrYSb9rGql'
+          LOCK_FILE: 'bun.lock'
+          COMPONENT_NAME: 'JavaScript Dependencies'
+          COMPONENT_VERSION: ${{ github.ref_name }}
+          SBOM_FORMAT: spdx
+          AUGMENT: true
+          ENRICH: true
+          UPLOAD: false
+          OUTPUT_FILE: github-action-frontend.spdx.json
+
+      - name: Attest Source SBOM (CycloneDX)
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: '${{ github.workspace }}/github-action.cdx.json'
 
-      - name: Attest Container SBOM
+      - name: Attest Source SBOM (SPDX)
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: '${{ github.workspace }}/github-action.spdx.json'
+
+      - name: Attest Container SBOM (CycloneDX)
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: '${{ github.workspace }}/github-action-container.cdx.json'
 
-      - name: Attest JavaScript Dependencies SBOM
+      - name: Attest Container SBOM (SPDX)
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: '${{ github.workspace }}/github-action-container.spdx.json'
+
+      - name: Attest JavaScript Dependencies SBOM (CycloneDX)
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: '${{ github.workspace }}/github-action-frontend.cdx.json'
+
+      - name: Attest JavaScript Dependencies SBOM (SPDX)
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: '${{ github.workspace }}/github-action-frontend.spdx.json'

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ docker run --rm -v $(pwd):/code \
     ENRICH: true
 ```
 
-That's it! This generates an SBOM from your lockfile and enriches it with metadata from package registries.
+That's it! This generates a CycloneDX SBOM from your lockfile and enriches it with metadata from package registries. For SPDX format, set `SBOM_FORMAT: spdx`.
 
 ## Features
 
-- **Generate** SBOMs from lockfiles (Python, Node, Rust, Go, Ruby, Dart, C++)
+- **Generate** SBOMs from lockfiles (Python, Node, Rust, Go, Ruby, Dart, C++) in CycloneDX or SPDX format
 - **Generate** SBOMs from Docker images
 - **Inject** additional packages not in lockfiles (vendored code, runtime deps, system libraries)
 - **Augment** with business metadata (supplier, authors, licenses, lifecycle phase) from config file or sbomify
@@ -138,6 +138,20 @@ See [Augmentation Config File](#augmentation-config-file) for the config format.
     ENRICH: true
 ```
 
+### SPDX Format
+
+Generate SPDX instead of CycloneDX:
+
+```yaml
+- uses: sbomify/github-action@master
+  env:
+    LOCK_FILE: requirements.txt
+    OUTPUT_FILE: sbom.spdx.json
+    SBOM_FORMAT: spdx
+    UPLOAD: false
+    ENRICH: true
+```
+
 ### With Attestation
 
 ```yaml
@@ -155,26 +169,27 @@ See [Augmentation Config File](#augmentation-config-file) for the config format.
 
 ## Configuration
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `LOCK_FILE` | † | Path to lockfile (requirements.txt, poetry.lock, Cargo.lock, etc.) |
-| `SBOM_FILE` | † | Path to existing SBOM file |
-| `DOCKER_IMAGE` | † | Docker image name |
-| `OUTPUT_FILE` | No | Write final SBOM to this path |
-| `ENRICH` | No | Add metadata from package registries |
-| `TOKEN` | ‡ | sbomify API token |
-| `COMPONENT_ID` | ‡ | sbomify component ID |
-| `AUGMENT` | No | Add metadata from sbomify |
-| `COMPONENT_NAME` | No | Override component name in SBOM |
-| `COMPONENT_VERSION` | No | Override component version in SBOM |
-| `COMPONENT_PURL` | No | Add or override component PURL in SBOM |
-| `PRODUCT_RELEASE` | No | Tag SBOM with product releases (see [Product Releases](#product-releases)) |
-| `UPLOAD` | No | Upload SBOM (default: true) |
-| `UPLOAD_DESTINATIONS` | No | Comma-separated destinations: `sbomify`, `dependency-track` (default: `sbomify`) |
-| `API_BASE_URL` | No | Override sbomify API URL for self-hosted instances |
-| `ADDITIONAL_PACKAGES_FILE` | No | Custom path to additional packages file |
-| `ADDITIONAL_PACKAGES` | No | Inline PURLs to inject (comma or newline separated) |
-| `DISABLE_VCS_AUGMENTATION` | No | Set to `true` to disable auto-detection of VCS info from CI environment |
+| Variable                   | Required | Description                                                                      |
+| -------------------------- | -------- | -------------------------------------------------------------------------------- |
+| `LOCK_FILE`                | †        | Path to lockfile (requirements.txt, poetry.lock, Cargo.lock, etc.)               |
+| `SBOM_FILE`                | †        | Path to existing SBOM file                                                       |
+| `DOCKER_IMAGE`             | †        | Docker image name                                                                |
+| `OUTPUT_FILE`              | No       | Write final SBOM to this path                                                    |
+| `SBOM_FORMAT`              | No       | Output format: `cyclonedx` (default) or `spdx`                                   |
+| `ENRICH`                   | No       | Add metadata from package registries                                             |
+| `TOKEN`                    | ‡        | sbomify API token                                                                |
+| `COMPONENT_ID`             | ‡        | sbomify component ID                                                             |
+| `AUGMENT`                  | No       | Add metadata from sbomify                                                        |
+| `COMPONENT_NAME`           | No       | Override component name in SBOM                                                  |
+| `COMPONENT_VERSION`        | No       | Override component version in SBOM                                               |
+| `COMPONENT_PURL`           | No       | Add or override component PURL in SBOM                                           |
+| `PRODUCT_RELEASE`          | No       | Tag SBOM with product releases (see [Product Releases](#product-releases))       |
+| `UPLOAD`                   | No       | Upload SBOM (default: true)                                                      |
+| `UPLOAD_DESTINATIONS`      | No       | Comma-separated destinations: `sbomify`, `dependency-track` (default: `sbomify`) |
+| `API_BASE_URL`             | No       | Override sbomify API URL for self-hosted instances                               |
+| `ADDITIONAL_PACKAGES_FILE` | No       | Custom path to additional packages file                                          |
+| `ADDITIONAL_PACKAGES`      | No       | Inline PURLs to inject (comma or newline separated)                              |
+| `DISABLE_VCS_AUGMENTATION` | No       | Set to `true` to disable auto-detection of VCS info from CI environment          |
 
 † **One** of `LOCK_FILE`, `SBOM_FILE`, or `DOCKER_IMAGE` is required (pick one)
 ‡ Required when uploading to sbomify or using sbomify features (`AUGMENT`, `PRODUCT_RELEASE`)
@@ -183,12 +198,12 @@ See [Augmentation Config File](#augmentation-config-file) for the config format.
 
 When uploading to Dependency Track (`UPLOAD_DESTINATIONS=dependency-track`), configure with `DTRACK_*` prefixed environment variables:
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `DTRACK_API_KEY` | Yes | Dependency Track API key |
-| `DTRACK_API_URL` | Yes | Full API base URL (e.g., `https://dtrack.example.com/api`) |
-| `DTRACK_PROJECT_ID` | § | Project UUID (alternative to using `COMPONENT_NAME`/`COMPONENT_VERSION`) |
-| `DTRACK_AUTO_CREATE` | No | Auto-create project if it doesn't exist (default: false) |
+| Variable             | Required | Description                                                              |
+| -------------------- | -------- | ------------------------------------------------------------------------ |
+| `DTRACK_API_KEY`     | Yes      | Dependency Track API key                                                 |
+| `DTRACK_API_URL`     | Yes      | Full API base URL (e.g., `https://dtrack.example.com/api`)               |
+| `DTRACK_PROJECT_ID`  | §        | Project UUID (alternative to using `COMPONENT_NAME`/`COMPONENT_VERSION`) |
+| `DTRACK_AUTO_CREATE` | No       | Auto-create project if it doesn't exist (default: false)                 |
 
 § Either `DTRACK_PROJECT_ID` **or** both `COMPONENT_NAME` and `COMPONENT_VERSION` are required
 
@@ -253,6 +268,7 @@ PRODUCT_RELEASE: '["product_id_1:v1.0.0", "product_id_2:v2.0.0"]'
 ```
 
 **Behavior:**
+
 - **Get-or-create**: If the release already exists, it's reused. If not, it's created automatically.
 - **Tagging**: The uploaded SBOM is associated with each specified release.
 - **Partial failures**: If some releases succeed and others fail, the action logs a warning but continues.
@@ -261,22 +277,22 @@ PRODUCT_RELEASE: '["product_id_1:v1.0.0", "product_id_2:v2.0.0"]'
 
 ## Supported Lockfiles
 
-| Language | Files |
-|----------|-------|
-| Python | `requirements.txt`, `poetry.lock`, `Pipfile.lock`, `uv.lock`, `pyproject.toml` |
+| Language   | Files                                                                          |
+| ---------- | ------------------------------------------------------------------------------ |
+| Python     | `requirements.txt`, `poetry.lock`, `Pipfile.lock`, `uv.lock`, `pyproject.toml` |
 | JavaScript | `package.json`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock` |
-| Java | `pom.xml`, `build.gradle`, `build.gradle.kts`, `gradle.lockfile` |
-| Go | `go.mod`, `go.sum` |
-| Rust | `Cargo.lock` |
-| Ruby | `Gemfile.lock` |
-| PHP | `composer.json`, `composer.lock` |
-| .NET/C# | `packages.lock.json` |
-| Swift | `Package.swift`, `Package.resolved` |
-| Dart | `pubspec.lock` |
-| Elixir | `mix.lock` |
-| Scala | `build.sbt` |
-| C++ | `conan.lock` |
-| Terraform | `.terraform.lock.hcl` |
+| Java       | `pom.xml`, `build.gradle`, `build.gradle.kts`, `gradle.lockfile`               |
+| Go         | `go.mod`, `go.sum`                                                             |
+| Rust       | `Cargo.lock`                                                                   |
+| Ruby       | `Gemfile.lock`                                                                 |
+| PHP        | `composer.json`, `composer.lock`                                               |
+| .NET/C#    | `packages.lock.json`                                                           |
+| Swift      | `Package.swift`, `Package.resolved`                                            |
+| Dart       | `pubspec.lock`                                                                 |
+| Elixir     | `mix.lock`                                                                     |
+| Scala      | `build.sbt`                                                                    |
+| C++        | `conan.lock`                                                                   |
+| Terraform  | `.terraform.lock.hcl`                                                          |
 
 ## Additional Packages
 
@@ -417,15 +433,15 @@ Create `sbomify.json` in your project root to provide augmentation metadata:
 
 **Supported fields:**
 
-| Field | Description | SBOM Mapping |
-|-------|-------------|--------------|
-| `lifecycle_phase` | Generation context (CISA 2025) | CycloneDX 1.5+: `metadata.lifecycles[].phase`; SPDX: `creationInfo.creatorComment` |
-| `supplier` | Organization that supplies the component | CycloneDX: `metadata.supplier`; SPDX: `packages[].supplier` |
-| `authors` | List of component authors | CycloneDX: `metadata.authors[]`; SPDX: `creationInfo.creators[]` |
-| `licenses` | SPDX license identifiers | CycloneDX: `metadata.licenses[]`; SPDX: Document-level licenses |
-| `vcs_url` | Repository URL (overrides CI auto-detection) | CycloneDX: `externalReferences[type=vcs]`; SPDX: `downloadLocation` |
-| `vcs_commit_sha` | Full commit SHA | Appended to VCS URL as `@sha` |
-| `vcs_ref` | Branch or tag name | Added as comment/context |
+| Field             | Description                                  | SBOM Mapping                                                                       |
+| ----------------- | -------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `lifecycle_phase` | Generation context (CISA 2025)               | CycloneDX 1.5+: `metadata.lifecycles[].phase`; SPDX: `creationInfo.creatorComment` |
+| `supplier`        | Organization that supplies the component     | CycloneDX: `metadata.supplier`; SPDX: `packages[].supplier`                        |
+| `authors`         | List of component authors                    | CycloneDX: `metadata.authors[]`; SPDX: `creationInfo.creators[]`                   |
+| `licenses`        | SPDX license identifiers                     | CycloneDX: `metadata.licenses[]`; SPDX: Document-level licenses                    |
+| `vcs_url`         | Repository URL (overrides CI auto-detection) | CycloneDX: `externalReferences[type=vcs]`; SPDX: `downloadLocation`                |
+| `vcs_commit_sha`  | Full commit SHA                              | Appended to VCS URL as `@sha`                                                      |
+| `vcs_ref`         | Branch or tag name                           | Added as comment/context                                                           |
 
 **Valid `lifecycle_phase` values:** `design`, `pre-build`, `build`, `post-build`, `operations`, `discovery`, `decommission`
 
@@ -435,11 +451,11 @@ Create `sbomify.json` in your project root to provide augmentation metadata:
 
 When running in CI environments, sbomify automatically detects and adds VCS (Version Control System) information to your SBOM:
 
-| CI Platform | Auto-Detected Fields |
-|-------------|---------------------|
-| GitHub Actions | Repository URL, commit SHA, branch/tag (supports GitHub Enterprise Server) |
-| GitLab CI | Project URL, commit SHA, ref name (supports self-managed instances) |
-| Bitbucket Pipelines | Repository URL, commit SHA, branch/tag |
+| CI Platform         | Auto-Detected Fields                                                       |
+| ------------------- | -------------------------------------------------------------------------- |
+| GitHub Actions      | Repository URL, commit SHA, branch/tag (supports GitHub Enterprise Server) |
+| GitLab CI           | Project URL, commit SHA, ref name (supports self-managed instances)        |
+| Bitbucket Pipelines | Repository URL, commit SHA, branch/tag                                     |
 
 **What's added to the SBOM:**
 
@@ -469,17 +485,17 @@ env:
 
 ### Enrichment Data Sources
 
-| Source | Package Types | Data |
-|--------|---------------|------|
-| PyPI | Python | License, author, homepage |
-| pub.dev | Dart | License, author, homepage, repo |
-| crates.io | Rust/Cargo | License, author, homepage, repo, description |
-| RPM Repos | Rocky, Alma, CentOS, Fedora, Amazon Linux | License, vendor, description, homepage |
-| Ubuntu APT | Ubuntu packages | Maintainer, description, homepage, download URL |
-| deps.dev | Python, npm, Maven, Go, Ruby, NuGet (+ Rust fallback) | License, homepage, repo |
-| ecosyste.ms | All major ecosystems | License, description, maintainer |
-| Debian Sources | Debian packages | Maintainer, description, homepage |
-| Repology | Linux distros | License, homepage |
+| Source         | Package Types                                         | Data                                            |
+| -------------- | ----------------------------------------------------- | ----------------------------------------------- |
+| PyPI           | Python                                                | License, author, homepage                       |
+| pub.dev        | Dart                                                  | License, author, homepage, repo                 |
+| crates.io      | Rust/Cargo                                            | License, author, homepage, repo, description    |
+| RPM Repos      | Rocky, Alma, CentOS, Fedora, Amazon Linux             | License, vendor, description, homepage          |
+| Ubuntu APT     | Ubuntu packages                                       | Maintainer, description, homepage, download URL |
+| deps.dev       | Python, npm, Maven, Go, Ruby, NuGet (+ Rust fallback) | License, homepage, repo                         |
+| ecosyste.ms    | All major ecosystems                                  | License, description, maintainer                |
+| Debian Sources | Debian packages                                       | Maintainer, description, homepage               |
+| Repology       | Linux distros                                         | License, homepage                               |
 
 ## SBOM Quality Improvement
 
@@ -521,15 +537,15 @@ After sbomify enrichment, the same component includes supplier, license, and ref
 
 sbomify attempts to populate these fields for each component:
 
-| Field | Description | Coverage |
-|-------|-------------|----------|
-| **Supplier/Publisher** | Package maintainer or organization | High for popular registries |
-| **License** | SPDX license expression | High (most registries require it) |
-| **Description** | Package summary | High |
-| **Homepage** | Project website | Medium-High |
-| **Repository** | Source code URL | Medium-High |
-| **Download URL** | Registry/distribution link | High |
-| **Issue Tracker** | Bug reporting URL | Medium |
+| Field                  | Description                        | Coverage                          |
+| ---------------------- | ---------------------------------- | --------------------------------- |
+| **Supplier/Publisher** | Package maintainer or organization | High for popular registries       |
+| **License**            | SPDX license expression            | High (most registries require it) |
+| **Description**        | Package summary                    | High                              |
+| **Homepage**           | Project website                    | Medium-High                       |
+| **Repository**         | Source code URL                    | Medium-High                       |
+| **Download URL**       | Registry/distribution link         | High                              |
+| **Issue Tracker**      | Bug reporting URL                  | Medium                            |
 
 **Coverage varies by ecosystem.** Popular packages on PyPI, npm, and crates.io have excellent metadata. RPM-based distros (Rocky, Alma, CentOS, Fedora, Amazon Linux) and Debian/Ubuntu have high coverage through direct repository queries. Alpine and less common registries may have partial data. sbomify queries multiple sources with fallbacks, but some fields may remain empty for obscure packages.
 
@@ -537,21 +553,21 @@ sbomify attempts to populate these fields for each component:
 
 sbomify queries sources in priority order, stopping when data is found:
 
-| Ecosystem | Primary Source | Fallback Sources |
-|-----------|----------------|------------------|
-| Python | PyPI API | deps.dev → ecosyste.ms |
-| JavaScript | deps.dev | ecosyste.ms |
-| Rust | crates.io API | deps.dev → ecosyste.ms |
-| Go | deps.dev | ecosyste.ms |
-| Ruby | deps.dev | ecosyste.ms |
-| Java/Maven | deps.dev | ecosyste.ms |
-| Dart | pub.dev API | ecosyste.ms |
-| Debian | Debian Sources | Repology → ecosyste.ms |
-| Ubuntu | Ubuntu APT | Repology → ecosyste.ms |
-| Alpine | Repology | ecosyste.ms |
-| Rocky/Alma/CentOS | RPM Repos | Repology → ecosyste.ms |
-| Fedora | RPM Repos | Repology → ecosyste.ms |
-| Amazon Linux | RPM Repos | Repology → ecosyste.ms |
+| Ecosystem         | Primary Source | Fallback Sources       |
+| ----------------- | -------------- | ---------------------- |
+| Python            | PyPI API       | deps.dev → ecosyste.ms |
+| JavaScript        | deps.dev       | ecosyste.ms            |
+| Rust              | crates.io API  | deps.dev → ecosyste.ms |
+| Go                | deps.dev       | ecosyste.ms            |
+| Ruby              | deps.dev       | ecosyste.ms            |
+| Java/Maven        | deps.dev       | ecosyste.ms            |
+| Dart              | pub.dev API    | ecosyste.ms            |
+| Debian            | Debian Sources | Repology → ecosyste.ms |
+| Ubuntu            | Ubuntu APT     | Repology → ecosyste.ms |
+| Alpine            | Repology       | ecosyste.ms            |
+| Rocky/Alma/CentOS | RPM Repos      | Repology → ecosyste.ms |
+| Fedora            | RPM Repos      | Repology → ecosyste.ms |
+| Amazon Linux      | RPM Repos      | Repology → ecosyste.ms |
 
 ### Limitations
 
@@ -569,13 +585,13 @@ sbomify uses a plugin architecture for SBOM generation, automatically selecting 
 
 Generators are tried in priority order. Native tools (optimized for specific ecosystems) are preferred over generic scanners. Each tool supports different ecosystems:
 
-| Priority | Generator | Supported Ecosystems | Output Formats |
-|----------|-----------|---------------------|----------------|
-| 10 | **cyclonedx-py** | Python only | CycloneDX 1.0–1.7 |
-| 10 | **cargo-cyclonedx** | Rust only | CycloneDX 1.4–1.6 |
-| 20 | **cdxgen** | Python, JavaScript, **Java/Gradle**, Go, Rust, Ruby, Dart, C++, PHP, .NET, Swift, Elixir, Scala, Docker images | CycloneDX 1.4–1.7 |
-| 30 | **Trivy** | Python, JavaScript, Java/Gradle, Go, Rust, Ruby, C++, PHP, .NET, Docker images | CycloneDX 1.6, SPDX 2.3 |
-| 35 | **Syft** | Python, JavaScript, Go, Rust, Ruby, Dart, C++, PHP, .NET, Swift, Elixir, Terraform, Docker images | CycloneDX 1.2–1.6, SPDX 2.2–2.3 |
+| Priority | Generator           | Supported Ecosystems                                                                                           | Output Formats                  |
+| -------- | ------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| 10       | **cyclonedx-py**    | Python only                                                                                                    | CycloneDX 1.0–1.7               |
+| 10       | **cargo-cyclonedx** | Rust only                                                                                                      | CycloneDX 1.4–1.6               |
+| 20       | **cdxgen**          | Python, JavaScript, **Java/Gradle**, Go, Rust, Ruby, Dart, C++, PHP, .NET, Swift, Elixir, Scala, Docker images | CycloneDX 1.4–1.7               |
+| 30       | **Trivy**           | Python, JavaScript, Java/Gradle, Go, Rust, Ruby, C++, PHP, .NET, Docker images                                 | CycloneDX 1.6, SPDX 2.3         |
+| 35       | **Syft**            | Python, JavaScript, Go, Rust, Ruby, Dart, C++, PHP, .NET, Swift, Elixir, Terraform, Docker images              | CycloneDX 1.2–1.6, SPDX 2.2–2.3 |
 
 ### How It Works
 
@@ -588,10 +604,12 @@ Generators are tried in priority order. Native tools (optimized for specific eco
 
 If the primary generator fails or doesn't support the input, the next one in priority order is tried automatically.
 
-### Format Defaults
+### Format Selection
 
-- **CycloneDX**: Version 1.6 (default)
-- **SPDX**: Version 2.3 (default)
+Control the output format with the `SBOM_FORMAT` environment variable:
+
+- **CycloneDX** (`SBOM_FORMAT=cyclonedx`): Default format. Uses the latest version supported by the selected generator.
+- **SPDX** (`SBOM_FORMAT=spdx`): Uses Trivy (2.3) or Syft (2.2/2.3) depending on availability.
 
 Generated SBOMs are validated against their JSON schemas before output.
 
@@ -599,12 +617,12 @@ Generated SBOMs are validated against their JSON schemas before output.
 
 When installed via pip, sbomify-action requires external SBOM generators. The Docker image includes all tools pre-installed.
 
-| Tool | Install Command | Notes |
-|------|-----------------|-------|
-| **cyclonedx-py** | `pip install cyclonedx-bom` | Native Python generator; `cyclonedx-py` is the CLI command provided by the `cyclonedx-bom` package (installed as a dependency) |
-| **Trivy** | [Installation guide](https://aquasecurity.github.io/trivy/latest/getting-started/installation/) | macOS: `brew install trivy` |
-| **Syft** | [Installation guide](https://github.com/anchore/syft#installation) | macOS: `brew install syft` |
-| **cdxgen** | `npm install -g @cyclonedx/cdxgen` | Requires Node.js/Bun |
+| Tool             | Install Command                                                                                 | Notes                                                                                                                          |
+| ---------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| **cyclonedx-py** | `pip install cyclonedx-bom`                                                                     | Native Python generator; `cyclonedx-py` is the CLI command provided by the `cyclonedx-bom` package (installed as a dependency) |
+| **Trivy**        | [Installation guide](https://aquasecurity.github.io/trivy/latest/getting-started/installation/) | macOS: `brew install trivy`                                                                                                    |
+| **Syft**         | [Installation guide](https://github.com/anchore/syft#installation)                              | macOS: `brew install syft`                                                                                                     |
+| **cdxgen**       | `npm install -g @cyclonedx/cdxgen`                                                              | Requires Node.js/Bun                                                                                                           |
 
 **Minimum requirement**: At least one generator must be installed for SBOM generation. For Python projects, `cyclonedx-bom` (which provides the `cyclonedx-py` command) is installed as a dependency when you install sbomify-action via pip. For other ecosystems or Docker images, install `trivy`, `syft`, or `cdxgen`.
 

--- a/docs/adr/0001-plugin-architecture.md
+++ b/docs/adr/0001-plugin-architecture.md
@@ -9,9 +9,9 @@ Accepted
 The sbomify action needs to integrate with multiple external services and data sources across different subsystems:
 
 - **Enrichment**: Multiple metadata sources (PyPI, deps.dev, ecosyste.ms, Repology, etc.)
-- **Augmentation**: Organizational metadata sources (sbomify API, etc.) - *to migrate*
-- **Generation**: Multiple SBOM generators (cyclonedx-py, Trivy, Syft) - *migrated*
-- **Upload**: Multiple destinations (sbomify API, GitHub release artifacts, etc.) - *to migrate*
+- **Augmentation**: Organizational metadata sources (sbomify API, etc.) - _to migrate_
+- **Generation**: Multiple SBOM generators (cyclonedx-py, Trivy, Syft) - _migrated_
+- **Upload**: Multiple destinations (sbomify API, GitHub release artifacts, etc.) - _to migrate_
 
 Each subsystem faces similar challenges:
 
@@ -53,12 +53,12 @@ Adopt a **Protocol + Registry + Factory** pattern for all extensible subsystems.
 
 A key design principle is **preferring domain-specific (native) implementations over generic ones**:
 
-| Priority Range | Category | Rationale |
-|----------------|----------|-----------|
-| 1-20 | Native/Authoritative | Direct from the ecosystem's official source |
-| 21-50 | Primary Aggregators | Well-maintained multi-ecosystem services |
-| 51-80 | Local Extraction | No external API calls, parse from available data |
-| 81-100 | Fallback Sources | Rate-limited or less reliable sources |
+| Priority Range | Category             | Rationale                                        |
+| -------------- | -------------------- | ------------------------------------------------ |
+| 1-20           | Native/Authoritative | Direct from the ecosystem's official source      |
+| 21-50          | Primary Aggregators  | Well-maintained multi-ecosystem services         |
+| 51-80          | Local Extraction     | No external API calls, parse from available data |
+| 81-100         | Fallback Sources     | Rate-limited or less reliable sources            |
 
 ### Rationale
 
@@ -93,13 +93,13 @@ A key design principle is **preferring domain-specific (native) implementations 
 
 The enrichment subsystem (`sbomify_action/_enrichment/`) demonstrates this pattern:
 
-| Generic Concept | Enrichment Implementation |
-|-----------------|---------------------------|
-| Protocol | `DataSource` in `protocol.py` |
-| Registry | `SourceRegistry` in `registry.py` |
-| Normalized Output | `NormalizedMetadata` in `metadata.py` |
-| Factory | `create_default_registry()` in `enricher.py` |
-| Plugins | 9 sources in `sources/` directory |
+| Generic Concept   | Enrichment Implementation                    |
+| ----------------- | -------------------------------------------- |
+| Protocol          | `DataSource` in `protocol.py`                |
+| Registry          | `SourceRegistry` in `registry.py`            |
+| Normalized Output | `NormalizedMetadata` in `metadata.py`        |
+| Factory           | `create_default_registry()` in `enricher.py` |
+| Plugins           | 9 sources in `sources/` directory            |
 
 ### Directory Structure
 

--- a/docs/enrichment_coverage.md
+++ b/docs/enrichment_coverage.md
@@ -6,18 +6,18 @@ This document details sbomify's enrichment capabilities, data sources, and expec
 
 sbomify queries multiple sources in priority order, using fallbacks when primary sources lack data.
 
-| Ecosystem | Primary Source | Fallbacks |
-|-----------|----------------|-----------|
-| Python (pip) | PyPI API | deps.dev → ecosyste.ms |
-| JavaScript (npm) | deps.dev | ecosyste.ms |
-| Rust (cargo) | deps.dev | ecosyste.ms |
-| Go (mod) | deps.dev | ecosyste.ms |
-| Ruby (gem) | deps.dev | ecosyste.ms |
-| Java/Maven | deps.dev | ecosyste.ms |
-| Dart (pub) | pub.dev API | ecosyste.ms |
-| Debian/Ubuntu (deb) | Debian Sources | Repology → ecosyste.ms |
-| Alpine (apk) | Repology | ecosyste.ms |
-| Red Hat/Fedora (rpm) | Repology | ecosyste.ms |
+| Ecosystem            | Primary Source | Fallbacks              |
+| -------------------- | -------------- | ---------------------- |
+| Python (pip)         | PyPI API       | deps.dev → ecosyste.ms |
+| JavaScript (npm)     | deps.dev       | ecosyste.ms            |
+| Rust (cargo)         | deps.dev       | ecosyste.ms            |
+| Go (mod)             | deps.dev       | ecosyste.ms            |
+| Ruby (gem)           | deps.dev       | ecosyste.ms            |
+| Java/Maven           | deps.dev       | ecosyste.ms            |
+| Dart (pub)           | pub.dev API    | ecosyste.ms            |
+| Debian/Ubuntu (deb)  | Debian Sources | Repology → ecosyste.ms |
+| Alpine (apk)         | Repology       | ecosyste.ms            |
+| Red Hat/Fedora (rpm) | Repology       | ecosyste.ms            |
 
 ## Expected Field Coverage
 
@@ -25,18 +25,18 @@ Coverage varies by ecosystem and data source availability.
 
 Legend: 🟢 High | 🟡 Medium | 🟠 Low
 
-| Ecosystem | Supplier | License | Description | Homepage | Repository |
-|-----------|----------|---------|-------------|----------|------------|
-| Python (pip) | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 |
-| JavaScript (npm) | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 |
-| Rust (cargo) | 🟢 | 🟢 | 🟢 | 🟡 | 🟢 |
-| Go (mod) | 🟡 | 🟢 | 🟡 | 🟠 | 🟢 |
-| Ruby (gem) | 🟢 | 🟢 | 🟢 | 🟢 | 🟡 |
-| Java/Maven | 🟢 | 🟢 | 🟡 | 🟡 | 🟡 |
-| Dart (pub) | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 |
-| Debian/Ubuntu (deb) | 🟢 | 🟢 | 🟢 | 🟡 | 🟠 |
-| Alpine (apk) | 🟢 | 🟢 | 🟡 | 🟡 | 🟠 |
-| Red Hat/Fedora (rpm) | 🟢 | 🟢 | 🟡 | 🟡 | 🟠 |
+| Ecosystem            | Supplier | License | Description | Homepage | Repository |
+| -------------------- | -------- | ------- | ----------- | -------- | ---------- |
+| Python (pip)         | 🟢       | 🟢      | 🟢          | 🟢       | 🟢         |
+| JavaScript (npm)     | 🟢       | 🟢      | 🟢          | 🟢       | 🟢         |
+| Rust (cargo)         | 🟢       | 🟢      | 🟢          | 🟡       | 🟢         |
+| Go (mod)             | 🟡       | 🟢      | 🟡          | 🟠       | 🟢         |
+| Ruby (gem)           | 🟢       | 🟢      | 🟢          | 🟢       | 🟡         |
+| Java/Maven           | 🟢       | 🟢      | 🟡          | 🟡       | 🟡         |
+| Dart (pub)           | 🟢       | 🟢      | 🟢          | 🟢       | 🟢         |
+| Debian/Ubuntu (deb)  | 🟢       | 🟢      | 🟢          | 🟡       | 🟠         |
+| Alpine (apk)         | 🟢       | 🟢      | 🟡          | 🟡       | 🟠         |
+| Red Hat/Fedora (rpm) | 🟢       | 🟢      | 🟡          | 🟡       | 🟠         |
 
 ## Ecosystem Notes
 
@@ -101,5 +101,4 @@ Legend: 🟢 High | 🟡 Medium | 🟠 Low
 - **Data freshness**: Metadata is fetched at enrichment time. Registry data may lag behind actual releases.
 - **Coverage varies**: Different ecosystems and registries have different metadata requirements and quality.
 
-
-*Generated: 2025-12-17*
+_Generated: 2025-12-17_

--- a/docs/ntia_comparison.md
+++ b/docs/ntia_comparison.md
@@ -9,15 +9,15 @@ more useful for vulnerability management, license compliance, and supply chain a
 sbomify helps you achieve compliance with the [NTIA Minimum Elements for SBOM](https://sbomify.com/compliance/ntia-minimum-elements/),
 the foundational US baseline for SBOM data fields. The table below shows how sbomify contributes to each required element:
 
-| NTIA Element | CycloneDX Field | SPDX Field | Provided By |
-|--------------|-----------------|------------|-------------|
-| **Supplier Name** | `components[].publisher` or `supplier.name` | `packages[].supplier` | Enrichment |
-| **Component Name** | `components[].name` | `packages[].name` | Generator |
-| **Component Version** | `components[].version` | `packages[].versionInfo` | Generator |
-| **Unique Identifiers** | `components[].purl` | `packages[].externalRefs[].purl` | Generator |
-| **Dependency Relationship** | `dependencies[]` | `relationships[]` | Generator |
-| **SBOM Author** | `metadata.authors[]` | `creationInfo.creators[]` | Augmentation |
-| **Timestamp** | `metadata.timestamp` | `creationInfo.created` | Generator |
+| NTIA Element                | CycloneDX Field                             | SPDX Field                       | Provided By  |
+| --------------------------- | ------------------------------------------- | -------------------------------- | ------------ |
+| **Supplier Name**           | `components[].publisher` or `supplier.name` | `packages[].supplier`            | Enrichment   |
+| **Component Name**          | `components[].name`                         | `packages[].name`                | Generator    |
+| **Component Version**       | `components[].version`                      | `packages[].versionInfo`         | Generator    |
+| **Unique Identifiers**      | `components[].purl`                         | `packages[].externalRefs[].purl` | Generator    |
+| **Dependency Relationship** | `dependencies[]`                            | `relationships[]`                | Generator    |
+| **SBOM Author**             | `metadata.authors[]`                        | `creationInfo.creators[]`        | Augmentation |
+| **Timestamp**               | `metadata.timestamp`                        | `creationInfo.created`           | Generator    |
 
 For the complete field mapping across CycloneDX and SPDX versions, see the
 [Schema Crosswalk](https://sbomify.com/compliance/schema-crosswalk/).
@@ -28,50 +28,50 @@ Beyond the NTIA minimum elements, sbomify enriches each component with **7 addit
 from authoritative package registries. These fields improve SBOM utility for vulnerability management,
 license compliance, and supply chain analysis:
 
-| Ecosystem | Scanner | Metadata Fields |  |  |
-|-----------|---------|-----------------|--|--|
-|  |  | **Before** | **After** | **Added** |
-| Python (pip) | Trivy | 0/7 | 7/7 ✅ | +7 fields |
-| Python (pip) | Syft | 0/7 | 7/7 ✅ | +7 fields |
-| Debian (deb) | Trivy | 0/7 | 7/7 ✅ | +7 fields |
-| Alpine (apk) | Trivy | 1/7 | 7/7 ✅ | +6 fields |
-| JavaScript (npm) | Trivy | 0/7 | 7/7 ✅ | +7 fields |
-| Rust (cargo) | Trivy | 0/7 | 7/7 ✅ | +7 fields |
-| Go (mod) | Trivy | 0/7 | 7/7 ✅ | +7 fields |
-| Ruby (gem) | Trivy | 0/7 | 7/7 ✅ | +7 fields |
-| Dart (pub) | Trivy | 0/7 | 7/7 ✅ | +7 fields |
+| Ecosystem        | Scanner | Metadata Fields |           |           |
+| ---------------- | ------- | --------------- | --------- | --------- |
+|                  |         | **Before**      | **After** | **Added** |
+| Python (pip)     | Trivy   | 0/7             | 7/7 ✅    | +7 fields |
+| Python (pip)     | Syft    | 0/7             | 7/7 ✅    | +7 fields |
+| Debian (deb)     | Trivy   | 0/7             | 7/7 ✅    | +7 fields |
+| Alpine (apk)     | Trivy   | 1/7             | 7/7 ✅    | +6 fields |
+| JavaScript (npm) | Trivy   | 0/7             | 7/7 ✅    | +7 fields |
+| Rust (cargo)     | Trivy   | 0/7             | 7/7 ✅    | +7 fields |
+| Go (mod)         | Trivy   | 0/7             | 7/7 ✅    | +7 fields |
+| Ruby (gem)       | Trivy   | 0/7             | 7/7 ✅    | +7 fields |
+| Dart (pub)       | Trivy   | 0/7             | 7/7 ✅    | +7 fields |
 
 ### Field-by-Field Breakdown
 
 Legend: ✅ Present in scanner output | 🔧 Added by sbomify
 
-| Ecosystem | Supplier | License | Description | Homepage | Repository | Download | Issues |
-|-----------|----------|---------|-------------|----------|------------|----------|--------|
-| Python (pip) | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 |
-| Debian (deb) | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 |
-| Alpine (apk) | 🔧 | ✅ | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 |
-| JavaScript (npm) | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 |
-| Rust (cargo) | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 |
-| Go (mod) | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 |
-| Ruby (gem) | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 |
-| Dart (pub) | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 |
+| Ecosystem        | Supplier | License | Description | Homepage | Repository | Download | Issues |
+| ---------------- | -------- | ------- | ----------- | -------- | ---------- | -------- | ------ |
+| Python (pip)     | 🔧       | 🔧      | 🔧          | 🔧       | 🔧         | 🔧       | 🔧     |
+| Debian (deb)     | 🔧       | 🔧      | 🔧          | 🔧       | 🔧         | 🔧       | 🔧     |
+| Alpine (apk)     | 🔧       | ✅      | 🔧          | 🔧       | 🔧         | 🔧       | 🔧     |
+| JavaScript (npm) | 🔧       | 🔧      | 🔧          | 🔧       | 🔧         | 🔧       | 🔧     |
+| Rust (cargo)     | 🔧       | 🔧      | 🔧          | 🔧       | 🔧         | 🔧       | 🔧     |
+| Go (mod)         | 🔧       | 🔧      | 🔧          | 🔧       | 🔧         | 🔧       | 🔧     |
+| Ruby (gem)       | 🔧       | 🔧      | 🔧          | 🔧       | 🔧         | 🔧       | 🔧     |
+| Dart (pub)       | 🔧       | 🔧      | 🔧          | 🔧       | 🔧         | 🔧       | 🔧     |
 
 ### Data Sources
 
 sbomify queries multiple authoritative sources in priority order:
 
-| Ecosystem | Primary Source | Fallback Sources |
-|-----------|----------------|------------------|
-| Python | PyPI API | deps.dev, ecosyste.ms |
-| JavaScript | deps.dev | ecosyste.ms |
-| Rust | deps.dev | ecosyste.ms |
-| Go | deps.dev | ecosyste.ms |
-| Ruby | deps.dev | ecosyste.ms |
-| Java/Maven | deps.dev | ecosyste.ms |
-| Dart | pub.dev API | ecosyste.ms |
-| Debian/Ubuntu | Debian Sources | Repology, ecosyste.ms |
-| Alpine | Repology | ecosyste.ms |
-| Red Hat/Fedora | Repology | ecosyste.ms |
+| Ecosystem      | Primary Source | Fallback Sources      |
+| -------------- | -------------- | --------------------- |
+| Python         | PyPI API       | deps.dev, ecosyste.ms |
+| JavaScript     | deps.dev       | ecosyste.ms           |
+| Rust           | deps.dev       | ecosyste.ms           |
+| Go             | deps.dev       | ecosyste.ms           |
+| Ruby           | deps.dev       | ecosyste.ms           |
+| Java/Maven     | deps.dev       | ecosyste.ms           |
+| Dart           | pub.dev API    | ecosyste.ms           |
+| Debian/Ubuntu  | Debian Sources | Repology, ecosyste.ms |
+| Alpine         | Repology       | ecosyste.ms           |
+| Red Hat/Fedora | Repology       | ecosyste.ms           |
 
 ### Before and After
 
@@ -127,11 +127,11 @@ sbomify queries multiple authoritative sources in priority order:
 The [CISA 2025 Minimum Elements](https://sbomify.com/compliance/cisa-minimum-elements/) draft introduces
 additional fields beyond NTIA 2021. sbomify supports these where applicable:
 
-| CISA 2025 Field | CycloneDX Field | SPDX Field | Status |
-|-----------------|-----------------|------------|--------|
-| **Component Hash** | `components[].hashes[]` | `packages[].checksums[]` | From generators |
-| **License** | `components[].licenses[]` | `packages[].licenseDeclared` | Enrichment adds |
-| **Tool Name/Version** | `metadata.tools` | `creationInfo.creators[]` | Augmentation adds sbomify |
+| CISA 2025 Field        | CycloneDX Field                      | SPDX Field                    | Status                         |
+| ---------------------- | ------------------------------------ | ----------------------------- | ------------------------------ |
+| **Component Hash**     | `components[].hashes[]`              | `packages[].checksums[]`      | From generators                |
+| **License**            | `components[].licenses[]`            | `packages[].licenseDeclared`  | Enrichment adds                |
+| **Tool Name/Version**  | `metadata.tools`                     | `creationInfo.creators[]`     | Augmentation adds sbomify      |
 | **Generation Context** | `metadata.lifecycles[].phase` (1.5+) | `creationInfo.creatorComment` | Augmentation adds from backend |
 
-*Generated: 2025-12-17 — Run `uv run scripts/generate_ntia_comparison.py` to update*
+_Generated: 2025-12-17 — Run `uv run scripts/generate_ntia_comparison.py` to update_


### PR DESCRIPTION
Add support for generating SBOMs in SPDX format via the SBOM_FORMAT environment variable. Defaults to CycloneDX for backward compatibility.

Changes:
- Add sbom_format field to Config with validation (cyclonedx|spdx)
- Load SBOM_FORMAT from environment (case-insensitive)
- Pass output_format to generate_sbom() and process_lock_file()
- Add proper error handling for process_lock_file() result
- Add 7 unit tests for format configuration
- Update workflow to generate and attest both CDX and SPDX formats
- Add conditionals to attestation steps for proper branch/tag handling
- Update README with SBOM_FORMAT documentation and examples

A special PR for @goneall. :)