### PR TITLE
Add user-friendly error handling for component not found errors

### DIFF
--- a/sbomify_action/_upload/destinations/sbomify.py
+++ b/sbomify_action/_upload/destinations/sbomify.py
@@ -136,6 +136,16 @@ class SbomifyDestination:
 
         # Handle response
         if not response.ok:
+            # Handle component not found error (check before JSON parsing)
+            if response.status_code == 404:
+                return UploadResult.failure_result(
+                    destination_name=self.name,
+                    error_message="The specified component does not exist. Verify your COMPONENT_ID is correct and the component exists in your sbomify dashboard.",
+                    error_code="COMPONENT_NOT_FOUND",
+                    validated=validated,
+                    validation_error=validation_error,
+                )
+
             error_code = None
             err_msg = f"Failed to upload SBOM file. [{response.status_code}]"
             try:

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -21,6 +21,7 @@ from ..augmentation import augment_sbom_from_file
 from ..console import (
     get_audit_trail,
     gha_notice,
+    print_component_not_found_error,
     print_duplicate_sbom_error,
     print_final_success,
     print_step_end,
@@ -1189,6 +1190,11 @@ def run_pipeline(config: Config) -> None:
                             f"version={config.component_version}"
                         )
                         print_duplicate_sbom_error(config.component_id, FORMAT, config.component_version)
+                    elif result.error_code == "COMPONENT_NOT_FOUND":
+                        logger.error(
+                            f"Upload to {destination} failed: component not found (component_id={config.component_id})"
+                        )
+                        print_component_not_found_error(config.component_id)
                     else:
                         logger.error(f"Upload to {destination} failed: {result.error_message}")
                     failed_destinations.append(destination)

--- a/sbomify_action/console.py
+++ b/sbomify_action/console.py
@@ -388,6 +388,36 @@ def print_duplicate_sbom_error(component_id: str, sbom_format: str, component_ve
     gha_error("SBOM already exists for this component version", title="Duplicate SBOM")
 
 
+def print_component_not_found_error(component_id: str) -> None:
+    """
+    Print a styled error panel for component not found error.
+
+    This provides a clear, user-friendly error message when the specified
+    component does not exist in sbomify, with suggested solutions.
+
+    Args:
+        component_id: The component ID that was not found
+    """
+    content = Text()
+    content.append("The specified component does not exist.\n\n", style="bold")
+    content.append("Details:\n", style="cyan")
+    content.append(f"  Component ID: {component_id}\n\n")
+    content.append("Possible solutions:\n", style="cyan")
+    content.append("  1. Verify your COMPONENT_ID matches the one in your sbomify dashboard\n")
+    content.append("  2. Check that the component exists in your sbomify account\n")
+    content.append("  3. Create the component in the sbomify dashboard if it doesn't exist\n")
+    content.append("  4. Ensure your API token has access to this component\n")
+
+    panel = Panel(content, title="[bold red]Component Not Found[/bold red]", border_style="red")
+    console.print(panel)
+
+    # Also emit GHA error annotation
+    gha_error(
+        f"Component '{component_id}' not found. Verify the COMPONENT_ID is correct.",
+        title="Component Not Found",
+    )
+
+
 def print_final_success() -> None:
     """Print final success message."""
     console.print()


### PR DESCRIPTION
When uploading an SBOM to a non-existent component, users now see a helpful error panel with actionable suggestions instead of a generic 404 error message. This follows the same pattern used for duplicate SBOM errors.

Changes:
- Add COMPONENT_NOT_FOUND error code handling in sbomify upload
- Add print_component_not_found_error() console helper with suggestions
- Add GitHub Actions error annotation for better CI visibility
- Add unit tests for 404 error handling (with and without JSON body)

