### PR TITLE
fix: move compound SPDX expressions from license.id to expression field

### DIFF
--- a/sbomify_action/serialization.py
+++ b/sbomify_action/serialization.py
@@ -12,6 +12,7 @@ import warnings
 from typing import TYPE_CHECKING, Any, Optional
 
 from cyclonedx.model.bom import Bom
+from license_expression import ExpressionError, get_spdx_licensing
 
 if TYPE_CHECKING:
     from cyclonedx.model.component import Component
@@ -20,6 +21,17 @@ from spdx_tools.spdx.model import Document  # type: ignore[attr-defined]
 
 from .console import get_transformation_tracker
 from .logging_config import logger
+
+_spdx_licensing_instance: Any = None
+
+
+def _spdx_licensing_singleton() -> Any:
+    """Return a cached SPDX licensing instance (singleton)."""
+    global _spdx_licensing_instance  # noqa: PLW0603
+    if _spdx_licensing_instance is None:
+        _spdx_licensing_instance = get_spdx_licensing()
+    return _spdx_licensing_instance
+
 
 # ============================================================================
 # CycloneDX Version Management
@@ -900,20 +912,21 @@ def get_supported_spdx_versions() -> list[str]:
 
 
 def _is_compound_expression(license_str: str) -> bool:
-    """Check if a license string is a compound SPDX expression (contains OR/AND).
+    """Check if a license string is a compound SPDX expression (OR/AND/WITH).
 
-    Uses the license-expression library to parse and count symbols, which
-    correctly handles WITH clauses (not compound) vs OR/AND (compound).
+    Uses the license-expression library to parse and count symbols. Returns True
+    if it contains OR or AND operators (more than one symbol). WITH clauses
+    (e.g. ``Apache-2.0 WITH LLVM-exception``) are a single license+exception
+    and are NOT compound — they can stay in ``license.id``.
+
+    The licensing singleton is cached at module level for performance.
     """
     try:
-        from license_expression import ExpressionError, get_spdx_licensing
-
-        licensing = get_spdx_licensing()
-        parsed = licensing.parse(license_str, validate=False)
+        parsed = _spdx_licensing_singleton().parse(license_str, validate=False)
         return len(parsed.symbols) > 1
-    except (ExpressionError, Exception):
-        # Fallback to string check if parsing fails
-        return " OR " in license_str or " AND " in license_str
+    except (ExpressionError, ImportError):
+        # Fallback to regex check if parsing fails or library is unavailable
+        return bool(re.search(r"\b(?:AND|OR)\b", license_str))
 
 
 def _is_valid_spdx_license_id(license_id: str) -> bool:
@@ -970,9 +983,8 @@ def sanitize_cyclonedx_licenses(data: dict[str, Any]) -> int:
                     # Compound expressions (containing OR/AND) belong in expression, not id
                     if _is_compound_expression(license_id):
                         logger.debug(f"Moving compound expression from license.id to expression: {license_id}")
-                        del license_obj["id"]
                         # Remove the license wrapper — expression is a peer of license, not nested
-                        choice.pop("license")
+                        choice.pop("license", None)
                         choice["expression"] = license_id
                         tracker.record_license_sanitized(license_id, f"expression:{license_id}", component=component)
                         count += 1
@@ -1016,7 +1028,7 @@ def sanitize_cyclonedx_licenses(data: dict[str, Any]) -> int:
             sanitized_count += _sanitize_license_choices(service["licenses"], component=svc_name)
 
     if sanitized_count > 0:
-        logger.info(f"Sanitized {sanitized_count} invalid license ID(s) to license name(s)")
+        logger.info(f"Sanitized {sanitized_count} license issue(s) (invalid IDs and/or compound expressions)")
 
     return sanitized_count
 

--- a/sbomify_action/serialization.py
+++ b/sbomify_action/serialization.py
@@ -916,6 +916,9 @@ def _is_compound_expression(license_str: str) -> bool:
     single IDs return False. Unparseable strings return False — they'll
     be caught by _is_valid_spdx_license_id and moved to license.name.
     """
+    if not license_str or len(license_str) > 1024:
+        return False
+
     from license_expression import AND, OR
 
     try:
