### PR TITLE
Add Conan Center enrichment source for C/C++ packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -168,6 +168,11 @@ ENV PATH="/app/node_modules/.bin:/opt/venv/bin:$PATH"
 # Make 'node' and 'npm' invoke 'bun' so tools that expect them actually run bun (compatibility shim)
 RUN ln -s /usr/local/bin/bun /usr/local/bin/node && \
     ln -s /usr/local/bin/bun /usr/local/bin/npm
+
+# Initialize Conan profile for C/C++ package metadata lookups
+# This creates a default profile based on the container's compiler/OS settings
+RUN conan profile detect --force
+
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ That's it! This generates a CycloneDX SBOM from your lockfile and enriches it wi
 - **Inject** additional packages not in lockfiles (vendored code, runtime deps, system libraries)
 - **Augment** with business metadata (supplier, authors, licenses, lifecycle phase) from config file or sbomify
 - **VCS Auto-Detection** — Automatically adds repository URL, commit SHA, and branch info from CI environment
-- **Enrich** with package metadata from PyPI, pub.dev, npm, Maven, deps.dev, and more
+- **Enrich** with package metadata from PyPI, pub.dev, crates.io, Conan Center, deps.dev, and more
 - **Audit Trail** — Every SBOM modification logged with timestamps for attestation and compliance
 - **Upload** to sbomify for collaboration and vulnerability management
 - **Tag** SBOMs with product releases
@@ -151,6 +151,7 @@ Every modification made to your SBOM is tracked and recorded for attestation and
 ### Example Output
 
 **Summary:**
+
 ```
 ┌─────────────────────┬───────┐
 │ Metric              │ Value │
@@ -162,6 +163,7 @@ Every modification made to your SBOM is tracked and recorded for attestation and
 ```
 
 **audit_trail.txt:**
