### PR TITLE
Fix SPDX lockfile detection for full paths generated by Trivy

### DIFF
--- a/sbomify_action/augmentation.py
+++ b/sbomify_action/augmentation.py
@@ -30,6 +30,7 @@ Version support:
     - SPDX: 2.2, 2.3
 """
 
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
@@ -111,8 +112,15 @@ def _propagate_supplier_to_lockfile_components(bom: Bom) -> None:
 
 
 def _is_lockfile_package(package: Package) -> bool:
-    """Check if an SPDX package represents a lockfile artifact."""
-    if package.name and package.name in LOCKFILE_NAMES:
+    """Check if an SPDX package represents a lockfile artifact.
+
+    Handles full paths like /github/workspace/uv.lock by extracting the basename.
+    """
+    if not package.name:
+        return False
+    # Extract basename to handle full paths (e.g., /github/workspace/uv.lock -> uv.lock)
+    basename = os.path.basename(package.name)
+    if basename in LOCKFILE_NAMES:
         # Check if it has a PURL - lockfiles typically don't have PURLs
         has_purl = any(ref.reference_type == "purl" for ref in package.external_references)
         if not has_purl:

--- a/tests/test_augmentation_module.py
+++ b/tests/test_augmentation_module.py
@@ -1127,6 +1127,88 @@ class TestLockfileComponentDetection:
         assert _is_lockfile_component(component) is False
 
 
+class TestLockfilePackageDetection:
+    """Test lockfile package detection for SPDX (augmentation module)."""
+
+    def test_lockfile_package_detected_by_name(self):
+        """Test that lockfile packages are detected by their filename."""
+        from spdx_tools.spdx.model import Package
+
+        from sbomify_action.augmentation import _is_lockfile_package
+
+        # requirements.txt is a known lockfile
+        package = Package(
+            spdx_id="SPDXRef-requirements",
+            name="requirements.txt",
+            download_location="NOASSERTION",
+        )
+        assert _is_lockfile_package(package) is True
+
+        # uv.lock is a known lockfile
+        package = Package(
+            spdx_id="SPDXRef-uv-lock",
+            name="uv.lock",
+            download_location="NOASSERTION",
+        )
+        assert _is_lockfile_package(package) is True
+
+    def test_lockfile_package_detected_by_full_path(self):
+        """Test that lockfile packages with full paths are detected.
+
+        Trivy generates SPDX with full paths like /github/workspace/uv.lock.
+        The detection should extract the basename to match against known lockfiles.
+        """
+        from spdx_tools.spdx.model import Package
+
+        from sbomify_action.augmentation import _is_lockfile_package
+
+        # Full path should be detected as lockfile
+        package = Package(
+            spdx_id="SPDXRef-uv-lock",
+            name="/github/workspace/uv.lock",
+            download_location="NOASSERTION",
+        )
+        assert _is_lockfile_package(package) is True
+
+        # Various path formats
+        package = Package(
+            spdx_id="SPDXRef-requirements",
+            name="/app/requirements.txt",
+            download_location="NOASSERTION",
+        )
+        assert _is_lockfile_package(package) is True
+
+        # Deep nested path
+        package = Package(
+            spdx_id="SPDXRef-poetry",
+            name="/home/runner/work/project/src/poetry.lock",
+            download_location="NOASSERTION",
+        )
+        assert _is_lockfile_package(package) is True
+
+    def test_non_lockfile_package_not_detected(self):
+        """Test that regular packages are not detected as lockfiles."""
+        from spdx_tools.spdx.model import Package
+
+        from sbomify_action.augmentation import _is_lockfile_package
+
+        # Regular package
+        package = Package(
+            spdx_id="SPDXRef-django",
+            name="django",
+            download_location="NOASSERTION",
+        )
+        assert _is_lockfile_package(package) is False
+
+        # Full path that is not a lockfile
+        package = Package(
+            spdx_id="SPDXRef-app",
+            name="/github/workspace/app.py",
+            download_location="NOASSERTION",
+        )
+        assert _is_lockfile_package(package) is False
+
+
 class TestErrorHandling:
     """Test error handling in augmentation."""
 


### PR DESCRIPTION
Trivy generates SPDX packages with full paths (e.g., /github/workspace/uv.lock) but the lockfile detection was doing exact string matching against filenames. This caused lockfile packages to not be enriched with supplier, version, and description - failing NTIA minimum elements compliance.

Changes:
- Update _is_lockfile_package() in augmentation.py to use os.path.basename()
- Update _is_lockfile_package() in enrichment.py to use os.path.basename()
- Fix LOCKFILE_DESCRIPTIONS lookup to use basename for full path packages
- Add tests for full-path lockfile detection and enrichment