@@ -948,12 +951,14 @@ def sanitize_cyclonedx_licenses(data: dict[str, Any]) -> int:
     """
     Sanitize CycloneDX license data by fixing invalid license IDs and expressions.
 
-    This handles two cases:
-    1. Invalid license.id values: moved to license.name field
-    2. Invalid expression values: invalid IDs replaced with LicenseRef-* format
+    This handles three cases:
+    1. Compound expressions in license.id (OR/AND): moved to expression field
+    2. Invalid license.id values: moved to license.name field
+    3. Invalid expression values: invalid IDs replaced with LicenseRef-* format
 
-    Some SBOM generators incorrectly put non-SPDX license strings in the
-    license.id field, which causes schema validation failures.
+    Some SBOM generators incorrectly put compound SPDX expressions or
+    non-SPDX license strings in the license.id field, which causes
+    schema validation failures.
 
     Args:
         data: CycloneDX SBOM data as a dict (modified in place)
@@ -983,15 +988,19 @@ def sanitize_cyclonedx_licenses(data: dict[str, Any]) -> int:
                         choice.pop("license", None)
                         if not existing_expr:
                             choice["expression"] = license_id
-                            logger.debug(f"Moving compound expression from license.id to expression: {license_id}")
+                            logger.debug("Moving compound expression from license.id to expression: %r", license_id)
                             tracker.record_license_sanitized(
                                 license_id, f"expression:{license_id}", component=component
                             )
                         else:
-                            logger.debug(
-                                f"Removed compound license.id={license_id}, kept existing expression={existing_expr}"
+                            logger.warning(
+                                "Both license.id=%r (compound) and expression=%r present "
+                                "in same licenseChoice — discarding license.id",
+                                license_id,
+                                existing_expr,
                             )
                         count += 1
+                        continue  # skip expression sanitization for this choice
                     elif not _is_valid_spdx_license_id(license_id):
                         # Move invalid id to name
                         logger.debug(f"Sanitizing invalid license ID: {license_id} -> name")

--- a/sbomify_action/serialization.py
+++ b/sbomify_action/serialization.py
@@ -148,7 +148,7 @@ def _extract_component_info_from_purl(
 # Regex patterns for PURL encoding bug fixes
 # These fix common encoding issues from various SBOM generators
 _DOUBLE_ENCODED_AT_PATTERN = re.compile(r"(%40){2,}")  # %40%40... → %40
-_DOUBLE_AT_PATTERN = re.compile(r"@@+")  # @@... → @
+_DOUBLE_AT_PATTERN = re.compile(r"@@+")  # @@... → @  (used inside re.sub callback)
 
 # Package types that require a version in the PURL
 # These ecosystems always have versioned packages in standard usage
@@ -907,22 +907,23 @@ def get_supported_spdx_versions() -> list[str]:
 # License Sanitization
 # ============================================================================
 
-_COMPOUND_OPERATOR_RE = re.compile(r"\b(?:AND|OR)\b")
-
 
 def _is_compound_expression(license_str: str) -> bool:
     """Check if a license string is a compound SPDX expression using AND/OR.
 
-    Uses the license-expression library to confirm the string parses as an SPDX
-    expression, then checks for explicit boolean operators. WITH clauses
-    (e.g. ``Apache-2.0 WITH LLVM-exception``) are a single license+exception
-    and are NOT compound — they can stay in ``license.id``.
+    Uses the license-expression library's parsed AST to detect compound
+    expressions. The parsed object's type is ``OR`` or ``AND`` for compound
+    expressions, ``LicenseSymbol`` for single IDs, and
+    ``LicenseWithExceptionSymbol`` for WITH clauses — no regex needed.
     """
+    from license_expression import AND, OR
+
     try:
-        _spdx_licensing_singleton().parse(license_str, validate=False)
+        parsed = _spdx_licensing_singleton().parse(license_str, validate=False)
+        return isinstance(parsed, (OR, AND))
     except ExpressionError:
-        pass  # Unparseable — still check regex below
-    return bool(_COMPOUND_OPERATOR_RE.search(license_str))
+        # Unparseable — fall back to simple string check
+        return " OR " in license_str or " AND " in license_str
 
 
 def _is_valid_spdx_license_id(license_id: str) -> bool:
@@ -1043,8 +1044,12 @@ _MAX_LICENSE_REF_LENGTH = 76
 
 def _to_license_ref(key: str) -> str:
     """Convert an arbitrary string to a valid LicenseRef-* identifier."""
-    sanitized_id = re.sub(r"[^a-zA-Z0-9.\-]", "-", key)
-    sanitized_id = re.sub(r"-+", "-", sanitized_id).strip("-")
+    _ALLOWED = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-")
+    sanitized_id = "".join(c if c in _ALLOWED else "-" for c in key)
+    # Collapse consecutive dashes
+    while "--" in sanitized_id:
+        sanitized_id = sanitized_id.replace("--", "-")
+    sanitized_id = sanitized_id.strip("-")
     if sanitized_id:
         return f"LicenseRef-{sanitized_id}"
     return "LicenseRef-unknown"

--- a/sbomify_action/serialization.py
+++ b/sbomify_action/serialization.py
@@ -977,11 +977,19 @@ def sanitize_cyclonedx_licenses(data: dict[str, Any]) -> int:
                 if license_id:
                     # Compound expressions (containing OR/AND) belong in expression, not id
                     if _is_compound_expression(license_id):
-                        logger.debug(f"Moving compound expression from license.id to expression: {license_id}")
                         # Remove the license wrapper — expression is a peer of license, not nested
+                        existing_expr = choice.get("expression")
                         choice.pop("license", None)
-                        choice["expression"] = license_id
-                        tracker.record_license_sanitized(license_id, f"expression:{license_id}", component=component)
+                        if not existing_expr:
+                            choice["expression"] = license_id
+                            logger.debug(f"Moving compound expression from license.id to expression: {license_id}")
+                            tracker.record_license_sanitized(
+                                license_id, f"expression:{license_id}", component=component
+                            )
+                        else:
+                            logger.debug(
+                                f"Removed compound license.id={license_id}, kept existing expression={existing_expr}"
+                            )
                         count += 1
                     elif not _is_valid_spdx_license_id(license_id):
                         # Move invalid id to name

--- a/sbomify_action/serialization.py
+++ b/sbomify_action/serialization.py
@@ -1066,6 +1066,7 @@ def sanitize_cyclonedx_licenses(data: dict[str, Any]) -> int:
     metadata = data.get("metadata", {})
     if "licenses" in metadata:
         sanitized_count += _sanitize_license_choices(metadata["licenses"], component="metadata")
+        sanitized_count += _consolidate_mixed_license_types(metadata["licenses"], component="metadata")
 
     # Process component licenses
     components = data.get("components", [])

--- a/sbomify_action/serialization.py
+++ b/sbomify_action/serialization.py
@@ -899,6 +899,23 @@ def get_supported_spdx_versions() -> list[str]:
 # ============================================================================
 
 
+def _is_compound_expression(license_str: str) -> bool:
+    """Check if a license string is a compound SPDX expression (contains OR/AND).
+
+    Uses the license-expression library to parse and count symbols, which
+    correctly handles WITH clauses (not compound) vs OR/AND (compound).
+    """
+    try:
+        from license_expression import ExpressionError, get_spdx_licensing
+
+        licensing = get_spdx_licensing()
+        parsed = licensing.parse(license_str, validate=False)
+        return len(parsed.symbols) > 1
+    except (ExpressionError, Exception):
+        # Fallback to string check if parsing fails
+        return " OR " in license_str or " AND " in license_str
+
+
 def _is_valid_spdx_license_id(license_id: str) -> bool:
     """
     Check if a string is a valid SPDX license ID using the license-expression library.