+
 ```
 # SBOM Audit Trail
 # Generated: 2026-01-18T12:34:56Z
@@ -558,9 +560,11 @@ env:
 | PyPI           | Python                                                           | License, author, homepage                       |
 | pub.dev        | Dart                                                             | License, author, homepage, repo                 |
 | crates.io      | Rust/Cargo                                                       | License, author, homepage, repo, description    |
+| Conan Center   | C/C++ (Conan)                                                    | License, author, homepage, repo, description    |
 | Debian Sources | Debian packages                                                  | Maintainer, description, homepage               |
 | deps.dev       | Python, npm, Maven, Go, Ruby, NuGet (+ Rust fallback)            | License, homepage, repo                         |
 | ecosyste.ms    | All major ecosystems                                             | License, description, maintainer                |
+| ClearlyDefined | Python, npm, Cargo, Maven, Ruby, NuGet, Go                       | License, attribution                            |
 | Repology       | Linux distros                                                    | License, homepage                               |
 
 ### License Database
@@ -724,22 +728,24 @@ sbomify attempts to populate these fields for each component:
 
 sbomify queries sources in priority order, stopping when data is found:
 
-| Ecosystem         | Primary Source | Fallback Sources       |
-| ----------------- | -------------- | ---------------------- |
-| Python            | PyPI API       | deps.dev → ecosyste.ms |
-| JavaScript        | deps.dev       | ecosyste.ms            |
-| Rust              | crates.io API  | deps.dev → ecosyste.ms |
-| Go                | deps.dev       | ecosyste.ms            |
-| Ruby              | deps.dev       | ecosyste.ms            |
-| Java/Maven        | deps.dev       | ecosyste.ms            |
-| Dart              | pub.dev API    | ecosyste.ms            |
-| Debian            | Debian Sources | Repology → ecosyste.ms |
-| Ubuntu            | License DB     | Repology → ecosyste.ms |
-| Alpine            | License DB     | Repology → ecosyste.ms |
-| Wolfi             | License DB     | Repology → ecosyste.ms |
-| Rocky/Alma/CentOS | License DB     | Repology → ecosyste.ms |
-| Fedora            | License DB     | Repology → ecosyste.ms |
-| Amazon Linux      | License DB     | Repology → ecosyste.ms |
+| Ecosystem         | Primary Source   | Fallback Sources                        |
+| ----------------- | ---------------- | --------------------------------------- |
+| Python            | PyPI API         | deps.dev → ecosyste.ms → ClearlyDefined |
+| JavaScript        | deps.dev         | ecosyste.ms → ClearlyDefined            |
+| Rust              | crates.io API    | deps.dev → ecosyste.ms → ClearlyDefined |
+| Go                | deps.dev         | ecosyste.ms → ClearlyDefined            |
+| Ruby              | deps.dev         | ecosyste.ms → ClearlyDefined            |
+| Java/Maven        | deps.dev         | ecosyste.ms → ClearlyDefined            |
+| NuGet             | deps.dev         | ecosyste.ms → ClearlyDefined            |
+| Dart              | pub.dev API      | ecosyste.ms                             |
+| C++ (Conan)       | Conan Center API | ecosyste.ms                             |
+| Debian            | Debian Sources   | Repology → ecosyste.ms                  |
+| Ubuntu            | License DB       | Repology → ecosyste.ms                  |
+| Alpine            | License DB       | Repology → ecosyste.ms                  |
+| Wolfi             | License DB       | Repology → ecosyste.ms                  |
+| Rocky/Alma/CentOS | License DB       | Repology → ecosyste.ms                  |
+| Fedora            | License DB       | Repology → ecosyste.ms                  |
+| Amazon Linux      | License DB       | Repology → ecosyste.ms                  |
 
 ### Limitations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "rich>=14.2.0",
     "zstandard>=0.25.0",
     "packageurl-python>=0.17.6",
+    "conan>=2.0,<3",
 ]
 
 [project.urls]

--- a/sbomify_action/_enrichment/enricher.py
+++ b/sbomify_action/_enrichment/enricher.py
@@ -20,6 +20,7 @@ from .metadata import NormalizedMetadata
 from .registry import SourceRegistry
 from .sources import (
     ClearlyDefinedSource,
+    ConanSource,
     CratesIOSource,
     DebianSource,
     DepsDevSource,
@@ -50,6 +51,7 @@ def create_default_registry() -> SourceRegistry:
     - PyPISource (10) - direct from PyPI for Python packages
     - PubDevSource (10) - direct from pub.dev for Dart packages
     - CratesIOSource (10) - direct from crates.io for Rust packages
+    - ConanSource (10) - direct from Conan Center for C/C++ packages
     - DebianSource (10) - direct from sources.debian.org
 
     Tier 2 - Primary Aggregators (40-49):
@@ -74,6 +76,7 @@ def create_default_registry() -> SourceRegistry:
     registry.register(PyPISource())
     registry.register(PubDevSource())
     registry.register(CratesIOSource())
+    registry.register(ConanSource())
     registry.register(DebianSource())
     registry.register(DepsDevSource())
     registry.register(EcosystemsSource())
@@ -251,6 +254,7 @@ class Enricher:
 def clear_all_caches() -> None:
     """Clear all data source caches."""
     from .sources.clearlydefined import clear_cache as clear_clearlydefined
+    from .sources.conan import clear_cache as clear_conan
     from .sources.cratesio import clear_cache as clear_cratesio
     from .sources.debian import clear_cache as clear_debian
     from .sources.depsdev import clear_cache as clear_depsdev
@@ -266,6 +270,7 @@ def clear_all_caches() -> None:
     clear_pypi()
     clear_pubdev()
     clear_cratesio()
+    clear_conan()
     clear_debian()
     clear_depsdev()
     clear_ecosystems()

--- a/sbomify_action/_enrichment/sources/__init__.py
+++ b/sbomify_action/_enrichment/sources/__init__.py
@@ -1,6 +1,7 @@
 """Data source implementations for SBOM enrichment."""
 
 from .clearlydefined import ClearlyDefinedSource
+from .conan import ConanSource
 from .cratesio import CratesIOSource
 from .debian import DebianSource
 from .depsdev import DepsDevSource
@@ -13,15 +14,16 @@ from .pypi import PyPISource
 from .repology import RepologySource
 
 __all__ = [
-    "PyPISource",
-    "PubDevSource",
+    "ClearlyDefinedSource",
+    "ConanSource",
     "CratesIOSource",
     "DebianSource",
     "DepsDevSource",
     "EcosystemsSource",
-    "PURLSource",
-    "ClearlyDefinedSource",
-    "RepologySource",
     "LicenseDBSource",
     "LifecycleSource",
+    "PubDevSource",
+    "PURLSource",
+    "PyPISource",
+    "RepologySource",
 ]

--- a/sbomify_action/_enrichment/sources/conan.py
+++ b/sbomify_action/_enrichment/sources/conan.py
@@ -1,0 +1,249 @@
+"""Conan Center data source for C/C++ package metadata.
+
+Uses the Conan Python API to fetch package metadata from Conan Center on-demand.
+This is the authoritative source for Conan packages.
+"""
+
+from typing import Any, Dict, Optional
+
+import requests
+from packageurl import PackageURL
+
+from sbomify_action.logging_config import logger
+
+from ..metadata import NormalizedMetadata
+from ..sanitization import normalize_vcs_url
+
+# Simple in-memory cache
+_cache: Dict[str, Optional[NormalizedMetadata]] = {}
+
+# Cache for Conan API instance and initialization state
+_conan_api: Optional[Any] = None
+_conan_available: Optional[bool] = None
+_profiles: Optional[tuple] = None
+
+
+def clear_cache() -> None:
+    """Clear the Conan metadata cache."""
+    global _conan_api, _conan_available, _profiles
+    _cache.clear()
+    _conan_api = None
+    _conan_available = None
+    _profiles = None
+
+
+def _get_conan_api() -> Optional[Any]:
+    """Get or create the Conan API instance."""
+    global _conan_api, _conan_available
+
+    if _conan_available is False:
+        return None
+
+    if _conan_api is not None:
+        return _conan_api
+
+    try:
+        from conan.api.conan_api import ConanAPI
+
+        _conan_api = ConanAPI()
+        _conan_available = True
+        logger.debug("Conan API initialized successfully")
+        return _conan_api
+    except ImportError:
+        logger.debug("Conan library not available")
+        _conan_available = False
+        return None
+    except Exception as e:
+        logger.warning(f"Failed to initialize Conan API: {e}")
+        _conan_available = False
+        return None
+
+
+def _get_profiles(api: Any) -> Optional[tuple]:
+    """Get or create Conan profiles."""
+    global _profiles
+
+    if _profiles is not None:
+        return _profiles
+
+    try:
+        # Get default profiles (will auto-detect if not configured)
+        profile_host = api.profiles.get_profile([])
+        profile_build = api.profiles.get_profile([])
+        _profiles = (profile_host, profile_build)
+        return _profiles
+    except Exception as e:
+        logger.warning(f"Failed to get Conan profiles: {e}")
+        return None
+
+
+class ConanSource:
+    """
+    Data source for Conan Center (C/C++ package registry) packages.
+
+    This source uses the Conan Python API to fetch package metadata from Conan Center.
+    It's the authoritative source for Conan packages and should be tried first
+    before generic sources like ecosyste.ms.
+
+    Priority: 10 (high - native source)
+    Supports: pkg:conan/* packages
+    """
+
+    @property
+    def name(self) -> str:
+        return "conan.io"
+
+    @property
+    def priority(self) -> int:
+        # Tier 1: Native sources (10-19) - Direct from official package registries
+        return 10
+
+    def supports(self, purl: PackageURL) -> bool:
+        """Check if this source supports the given PURL."""
+        return purl.type == "conan"
+
+    def fetch(self, purl: PackageURL, session: requests.Session) -> Optional[NormalizedMetadata]:
+        """
+        Fetch metadata from Conan Center via Python API.
+
+        Args:
+            purl: Parsed PackageURL for a Conan package
+            session: requests.Session (not used, but required by protocol)
+
+        Returns:
+            NormalizedMetadata if successful, None otherwise
+        """
+        # Get Conan API
+        api = _get_conan_api()
+        if api is None:
+            logger.debug("Conan API not available, skipping Conan enrichment")
+            return None
+
+        # Get profiles
+        profiles = _get_profiles(api)
+        if profiles is None:
+            logger.debug("Conan profiles not available, skipping Conan enrichment")
+            return None
+
+        profile_host, profile_build = profiles
+
+        # Build cache key
+        version = purl.version or "latest"
+        cache_key = f"conan:{purl.name}:{version}"
+
+        # Check cache
+        if cache_key in _cache:
+            logger.debug(f"Cache hit (Conan): {purl.name}")
+            return _cache[cache_key]
+
+        try:
+            # Build the requires string
+            if purl.version:
+                requires = f"{purl.name}/{purl.version}"
+            else:
+                requires = purl.name
+
+            logger.debug(f"Fetching Conan metadata for: {requires}")
+
+            # Get remotes
+            remotes = api.remotes.list()
+
+            # Load dependency graph
+            graph = api.graph.load_graph_requires(
+                requires=[requires],
+                tool_requires=None,
+                profile_host=profile_host,
+                profile_build=profile_build,
+                lockfile=None,
+                remotes=remotes,
+                update=False,
+            )
+
+            # Find our package in the graph
+            metadata = self._extract_metadata_from_graph(purl.name, graph)
+
+            # Cache result
+            _cache[cache_key] = metadata
+            return metadata
+
+        except Exception as e:
+            error_msg = str(e).lower()
+            if "not found" in error_msg or "unable to find" in error_msg:
+                logger.debug(f"Package not found in Conan Center: {purl.name}")
+            else:
+                logger.warning(f"Error fetching Conan metadata for {purl.name}: {e}")
+            _cache[cache_key] = None
+            return None
+
+    def _extract_metadata_from_graph(self, package_name: str, graph: Any) -> Optional[NormalizedMetadata]:
+        """
+        Extract metadata from a Conan dependency graph.
+
+        Args:
+            package_name: Name of the package to find
+            graph: Conan Deps graph object
+
+        Returns:
+            NormalizedMetadata with extracted fields, or None if not found
+        """
+        # Find the node matching our package name
+        conanfile = None
+        for node in graph.nodes:
+            if node.conanfile and node.conanfile.name == package_name:
+                conanfile = node.conanfile
+                break
+
+        if not conanfile:
+            logger.debug(f"Package not found in Conan graph: {package_name}")
+            return None
+
+        # Extract license
+        license_val = getattr(conanfile, "license", None)
+        licenses = []
+        if license_val:
+            # License can be a string or tuple
+            if isinstance(license_val, (list, tuple)):
+                licenses = list(license_val)
+            else:
+                licenses = [str(license_val)]
+
+        # Extract other fields
+        description = getattr(conanfile, "description", None)
+        homepage = getattr(conanfile, "homepage", None)
+        url = getattr(conanfile, "url", None)  # Usually the conan-center-index repo
+        author = getattr(conanfile, "author", None)
+
+        # Normalize repository URL
+        repository_url = normalize_vcs_url(url) if url else None
+
+        # Build field_sources for attribution
+        field_sources: Dict[str, str] = {}
+        if description:
+            field_sources["description"] = self.name
+        if licenses:
+            field_sources["licenses"] = self.name
+        if homepage:
+            field_sources["homepage"] = self.name
+        if repository_url:
+            field_sources["repository_url"] = self.name
+
+        # Use author as supplier if available
+        supplier = author if author else None
+        if supplier:
+            field_sources["supplier"] = self.name
+
+        metadata = NormalizedMetadata(
+            description=description,
+            licenses=licenses,
+            supplier=supplier,
+            homepage=homepage,
+            repository_url=repository_url,
+            registry_url=f"https://conan.io/center/recipes/{package_name}",
+            source=self.name,
+            field_sources=field_sources,
+        )
+
+        if metadata.has_data():
+            logger.debug(f"Successfully fetched Conan metadata for: {package_name}")
+            return metadata
+        return None

--- a/tests/test_conan_source.py
+++ b/tests/test_conan_source.py
@@ -1,0 +1,442 @@
+"""Tests for the ConanSource enrichment data source."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+from packageurl import PackageURL
+
+from sbomify_action._enrichment.sources.conan import ConanSource, clear_cache
+
+
+@pytest.fixture(autouse=True)
+def clear_cache_before_test():
+    """Clear the cache before each test to ensure isolation."""
+    clear_cache()
+    yield
+    clear_cache()
+
+
+@pytest.fixture
+def mock_session():
+    """Create a mock requests session (not used by ConanSource but required by protocol)."""
+    return Mock(spec=requests.Session)
+
+
+class TestConanSourceBasics:
+    """Test basic properties of ConanSource."""
+
+    def test_source_name(self):
+        """Test that the source name is correct."""
+        source = ConanSource()
+        assert source.name == "conan.io"
+
+    def test_source_priority(self):
+        """Test that the source has Tier 1 priority."""
+        source = ConanSource()
+        assert source.priority == 10  # Tier 1: Native sources
+
+    def test_supports_conan_packages(self):
+        """Test that ConanSource supports conan packages."""
+        source = ConanSource()
+        purl = PackageURL.from_string("pkg:conan/zlib@1.3.1")
+        assert source.supports(purl) is True
+
+    def test_supports_conan_without_version(self):
+        """Test that ConanSource supports conan packages without version."""
+        source = ConanSource()
+        purl = PackageURL.from_string("pkg:conan/boost")
+        assert source.supports(purl) is True
+
+    def test_does_not_support_pypi(self):
+        """Test that ConanSource does not support PyPI packages."""
+        source = ConanSource()
+        purl = PackageURL.from_string("pkg:pypi/requests@2.31.0")
+        assert source.supports(purl) is False
+
+    def test_does_not_support_npm(self):
+        """Test that ConanSource does not support npm packages."""
+        source = ConanSource()
+        purl = PackageURL.from_string("pkg:npm/lodash@4.17.21")
+        assert source.supports(purl) is False
+
+    def test_does_not_support_cargo(self):
+        """Test that ConanSource does not support cargo packages."""
+        source = ConanSource()
+        purl = PackageURL.from_string("pkg:cargo/serde@1.0.0")
+        assert source.supports(purl) is False
+
+    def test_does_not_support_deb(self):
+        """Test that ConanSource does not support deb packages."""
+        source = ConanSource()
+        purl = PackageURL.from_string("pkg:deb/debian/bash@5.2")
+        assert source.supports(purl) is False
+
+
+class TestConanSourceFetchMocked:
+    """Test fetch functionality of ConanSource with mocked Conan API."""
+
+    def test_fetch_conan_not_available(self, mock_session):
+        """Test graceful handling when Conan library is not available."""
+        source = ConanSource()
+        purl = PackageURL.from_string("pkg:conan/zlib@1.3.1")
+
+        with patch("sbomify_action._enrichment.sources.conan._get_conan_api", return_value=None):
+            metadata = source.fetch(purl, mock_session)
+
+        assert metadata is None
+
+    def test_fetch_profiles_not_available(self, mock_session):
+        """Test graceful handling when profiles are not available."""
+        source = ConanSource()
+        purl = PackageURL.from_string("pkg:conan/zlib@1.3.1")
+
+        mock_api = Mock()
+        with patch("sbomify_action._enrichment.sources.conan._get_conan_api", return_value=mock_api):
+            with patch("sbomify_action._enrichment.sources.conan._get_profiles", return_value=None):
+                metadata = source.fetch(purl, mock_session)
+
+        assert metadata is None
+
+    def test_fetch_success_with_mocked_graph(self, mock_session):
+        """Test successful metadata fetch with mocked graph response."""
+        source = ConanSource()
+        purl = PackageURL.from_string("pkg:conan/zlib@1.3.1")
+
+        # Create mock conanfile
+        mock_conanfile = Mock()
+        mock_conanfile.name = "zlib"
+        mock_conanfile.license = "Zlib"
+        mock_conanfile.description = "A Massively Spiffy Yet Delicately Unobtrusive Compression Library"
+        mock_conanfile.homepage = "https://zlib.net"
+        mock_conanfile.url = "https://github.com/conan-io/conan-center-index"
+        mock_conanfile.topics = ("zlib", "compression")
+        mock_conanfile.author = None
+
+        # Create mock node
+        mock_node = Mock()
+        mock_node.conanfile = mock_conanfile
+
+        # Create mock graph
+        mock_graph = Mock()
+        mock_graph.nodes = [mock_node]
+
+        # Create mock API
+        mock_api = Mock()
+        mock_api.remotes.list.return_value = []
+        mock_api.graph.load_graph_requires.return_value = mock_graph
+
+        mock_profiles = (Mock(), Mock())
+
+        with patch("sbomify_action._enrichment.sources.conan._get_conan_api", return_value=mock_api):
+            with patch("sbomify_action._enrichment.sources.conan._get_profiles", return_value=mock_profiles):
+                metadata = source.fetch(purl, mock_session)
+
+        assert metadata is not None
+        assert metadata.licenses == ["Zlib"]
+        assert metadata.description == "A Massively Spiffy Yet Delicately Unobtrusive Compression Library"
+        assert metadata.homepage == "https://zlib.net"
+        assert "github.com/conan-io/conan-center-index" in metadata.repository_url
+        assert metadata.registry_url == "https://conan.io/center/recipes/zlib"
+        assert metadata.source == "conan.io"
+
+    def test_fetch_success_with_tuple_license(self, mock_session):
+        """Test handling of tuple license (multiple licenses)."""
+        source = ConanSource()
+        purl = PackageURL.from_string("pkg:conan/mbedtls@3.6.4")
+
+        mock_conanfile = Mock()
+        mock_conanfile.name = "mbedtls"
+        mock_conanfile.license = ("Apache-2.0", "GPL-2.0-or-later")
+        mock_conanfile.description = "mbed TLS"
+        mock_conanfile.homepage = "https://tls.mbed.org"
+        mock_conanfile.url = None
+        mock_conanfile.topics = None
+        mock_conanfile.author = None
+
+        mock_node = Mock()
+        mock_node.conanfile = mock_conanfile
+
+        mock_graph = Mock()
+        mock_graph.nodes = [mock_node]
+
+        mock_api = Mock()
+        mock_api.remotes.list.return_value = []
+        mock_api.graph.load_graph_requires.return_value = mock_graph
+
+        mock_profiles = (Mock(), Mock())
+
+        with patch("sbomify_action._enrichment.sources.conan._get_conan_api", return_value=mock_api):
+            with patch("sbomify_action._enrichment.sources.conan._get_profiles", return_value=mock_profiles):
+                metadata = source.fetch(purl, mock_session)
+
+        assert metadata is not None
+        assert metadata.licenses == ["Apache-2.0", "GPL-2.0-or-later"]
+
+    def test_fetch_package_not_found(self, mock_session):
+        """Test handling when package is not found in Conan Center."""
+        source = ConanSource()
+        purl = PackageURL.from_string("pkg:conan/nonexistent-package@1.0.0")
+
+        mock_api = Mock()
+        mock_api.remotes.list.return_value = []
+        mock_api.graph.load_graph_requires.side_effect = Exception("Package not found")
+
+        mock_profiles = (Mock(), Mock())
+
+        with patch("sbomify_action._enrichment.sources.conan._get_conan_api", return_value=mock_api):
+            with patch("sbomify_action._enrichment.sources.conan._get_profiles", return_value=mock_profiles):
+                metadata = source.fetch(purl, mock_session)
+
+        assert metadata is None
+
+    def test_fetch_with_author(self, mock_session):
+        """Test that author is used as supplier."""
+        source = ConanSource()
+        purl = PackageURL.from_string("pkg:conan/testpkg@1.0.0")
+
+        mock_conanfile = Mock()
+        mock_conanfile.name = "testpkg"
+        mock_conanfile.license = "MIT"
+        mock_conanfile.description = "Test package"
+        mock_conanfile.homepage = "https://example.com"
+        mock_conanfile.url = None
+        mock_conanfile.topics = None
+        mock_conanfile.author = "Test Author"
+
+        mock_node = Mock()
+        mock_node.conanfile = mock_conanfile
+
+        mock_graph = Mock()
+        mock_graph.nodes = [mock_node]
+
+        mock_api = Mock()
+        mock_api.remotes.list.return_value = []
+        mock_api.graph.load_graph_requires.return_value = mock_graph
+
+        mock_profiles = (Mock(), Mock())
+
+        with patch("sbomify_action._enrichment.sources.conan._get_conan_api", return_value=mock_api):
+            with patch("sbomify_action._enrichment.sources.conan._get_profiles", return_value=mock_profiles):
+                metadata = source.fetch(purl, mock_session)
+
+        assert metadata is not None
+        assert metadata.supplier == "Test Author"
+
+
+class TestConanSourceCaching:
+    """Test caching behavior of ConanSource."""
+
+    def test_cache_hit(self, mock_session):
+        """Test that repeated requests use cache."""
+        source = ConanSource()
+        purl = PackageURL.from_string("pkg:conan/zlib@1.3.1")
+
+        mock_conanfile = Mock()
+        mock_conanfile.name = "zlib"
+        mock_conanfile.license = "Zlib"
+        mock_conanfile.description = "Compression library"
+        mock_conanfile.homepage = "https://zlib.net"
+        mock_conanfile.url = None
+        mock_conanfile.topics = None
+        mock_conanfile.author = None
+
+        mock_node = Mock()
+        mock_node.conanfile = mock_conanfile
+
+        mock_graph = Mock()
+        mock_graph.nodes = [mock_node]
+
+        mock_api = Mock()
+        mock_api.remotes.list.return_value = []
+        mock_api.graph.load_graph_requires.return_value = mock_graph
+
+        mock_profiles = (Mock(), Mock())
+
+        with patch("sbomify_action._enrichment.sources.conan._get_conan_api", return_value=mock_api):
+            with patch("sbomify_action._enrichment.sources.conan._get_profiles", return_value=mock_profiles):
+                # First fetch
+                metadata1 = source.fetch(purl, mock_session)
+                # Second fetch (should use cache)
+                metadata2 = source.fetch(purl, mock_session)
+
+        assert metadata1 is not None
+        assert metadata2 is not None
+        assert metadata1.description == metadata2.description
+        # API should only be called once
+        assert mock_api.graph.load_graph_requires.call_count == 1
+
+    def test_cache_cleared(self, mock_session):
+        """Test that clear_cache() works."""
+        source = ConanSource()
+        purl = PackageURL.from_string("pkg:conan/zlib@1.3.1")
+
+        mock_conanfile = Mock()
+        mock_conanfile.name = "zlib"
+        mock_conanfile.license = "Zlib"
+        mock_conanfile.description = "Compression library"
+        mock_conanfile.homepage = "https://zlib.net"
+        mock_conanfile.url = None
+        mock_conanfile.topics = None
+        mock_conanfile.author = None
+
+        mock_node = Mock()
+        mock_node.conanfile = mock_conanfile
+
+        mock_graph = Mock()
+        mock_graph.nodes = [mock_node]
+
+        mock_api = Mock()
+        mock_api.remotes.list.return_value = []
+        mock_api.graph.load_graph_requires.return_value = mock_graph
+
+        mock_profiles = (Mock(), Mock())
+
+        with patch("sbomify_action._enrichment.sources.conan._get_conan_api", return_value=mock_api):
+            with patch("sbomify_action._enrichment.sources.conan._get_profiles", return_value=mock_profiles):
+                # First fetch
+                source.fetch(purl, mock_session)
+                # Clear cache
+                clear_cache()
+                # Second fetch (should not use cache)
+                source.fetch(purl, mock_session)
+
+        # API should be called twice (cache was cleared)
+        assert mock_api.graph.load_graph_requires.call_count == 2
+
+
+class TestConanSourceFieldSources:
+    """Test field_sources attribution in ConanSource."""
+
+    def test_field_sources_populated(self, mock_session):
+        """Test that field_sources is populated correctly."""
+        source = ConanSource()
+        purl = PackageURL.from_string("pkg:conan/zlib@1.3.1")
+
+        mock_conanfile = Mock()
+        mock_conanfile.name = "zlib"
+        mock_conanfile.license = "Zlib"
+        mock_conanfile.description = "Compression library"
+        mock_conanfile.homepage = "https://zlib.net"
+        mock_conanfile.url = "https://github.com/conan-io/conan-center-index"
+        mock_conanfile.topics = ("zlib", "compression")
+        mock_conanfile.author = None
+
+        mock_node = Mock()
+        mock_node.conanfile = mock_conanfile
+
+        mock_graph = Mock()
+        mock_graph.nodes = [mock_node]
+
+        mock_api = Mock()
+        mock_api.remotes.list.return_value = []
+        mock_api.graph.load_graph_requires.return_value = mock_graph
+
+        mock_profiles = (Mock(), Mock())
+
+        with patch("sbomify_action._enrichment.sources.conan._get_conan_api", return_value=mock_api):
+            with patch("sbomify_action._enrichment.sources.conan._get_profiles", return_value=mock_profiles):
+                metadata = source.fetch(purl, mock_session)
+
+        assert metadata is not None
+        assert metadata.field_sources.get("description") == "conan.io"
+        assert metadata.field_sources.get("licenses") == "conan.io"
+        assert metadata.field_sources.get("homepage") == "conan.io"
+        assert metadata.field_sources.get("repository_url") == "conan.io"
+
+
+class TestConanSourceRegistration:
+    """Test ConanSource registration in the enrichment registry."""
+
+    def test_registered_in_default_registry(self):
+        """Test that ConanSource is in the default registry."""
+        from sbomify_action._enrichment.enricher import create_default_registry
+
+        registry = create_default_registry()
+        purl = PackageURL.from_string("pkg:conan/zlib@1.3.1")
+
+        sources = registry.get_sources_for(purl)
+
+        # ConanSource should be in the list
+        source_names = [s.name for s in sources]
+        assert "conan.io" in source_names
+
+        # ConanSource should have Tier 1 priority
+        conan_source = next(s for s in sources if s.name == "conan.io")
+        assert conan_source.priority == 10
+
+    def test_priority_over_depsdev(self):
+        """Test that ConanSource has priority over DepsDevSource for conan."""
+        from sbomify_action._enrichment.enricher import create_default_registry
+
+        registry = create_default_registry()
+        purl = PackageURL.from_string("pkg:conan/zlib@1.3.1")
+
+        sources = registry.get_sources_for(purl)
+
+        # Find both sources
+        source_dict = {s.name: s for s in sources}
+        assert "conan.io" in source_dict
+
+        # conan.io should have lower priority number (= higher priority) than aggregators
+        # Note: deps.dev doesn't support conan, so just verify conan.io priority
+        assert source_dict["conan.io"].priority == 10
+
+
+# Integration tests - these make real network calls to Conan Center
+# Mark with @pytest.mark.slow so they can be skipped in quick test runs
+class TestConanSourceIntegration:
+    """Integration tests for ConanSource with real Conan Center lookups.
+
+    These tests use the packages from tests/test-data/conan.lock:
+    - mbedtls/3.6.4 (Apache-2.0)
+    - cjson/1.7.18 (MIT)
+    """
+
+    @pytest.mark.slow
+    def test_integration_zlib(self):
+        """Integration test with real zlib package."""
+        source = ConanSource()
+        purl = PackageURL.from_string("pkg:conan/zlib@1.3.1")
+        metadata = source.fetch(purl, requests.Session())
+
+        assert metadata is not None
+        assert metadata.licenses == ["Zlib"]
+        assert metadata.description is not None
+        assert "compression" in metadata.description.lower() or "zlib" in metadata.description.lower()
+        assert metadata.homepage == "https://zlib.net"
+        assert metadata.source == "conan.io"
+
+    @pytest.mark.slow
+    def test_integration_mbedtls_from_conan_lock(self):
+        """Integration test with real mbedtls package from conan.lock test data."""
+        source = ConanSource()
+        purl = PackageURL.from_string("pkg:conan/mbedtls@3.6.4")
+        metadata = source.fetch(purl, requests.Session())
+
+        assert metadata is not None
+        assert metadata.licenses  # Should have license
+        assert "Apache-2.0" in metadata.licenses[0] or "Apache" in str(metadata.licenses)
+        assert metadata.description is not None
+        assert metadata.homepage is not None
+
+    @pytest.mark.slow
+    def test_integration_cjson_from_conan_lock(self):
+        """Integration test with real cjson package from conan.lock test data."""
+        source = ConanSource()
+        purl = PackageURL.from_string("pkg:conan/cjson@1.7.18")
+        metadata = source.fetch(purl, requests.Session())
+
+        assert metadata is not None
+        assert "MIT" in metadata.licenses
+        assert metadata.description is not None
+        assert metadata.homepage is not None
+
+    @pytest.mark.slow
+    def test_integration_nonexistent_package(self):
+        """Integration test with nonexistent package."""
+        source = ConanSource()
+        purl = PackageURL.from_string("pkg:conan/this-package-definitely-does-not-exist@99.99.99")
+        metadata = source.fetch(purl, requests.Session())
+
+        assert metadata is None

--- a/uv.lock
+++ b/uv.lock
@@ -242,6 +242,23 @@ wheels = [
 ]
 
 [[package]]
+name = "conan"
+version = "2.24.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "distro", marker = "platform_system == 'FreeBSD' or sys_platform == 'linux'" },
+    { name = "fasteners" },
+    { name = "jinja2" },
+    { name = "patch-ng" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b8/2a926814018061d84fbadffb2286927f3986f42599598ac5af1b108e86fd/conan-2.24.0.tar.gz", hash = "sha256:3467b5b9a1099a16fe2d2c425d7eb02c84291bfd09417df16b028cbcae9060e2", size = 552998, upload-time = "2025-12-15T13:48:31.359Z" }
+
+[[package]]
 name = "coverage"
 version = "7.13.1"
 source = { registry = "https://pypi.org/simple" }
@@ -453,6 +470,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.22.4"
 source = { registry = "https://pypi.org/simple" }
@@ -471,6 +497,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fasteners"
+version = "0.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/18/7881a99ba5244bfc82f06017316ffe93217dbbbcfa52b887caa1d4f2a6d3/fasteners-0.20.tar.gz", hash = "sha256:55dce8792a41b56f727ba6e123fcaee77fd87e638a6863cec00007bfea84c8d8", size = 25087, upload-time = "2025-08-11T10:19:37.785Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl", hash = "sha256:9422c40d1e350e4259f509fb2e608d6bc43c0136f79a00db1b49046029d0b3b7", size = 18702, upload-time = "2025-08-11T10:19:35.716Z" },
 ]
 
 [[package]]
@@ -606,6 +641,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -833,6 +880,91 @@ wheels = [
 ]
 
 [[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -909,6 +1041,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
+
+[[package]]
+name = "patch-ng"
+version = "1.18.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/c0/53a2f017ac5b5397a7064c2654b73c3334ac8461315707cbede6c12199eb/patch-ng-1.18.1.tar.gz", hash = "sha256:52fd46ee46f6c8667692682c1fd7134edc65a2d2d084ebec1d295a6087fc0291", size = 17913, upload-time = "2024-10-25T12:20:10.591Z" }
 
 [[package]]
 name = "pip-requirements-parser"
@@ -1409,6 +1547,7 @@ name = "sbomify-action"
 version = "0.12"
 source = { editable = "." }
 dependencies = [
+    { name = "conan" },
     { name = "cyclonedx-bom" },
     { name = "cyclonedx-python-lib" },
     { name = "packageurl-python" },
@@ -1432,6 +1571,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "conan", specifier = ">=2.0,<3" },
     { name = "cyclonedx-bom", specifier = ">=7.2.1,<8" },
     { name = "cyclonedx-python-lib", specifier = ">=11.5.0,<12" },
     { name = "packageurl-python", specifier = ">=0.17.6" },


### PR DESCRIPTION
Integrate Conan Center as a native enrichment source (Tier 1, priority 10) for C/C++ packages using the Conan Python API.

Changes:
- Add ConanSource that queries Conan Center via Python API for metadata (license, description, homepage, repository, author)
- Add conan>=2.0 dependency to pyproject.toml
- Initialize Conan profile in Dockerfile for container builds
- Register ConanSource in enricher with cache clearing support
- Add comprehensive tests (23 tests, 86% coverage) including integration tests using packages from tests/test-data/conan.lock
- Update README with Conan Center and ClearlyDefined documentation
