### PR TITLE
Add DockerImageNotFoundError for better error handling when Docker images don't exist

### DIFF
--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -32,6 +32,7 @@ from ..console import (
 from ..exceptions import (
     APIError,
     ConfigurationError,
+    DockerImageNotFoundError,
     FileProcessingError,
     SBOMGenerationError,
     SBOMValidationError,
@@ -588,7 +589,8 @@ def initialize_sentry() -> None:
             exc_type, exc_value, tb = hint["exc_info"]
             # Don't send validation or configuration errors - these are user errors
             # SBOMGenerationError and APIError should still be sent (tool/system bugs)
-            if isinstance(exc_value, (SBOMValidationError, ConfigurationError)):
+            # DockerImageNotFoundError is a user configuration error (image doesn't exist)
+            if isinstance(exc_value, (SBOMValidationError, ConfigurationError, DockerImageNotFoundError)):
                 return None
         return event
 

--- a/sbomify_action/exceptions.py
+++ b/sbomify_action/exceptions.py
@@ -13,6 +13,27 @@ class SBOMGenerationError(SbomifyError):
     """Raised when SBOM generation fails."""
 
 
+class DockerImageNotFoundError(SBOMGenerationError):
+    """Raised when a Docker image cannot be found in any registry.
+
+    This error is raised when SBOM generation tools (trivy, syft, cdxgen) fail
+    because the specified Docker image doesn't exist or the tag is invalid.
+
+    Attributes:
+        image: The Docker image that was not found
+        message: Detailed error message
+    """
+
+    def __init__(self, image: str, message: str | None = None):
+        self.image = image
+        if message:
+            super().__init__(message)
+        else:
+            super().__init__(
+                f"Docker image '{image}' not found. Verify the image exists in the registry and the tag is correct."
+            )
+
+
 class SBOMValidationError(SbomifyError):
     """Raised when SBOM validation fails."""
 


### PR DESCRIPTION
- Add new DockerImageNotFoundError exception for clearer error messages
- Add detection patterns for common Docker image not found errors from trivy, syft, cdxgen
- Update run_command() to detect and raise DockerImageNotFoundError with WARNING log level
- Update trivy, syft, cdxgen generators to handle DockerImageNotFoundError
- Filter DockerImageNotFoundError from Sentry (user configuration error, not a bug)
- Add comprehensive tests for error detection and handling