@@ -951,7 +968,7 @@ def sanitize_cyclonedx_licenses(data: dict[str, Any]) -> int:
                 license_id = license_obj.get("id")
                 if license_id:
                     # Compound expressions (containing OR/AND) belong in expression, not id
-                    if " OR " in license_id or " AND " in license_id:
+                    if _is_compound_expression(license_id):
                         logger.debug(f"Moving compound expression from license.id to expression: {license_id}")
                         del license_obj["id"]
                         # Remove the license wrapper — expression is a peer of license, not nested

--- a/sbomify_action/serialization.py
+++ b/sbomify_action/serialization.py
@@ -907,6 +907,8 @@ def get_supported_spdx_versions() -> list[str]:
 # License Sanitization
 # ============================================================================
 
+_COMPOUND_OPERATOR_RE = re.compile(r"\b(?:AND|OR)\b")
+
 
 def _is_compound_expression(license_str: str) -> bool:
     """Check if a license string is a compound SPDX expression using AND/OR.
@@ -918,10 +920,9 @@ def _is_compound_expression(license_str: str) -> bool:
     """
     try:
         _spdx_licensing_singleton().parse(license_str, validate=False)
-        return bool(re.search(r"\b(?:AND|OR)\b", license_str))
     except ExpressionError:
-        # Unparseable — fall back to regex only
-        return bool(re.search(r"\b(?:AND|OR)\b", license_str))
+        pass  # Unparseable — still check regex below
+    return bool(_COMPOUND_OPERATOR_RE.search(license_str))
 
 
 def _is_valid_spdx_license_id(license_id: str) -> bool:

--- a/sbomify_action/serialization.py
+++ b/sbomify_action/serialization.py
@@ -907,22 +907,22 @@ def get_supported_spdx_versions() -> list[str]:
 # License Sanitization
 # ============================================================================
 
-_COMPOUND_OPERATOR_RE = re.compile(r"\b(?:AND|OR)\b")
-
 
 def _is_compound_expression(license_str: str) -> bool:
-    """Check if a license string is a compound SPDX expression using AND/OR.
+    """Check if a license string is a compound SPDX expression (OR/AND).
 
-    Uses the license-expression library to confirm the string parses as an SPDX
-    expression, then checks for explicit boolean operators. WITH clauses
-    (e.g. ``Apache-2.0 WITH LLVM-exception``) are a single license+exception
-    and are NOT compound — they can stay in ``license.id``.
+    Uses the license-expression library's parsed AST to detect compound
+    expressions. Returns True only for OR/AND nodes. WITH clauses and
+    single IDs return False. Unparseable strings return False — they'll
+    be caught by _is_valid_spdx_license_id and moved to license.name.
     """
+    from license_expression import AND, OR
+
     try:
-        _spdx_licensing_singleton().parse(license_str, validate=False)
+        parsed = _spdx_licensing_singleton().parse(license_str, validate=False)
+        return isinstance(parsed, (OR, AND))
     except ExpressionError:
-        pass  # Unparseable — still check regex below
-    return bool(_COMPOUND_OPERATOR_RE.search(license_str))
+        return False
 
 
 def _is_valid_spdx_license_id(license_id: str) -> bool:

--- a/sbomify_action/serialization.py
+++ b/sbomify_action/serialization.py
@@ -949,13 +949,23 @@ def sanitize_cyclonedx_licenses(data: dict[str, Any]) -> int:
             license_obj = choice.get("license")
             if isinstance(license_obj, dict):
                 license_id = license_obj.get("id")
-                if license_id and not _is_valid_spdx_license_id(license_id):
-                    # Move id to name
-                    logger.debug(f"Sanitizing invalid license ID: {license_id} -> name")
-                    del license_obj["id"]
-                    license_obj["name"] = license_id
-                    tracker.record_license_sanitized(license_id, f"name:{license_id}", component=component)
-                    count += 1
+                if license_id:
+                    # Compound expressions (containing OR/AND) belong in expression, not id
+                    if " OR " in license_id or " AND " in license_id:
+                        logger.debug(f"Moving compound expression from license.id to expression: {license_id}")
+                        del license_obj["id"]
+                        # Remove the license wrapper — expression is a peer of license, not nested
+                        choice.pop("license")
+                        choice["expression"] = license_id
+                        tracker.record_license_sanitized(license_id, f"expression:{license_id}", component=component)
+                        count += 1
+                    elif not _is_valid_spdx_license_id(license_id):
+                        # Move invalid id to name
+                        logger.debug(f"Sanitizing invalid license ID: {license_id} -> name")
+                        del license_obj["id"]
+                        license_obj["name"] = license_id
+                        tracker.record_license_sanitized(license_id, f"name:{license_id}", component=component)
+                        count += 1
 
             # Handle expression field
             expression = choice.get("expression")

--- a/sbomify_action/serialization.py
+++ b/sbomify_action/serialization.py
@@ -148,7 +148,7 @@ def _extract_component_info_from_purl(
 # Regex patterns for PURL encoding bug fixes
 # These fix common encoding issues from various SBOM generators
 _DOUBLE_ENCODED_AT_PATTERN = re.compile(r"(%40){2,}")  # %40%40... → %40
-_DOUBLE_AT_PATTERN = re.compile(r"@@+")  # @@... → @  (used inside re.sub callback)
+_DOUBLE_AT_PATTERN = re.compile(r"@@+")  # @@... → @
 
 # Package types that require a version in the PURL
 # These ecosystems always have versioned packages in standard usage
@@ -907,23 +907,22 @@ def get_supported_spdx_versions() -> list[str]:
 # License Sanitization
 # ============================================================================
 
+_COMPOUND_OPERATOR_RE = re.compile(r"\b(?:AND|OR)\b")
+
 
 def _is_compound_expression(license_str: str) -> bool:
     """Check if a license string is a compound SPDX expression using AND/OR.
 
