### PR TITLE
Add helpful error when file path looks like CLI flag

### DIFF
--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -714,8 +714,16 @@ def path_expansion(path: str) -> str:
         Absolute path string
 
     Raises:
-        FileProcessingError: If file is not found
+        FileProcessingError: If file is not found or path looks like a CLI flag
     """
+    # Check if the path looks like a CLI flag (common mistake when forgetting to provide a value)
+    if path.startswith("-"):
+        raise FileProcessingError(
+            f"Invalid file path '{path}' - this looks like a CLI flag. "
+            f"Did you forget to specify a file path? "
+            f"Example: --lock-file requirements.txt or set the LOCK_FILE environment variable."
+        )
+
     current_dir = Path.cwd()
     relative_path = current_dir / path
     workspace_relative_path = Path("/github/workspace") / path

--- a/tests/test_path_expansion.py
+++ b/tests/test_path_expansion.py
@@ -154,6 +154,26 @@ class TestPathExpansionEdgeCases(unittest.TestCase):
             # Should resolve to the symlink path (Path.is_file() returns True for symlinks)
             self.assertTrue(Path(result).is_file())
 
+    def test_path_looks_like_cli_flag_raises_helpful_error(self):
+        """Test that a path starting with '-' raises a helpful error message."""
+        with self.assertRaises(FileProcessingError) as context:
+            path_expansion("--no-augment")
+
+        error_message = str(context.exception)
+        self.assertIn("--no-augment", error_message)
+        self.assertIn("looks like a CLI flag", error_message)
+        self.assertIn("Did you forget to specify a file path?", error_message)
+        self.assertIn("LOCK_FILE environment variable", error_message)
+
+    def test_path_looks_like_short_cli_flag_raises_helpful_error(self):
+        """Test that a path starting with single '-' raises a helpful error message."""
+        with self.assertRaises(FileProcessingError) as context:
+            path_expansion("-v")
+
+        error_message = str(context.exception)
+        self.assertIn("-v", error_message)
+        self.assertIn("looks like a CLI flag", error_message)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When users forget to provide a file path after --lock-file, the next argument gets consumed as the path value. This adds early detection for paths starting with '-' and provides a clear error message with usage examples.
