### PR TITLE
fix: capture stdout in error logging for tools that output errors there

### DIFF
--- a/sbomify_action/_generation/generators/cyclonedx_cargo.py
+++ b/sbomify_action/_generation/generators/cyclonedx_cargo.py
@@ -152,7 +152,7 @@ class CycloneDXCargoGenerator:
                 generator_name=self.name,
             )
         else:
-            log_command_error("cargo-cyclonedx", result.stderr)
+            log_command_error("cargo-cyclonedx", result.stderr, result.stdout)
             return GenerationResult.failure_result(
                 error_message=f"cargo-cyclonedx failed with return code {result.returncode}",
                 sbom_format="cyclonedx",

--- a/sbomify_action/_generation/generators/cyclonedx_py.py
+++ b/sbomify_action/_generation/generators/cyclonedx_py.py
@@ -174,7 +174,7 @@ class CycloneDXPyGenerator:
                 generator_name=self.name,
             )
         else:
-            log_command_error("cyclonedx-py", result.stderr)
+            log_command_error("cyclonedx-py", result.stderr, result.stdout)
             return GenerationResult.failure_result(
                 error_message=f"cyclonedx-py failed with return code {result.returncode}",
                 sbom_format="cyclonedx",
@@ -216,7 +216,7 @@ class CycloneDXPyGenerator:
                 generator_name=self.name,
             )
         else:
-            log_command_error("cyclonedx-py", result.stderr)
+            log_command_error("cyclonedx-py", result.stderr, result.stdout)
             return GenerationResult.failure_result(
                 error_message=f"cyclonedx-py failed with return code {result.returncode}",
                 sbom_format="cyclonedx",


### PR DESCRIPTION
Some SBOM generators like cdxgen output error messages to stdout instead of stderr. When these tools failed, the actual error details were lost because only stderr was being logged. This made debugging production failures difficult since Sentry only showed "returned non-zero exit status 1" without the underlying cause.