-    Uses the license-expression library's parsed AST to detect compound
-    expressions. The parsed object's type is ``OR`` or ``AND`` for compound
-    expressions, ``LicenseSymbol`` for single IDs, and
-    ``LicenseWithExceptionSymbol`` for WITH clauses — no regex needed.
+    Uses the license-expression library to confirm the string parses as an SPDX
+    expression, then checks for explicit boolean operators. WITH clauses
+    (e.g. ``Apache-2.0 WITH LLVM-exception``) are a single license+exception
+    and are NOT compound — they can stay in ``license.id``.
     """
-    from license_expression import AND, OR
-
     try:
-        parsed = _spdx_licensing_singleton().parse(license_str, validate=False)
-        return isinstance(parsed, (OR, AND))
+        _spdx_licensing_singleton().parse(license_str, validate=False)
     except ExpressionError:
-        # Unparseable — fall back to simple string check
-        return " OR " in license_str or " AND " in license_str
+        pass  # Unparseable — still check regex below
+    return bool(_COMPOUND_OPERATOR_RE.search(license_str))
 
 
 def _is_valid_spdx_license_id(license_id: str) -> bool:
@@ -1044,12 +1043,8 @@ _MAX_LICENSE_REF_LENGTH = 76
 
 def _to_license_ref(key: str) -> str:
     """Convert an arbitrary string to a valid LicenseRef-* identifier."""
-    _ALLOWED = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-")
-    sanitized_id = "".join(c if c in _ALLOWED else "-" for c in key)
-    # Collapse consecutive dashes
-    while "--" in sanitized_id:
-        sanitized_id = sanitized_id.replace("--", "-")
-    sanitized_id = sanitized_id.strip("-")
+    sanitized_id = re.sub(r"[^a-zA-Z0-9.\-]", "-", key)
+    sanitized_id = re.sub(r"-+", "-", sanitized_id).strip("-")
     if sanitized_id:
         return f"LicenseRef-{sanitized_id}"
     return "LicenseRef-unknown"

--- a/sbomify_action/serialization.py
+++ b/sbomify_action/serialization.py
@@ -909,21 +909,24 @@ def get_supported_spdx_versions() -> list[str]:
 
 
 def _is_compound_expression(license_str: str) -> bool:
-    """Check if a license string is a compound SPDX expression (OR/AND).
+    """Check if a license string is an SPDX expression (not a bare license ID).
 
-    Uses the license-expression library's parsed AST to detect compound
-    expressions. Returns True only for OR/AND nodes. WITH clauses and
-    single IDs return False. Unparseable strings return False — they'll
-    be caught by _is_valid_spdx_license_id and moved to license.name.
+    Uses the license-expression library's parsed AST. Returns True for any
+    expression that is not a single license identifier — including OR, AND,
+    and WITH clauses. CycloneDX license.id only accepts bare SPDX IDs;
+    anything else belongs in the expression field.
+
+    Unparseable strings return False — they'll be caught by
+    _is_valid_spdx_license_id and moved to license.name.
     """
     if not license_str or len(license_str) > 1024:
         return False
 
-    from license_expression import AND, OR
+    from license_expression import AND, OR, LicenseWithExceptionSymbol
 
     try:
         parsed = _spdx_licensing_singleton().parse(license_str, validate=False)
-        return isinstance(parsed, (OR, AND))
+        return isinstance(parsed, (OR, AND, LicenseWithExceptionSymbol))
     except ExpressionError:
         return False
 
@@ -968,6 +971,44 @@ def sanitize_cyclonedx_licenses(data: dict[str, Any]) -> int:
     """
     sanitized_count = 0
     tracker = get_transformation_tracker()
+
+    def _consolidate_mixed_license_types(license_choices: list[Any], component: str | None = None) -> int:
+        """Consolidate mixed license/expression entries into a single expression.
+
+        cyclonedx-python-lib cannot serialize a component that has both
+        LicenseExpression and DisjunctiveLicense objects. When sanitization
+        produces a mix, consolidate all entries into one OR expression.
+        """
+        has_expression = any("expression" in c for c in license_choices if isinstance(c, dict))
+        has_license = any("license" in c for c in license_choices if isinstance(c, dict))
+        if not (has_expression and has_license):
+            return 0
+
+        # Collect all license identifiers and expressions
+        parts: list[str] = []
+        for choice in license_choices:
+            if not isinstance(choice, dict):
+                continue
+            if "expression" in choice:
+                parts.append(choice["expression"])
+            elif "license" in choice:
+                lic = choice["license"]
+                if isinstance(lic, dict):
+                    parts.append(lic.get("id") or lic.get("name", "NOASSERTION"))
+
+        if not parts:
+            return 0
+
+        # Replace all entries with a single expression
+        combined = " OR ".join(parts)
+        license_choices.clear()
+        license_choices.append({"expression": combined})
+        logger.debug(
+            "Consolidated mixed license/expression entries into single expression for %s: %r",
+            component or "unknown",
+            combined,
+        )
+        return 1
 
     def _sanitize_license_choices(license_choices: list[Any], component: str | None = None) -> int:
         """Process a list of licenseChoice objects."""
@@ -1032,6 +1073,7 @@ def sanitize_cyclonedx_licenses(data: dict[str, Any]) -> int:
         comp_name = component.get("name")
         if "licenses" in component:
             sanitized_count += _sanitize_license_choices(component["licenses"], component=comp_name)
+            sanitized_count += _consolidate_mixed_license_types(component["licenses"], component=comp_name)
 
     # Process service licenses (if present)
     services = data.get("services", [])
@@ -1039,6 +1081,7 @@ def sanitize_cyclonedx_licenses(data: dict[str, Any]) -> int:
         svc_name = service.get("name")
         if "licenses" in service:
             sanitized_count += _sanitize_license_choices(service["licenses"], component=svc_name)
+            sanitized_count += _consolidate_mixed_license_types(service["licenses"], component=svc_name)
 
     if sanitized_count > 0:
         logger.info(f"Sanitized {sanitized_count} license issue(s) (invalid IDs and/or compound expressions)")

--- a/sbomify_action/serialization.py
+++ b/sbomify_action/serialization.py
@@ -5,6 +5,7 @@ This module provides centralized serialization functions for both CycloneDX and 
 formats, supporting multiple versions and making it easy to add new versions in the future.
 """
 
+import functools
 import hashlib
 import json
 import re
@@ -22,15 +23,11 @@ from spdx_tools.spdx.model import Document  # type: ignore[attr-defined]
 from .console import get_transformation_tracker
 from .logging_config import logger
 
-_spdx_licensing_instance: Any = None
 
-
+@functools.lru_cache(maxsize=1)
 def _spdx_licensing_singleton() -> Any:
     """Return a cached SPDX licensing instance (singleton)."""
-    global _spdx_licensing_instance  # noqa: PLW0603
-    if _spdx_licensing_instance is None:
-        _spdx_licensing_instance = get_spdx_licensing()
-    return _spdx_licensing_instance
+    return get_spdx_licensing()
 
 
 # ============================================================================
@@ -912,20 +909,18 @@ def get_supported_spdx_versions() -> list[str]:
 
 
 def _is_compound_expression(license_str: str) -> bool:
-    """Check if a license string is a compound SPDX expression (OR/AND/WITH).
+    """Check if a license string is a compound SPDX expression using AND/OR.
 
-    Uses the license-expression library to parse and count symbols. Returns True
-    if it contains OR or AND operators (more than one symbol). WITH clauses
+    Uses the license-expression library to confirm the string parses as an SPDX
+    expression, then checks for explicit boolean operators. WITH clauses
     (e.g. ``Apache-2.0 WITH LLVM-exception``) are a single license+exception
     and are NOT compound — they can stay in ``license.id``.
-
-    The licensing singleton is cached at module level for performance.
     """
     try:
-        parsed = _spdx_licensing_singleton().parse(license_str, validate=False)
-        return len(parsed.symbols) > 1
-    except (ExpressionError, ImportError):
-        # Fallback to regex check if parsing fails or library is unavailable
+        _spdx_licensing_singleton().parse(license_str, validate=False)
+        return bool(re.search(r"\b(?:AND|OR)\b", license_str))
+    except ExpressionError:
+        # Unparseable — fall back to regex only
         return bool(re.search(r"\b(?:AND|OR)\b", license_str))
 
 

--- a/sbomify_action/serialization.py
+++ b/sbomify_action/serialization.py
@@ -13,7 +13,7 @@ import warnings
 from typing import TYPE_CHECKING, Any, Optional
 
 from cyclonedx.model.bom import Bom
-from license_expression import ExpressionError, get_spdx_licensing
+from license_expression import ExpressionError, Licensing, get_spdx_licensing
 
 if TYPE_CHECKING:
     from cyclonedx.model.component import Component
@@ -25,7 +25,7 @@ from .logging_config import logger
 
 
 @functools.lru_cache(maxsize=1)
-def _spdx_licensing_singleton() -> Any:
+def _spdx_licensing_singleton() -> Licensing:
     """Return a cached SPDX licensing instance (singleton)."""
     return get_spdx_licensing()
 
@@ -922,6 +922,10 @@ def _is_compound_expression(license_str: str) -> bool:
     if not license_str or len(license_str) > 1024:
         return False
 
+    # Cheap pre-check: skip parser for simple IDs without operators
+    if " OR " not in license_str and " AND " not in license_str and " WITH " not in license_str:
+        return False
+
     from license_expression import AND, OR, LicenseWithExceptionSymbol
 
     try:
@@ -989,12 +993,16 @@ def sanitize_cyclonedx_licenses(data: dict[str, Any]) -> int:
         for choice in license_choices:
             if not isinstance(choice, dict):
                 continue
-            if "expression" in choice:
-                parts.append(choice["expression"])
+            expr = choice.get("expression")
+            if isinstance(expr, str) and expr:
+                # Wrap in parens if it contains AND to preserve precedence in OR join
+                parts.append(f"({expr})" if " AND " in expr else expr)
             elif "license" in choice:
                 lic = choice["license"]
                 if isinstance(lic, dict):
-                    parts.append(lic.get("id") or lic.get("name", "NOASSERTION"))
+                    part = lic.get("id") or lic.get("name")
+                    if isinstance(part, str) and part:
+                        parts.append(part)
 
         if not parts:
             return 0
@@ -1041,7 +1049,7 @@ def sanitize_cyclonedx_licenses(data: dict[str, Any]) -> int:
                                 existing_expr,
                             )
                         count += 1
-                        continue  # skip expression sanitization for this choice
+                        # Fall through to expression sanitization below
                     elif not _is_valid_spdx_license_id(license_id):
                         # Move invalid id to name
                         logger.debug(f"Sanitizing invalid license ID: {license_id} -> name")

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -2082,8 +2082,8 @@ class TestSanitizeCycloneDXLicenses:
         assert count == 0
         assert data["components"][0]["licenses"][0]["license"]["id"] == "MIT"
 
-    def test_with_clause_not_treated_as_compound(self):
-        """A WITH clause is not compound — should stay in license.id."""
+    def test_with_clause_stays_in_license_id(self):
+        """A WITH clause is a single license+exception, not compound — stays in license.id."""
         data = {
             "components": [
                 {
@@ -2092,8 +2092,8 @@ class TestSanitizeCycloneDXLicenses:
                 }
             ]
         }
-        sanitize_cyclonedx_licenses(data)
-        # WITH is a single license, not compound — should not be moved
+        count = sanitize_cyclonedx_licenses(data)
+        assert count == 0
         assert data["components"][0]["licenses"][0]["license"]["id"] == "Apache-2.0 WITH LLVM-exception"
 
     def test_invalid_license_id_moved_to_name(self):
@@ -2138,3 +2138,18 @@ class TestSanitizeCycloneDXLicenses:
         assert count == 1
         assert data["components"][0]["licenses"][0]["expression"] == "GPL-2.0-only OR GPL-2.0-or-later OR MPL-2.0"
         assert "license" not in data["components"][0]["licenses"][0]
+
+    def test_services_licenses_also_sanitized(self):
+        """Compound expressions in services[*].licenses should also be fixed."""
+        data = {
+            "components": [],
+            "services": [
+                {
+                    "name": "my-service",
+                    "licenses": [{"license": {"id": "MIT OR Apache-2.0"}}],
+                }
+            ],
+        }
+        count = sanitize_cyclonedx_licenses(data)
+        assert count == 1
+        assert data["services"][0]["licenses"][0]["expression"] == "MIT OR Apache-2.0"

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -2082,8 +2082,8 @@ class TestSanitizeCycloneDXLicenses:
         assert count == 0
         assert data["components"][0]["licenses"][0]["license"]["id"] == "MIT"
 
-    def test_with_clause_stays_in_license_id(self):
-        """A WITH clause is a single license+exception, not compound — stays in license.id."""
+    def test_with_clause_moved_to_expression(self):
+        """A WITH clause is an expression, not a bare ID — should move to expression."""
         data = {
             "components": [
                 {
@@ -2093,8 +2093,9 @@ class TestSanitizeCycloneDXLicenses:
             ]
         }
         count = sanitize_cyclonedx_licenses(data)
-        assert count == 0
-        assert data["components"][0]["licenses"][0]["license"]["id"] == "Apache-2.0 WITH LLVM-exception"
+        assert count == 1
+        assert data["components"][0]["licenses"][0]["expression"] == "Apache-2.0 WITH LLVM-exception"
+        assert "license" not in data["components"][0]["licenses"][0]
 
     def test_invalid_license_id_moved_to_name(self):
         """An invalid (non-SPDX) license ID should move to license.name."""

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -17,6 +17,7 @@ from sbomify_action.serialization import (
     link_root_dependencies,
     normalize_purl,
     restore_spdx_document_describes,
+    sanitize_cyclonedx_licenses,
     sanitize_dependency_graph,
     sanitize_purls,
     sanitize_spdx_json_file,
@@ -2031,3 +2032,109 @@ class TestAddCompositionsIfMissing:
         from sbomify_action.serialization import _add_compositions_if_missing
 
         assert _add_compositions_if_missing("not json") == "not json"
+
+
+class TestSanitizeCycloneDXLicenses:
+    """Tests for sanitize_cyclonedx_licenses — compound expression handling."""
+
+    def test_compound_or_expression_moved_from_id_to_expression(self):
+        """A compound OR expression in license.id should move to expression field."""
+        data = {
+            "components": [
+                {
+                    "name": "certifi",
+                    "licenses": [{"license": {"id": "GPL-2.0-only OR MPL-2.0"}}],
+                }
+            ]
+        }
+        count = sanitize_cyclonedx_licenses(data)
+        assert count == 1
+        licenses = data["components"][0]["licenses"]
+        assert len(licenses) == 1
+        assert "license" not in licenses[0]
+        assert licenses[0]["expression"] == "GPL-2.0-only OR MPL-2.0"
+
+    def test_compound_and_expression_moved_from_id_to_expression(self):
+        """A compound AND expression in license.id should move to expression field."""
+        data = {
+            "components": [
+                {
+                    "name": "pkg",
+                    "licenses": [{"license": {"id": "MIT AND Apache-2.0"}}],
+                }
+            ]
+        }
+        count = sanitize_cyclonedx_licenses(data)
+        assert count == 1
+        assert data["components"][0]["licenses"][0]["expression"] == "MIT AND Apache-2.0"
+
+    def test_single_license_id_not_moved(self):
+        """A single valid SPDX ID should stay in license.id."""
+        data = {
+            "components": [
+                {
+                    "name": "pkg",
+                    "licenses": [{"license": {"id": "MIT"}}],
+                }
+            ]
+        }
+        count = sanitize_cyclonedx_licenses(data)
+        assert count == 0
+        assert data["components"][0]["licenses"][0]["license"]["id"] == "MIT"
+
+    def test_with_clause_not_treated_as_compound(self):
+        """A WITH clause is not compound — should stay in license.id."""
+        data = {
+            "components": [
+                {
+                    "name": "pkg",
+                    "licenses": [{"license": {"id": "Apache-2.0 WITH LLVM-exception"}}],
+                }
+            ]
+        }
+        sanitize_cyclonedx_licenses(data)
+        # WITH is a single license, not compound — should not be moved
+        assert data["components"][0]["licenses"][0]["license"]["id"] == "Apache-2.0 WITH LLVM-exception"
+
+    def test_invalid_license_id_moved_to_name(self):
+        """An invalid (non-SPDX) license ID should move to license.name."""
+        data = {
+            "components": [
+                {
+                    "name": "pkg",
+                    "licenses": [{"license": {"id": "Some Custom License"}}],
+                }
+            ]
+        }
+        count = sanitize_cyclonedx_licenses(data)
+        assert count == 1
+        license_obj = data["components"][0]["licenses"][0]["license"]
+        assert "id" not in license_obj
+        assert license_obj["name"] == "Some Custom License"
+
+    def test_metadata_licenses_also_sanitized(self):
+        """Compound expressions in metadata.licenses should also be fixed."""
+        data = {
+            "metadata": {
+                "licenses": [{"license": {"id": "GPL-2.0-only OR MIT"}}],
+            },
+            "components": [],
+        }
+        count = sanitize_cyclonedx_licenses(data)
+        assert count == 1
+        assert data["metadata"]["licenses"][0]["expression"] == "GPL-2.0-only OR MIT"
+
+    def test_three_way_or_expression(self):
+        """Real-world case from issue #211: certifi with three-way OR."""
+        data = {
+            "components": [
+                {
+                    "name": "certifi",
+                    "licenses": [{"license": {"id": "GPL-2.0-only OR GPL-2.0-or-later OR MPL-2.0"}}],
+                }
+            ]
+        }
+        count = sanitize_cyclonedx_licenses(data)
+        assert count == 1
+        assert data["components"][0]["licenses"][0]["expression"] == "GPL-2.0-only OR GPL-2.0-or-later OR MPL-2.0"
+        assert "license" not in data["components"][0]["licenses"][0]

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -2175,3 +2175,125 @@ class TestSanitizeCycloneDXLicenses:
         # Existing expression is preserved, compound license.id is discarded
         assert data["components"][0]["licenses"][0]["expression"] == "MIT"
         assert "license" not in data["components"][0]["licenses"][0]
+
+    def test_mixed_metadata_licenses_consolidated(self):
+        """Mixed license/expression in metadata.licenses should be consolidated."""
+        data = {
+            "metadata": {
+                "licenses": [
+                    {"license": {"id": "MIT"}},
+                    {"license": {"id": "GPL-2.0-only OR Apache-2.0"}},
+                ],
+            },
+            "components": [],
+        }
+        count = sanitize_cyclonedx_licenses(data)
+        assert count >= 2
+        licenses = data["metadata"]["licenses"]
+        assert len(licenses) == 1
+        assert "expression" in licenses[0]
+        assert "MIT" in licenses[0]["expression"]
+        assert "GPL-2.0-only" in licenses[0]["expression"]
+
+    def test_nested_compound_with_parentheses(self):
+        """Nested compound like (MIT OR BSD) AND Apache should move to expression."""
+        data = {
+            "components": [
+                {
+                    "name": "pkg",
+                    "licenses": [{"license": {"id": "(MIT OR BSD-2-Clause) AND Apache-2.0"}}],
+                }
+            ]
+        }
+        count = sanitize_cyclonedx_licenses(data)
+        assert count == 1
+        assert data["components"][0]["licenses"][0]["expression"] == "(MIT OR BSD-2-Clause) AND Apache-2.0"
+
+    def test_mixed_valid_and_compound_consolidated(self):
+        """Component with valid ID + compound expression should consolidate."""
+        data = {
+            "components": [
+                {
+                    "name": "pkg",
+                    "licenses": [
+                        {"license": {"id": "MIT"}},
+                        {"license": {"id": "GPL-2.0-only OR LGPL-2.1-only"}},
+                    ],
+                }
+            ]
+        }
+        sanitize_cyclonedx_licenses(data)
+        licenses = data["components"][0]["licenses"]
+        assert len(licenses) == 1
+        assert "expression" in licenses[0]
+        assert "MIT" in licenses[0]["expression"]
+        assert "GPL-2.0-only" in licenses[0]["expression"]
+
+    def test_mixed_valid_compound_and_invalid_consolidated(self):
+        """Three-way mix: valid ID + compound + invalid should all consolidate."""
+        data = {
+            "components": [
+                {
+                    "name": "pkg",
+                    "licenses": [
+                        {"license": {"id": "MIT"}},
+                        {"license": {"id": "GPL-3.0-only OR LGPL-3.0-only"}},
+                        {"license": {"id": "Custom License XYZ"}},
+                    ],
+                }
+            ]
+        }
+        sanitize_cyclonedx_licenses(data)
+        licenses = data["components"][0]["licenses"]
+        assert len(licenses) == 1
+        assert "expression" in licenses[0]
+
+    def test_multiple_valid_ids_not_consolidated(self):
+        """Multiple valid single IDs should NOT be consolidated (no mixing)."""
+        data = {
+            "components": [
+                {
+                    "name": "pkg",
+                    "licenses": [
+                        {"license": {"id": "MIT"}},
+                        {"license": {"id": "Apache-2.0"}},
+                    ],
+                }
+            ]
+        }
+        count = sanitize_cyclonedx_licenses(data)
+        assert count == 0
+        licenses = data["components"][0]["licenses"]
+        assert len(licenses) == 2
+        assert licenses[0]["license"]["id"] == "MIT"
+        assert licenses[1]["license"]["id"] == "Apache-2.0"
+
+    def test_already_expression_not_modified(self):
+        """An existing expression field should pass through unchanged."""
+        data = {
+            "components": [
+                {
+                    "name": "pkg",
+                    "licenses": [{"expression": "MIT OR Apache-2.0"}],
+                }
+            ]
+        }
+        count = sanitize_cyclonedx_licenses(data)
+        assert count == 0
+        assert data["components"][0]["licenses"][0]["expression"] == "MIT OR Apache-2.0"
+
+    def test_long_license_id_not_treated_as_compound(self):
+        """License IDs exceeding 1024 chars should not be parsed for compound detection."""
+        long_id = "MIT OR " + "A" * 1020
+        data = {
+            "components": [
+                {
+                    "name": "pkg",
+                    "licenses": [{"license": {"id": long_id}}],
+                }
+            ]
+        }
+        count = sanitize_cyclonedx_licenses(data)
+        # Should be treated as invalid ID (moved to name), not compound
+        assert count == 1
+        assert "name" in data["components"][0]["licenses"][0]["license"]

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -2153,3 +2153,24 @@ class TestSanitizeCycloneDXLicenses:
         count = sanitize_cyclonedx_licenses(data)
         assert count == 1
         assert data["services"][0]["licenses"][0]["expression"] == "MIT OR Apache-2.0"
+
+    def test_dual_field_preserves_existing_expression(self):
+        """When both license.id (compound) and expression exist, keep existing expression."""
+        data = {
+            "components": [
+                {
+                    "name": "pkg",
+                    "licenses": [
+                        {
+                            "license": {"id": "GPL-3.0-only OR AGPL-3.0-only"},
+                            "expression": "MIT",
+                        }
+                    ],
+                }
+            ]
+        }
+        count = sanitize_cyclonedx_licenses(data)
+        assert count == 1
+        # Existing expression is preserved, compound license.id is discarded
+        assert data["components"][0]["licenses"][0]["expression"] == "MIT"
+        assert "license" not in data["components"][0]["licenses"][0]


### PR DESCRIPTION
## Summary
Fix CycloneDX validation failure when compound SPDX expressions (containing `OR`/`AND`) appear in `license.id` instead of `expression`.

Fixes #211

## Problem
Enrichment sources like ClearlyDefined return compound license expressions (e.g. `"GPL-2.0-only OR GPL-2.0-or-later OR MPL-2.0"`) as a single string. These get serialized correctly by `cyclonedx-python-lib` as `{"expression": "..."}`, but some input SBOMs (e.g. from docker-scout/sbom-convert) already have compound expressions in `license.id`:
```json
{"license": {"id": "GPL-2.0-only OR GPL-2.0-or-later OR MPL-2.0"}}
```
The existing sanitizer didn't catch this because `validate_spdx_expression` returns true for compound expressions. But per the CycloneDX spec, `license.id` must be a single SPDX ID.

## Fix
In `sanitize_cyclonedx_licenses`, check for `OR`/`AND` in `license.id` before the validity check. If found, move the value to the `expression` field (a peer of `license`, not nested).

## Test plan
- [x] `uv run pytest tests/test_serialization.py` — 108 passed
- [x] `uv run mypy sbomify_action` — 0 errors
- [x] Manual test: compound expression correctly moved from `license.id` to `expression`