### PR TITLE
Replace softprops/action-gh-release with gh CLI

### DIFF
--- a/.github/workflows/license-db.yaml
+++ b/.github/workflows/license-db.yaml
@@ -137,7 +137,7 @@ jobs:
       - name: Upload to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.get_tag.outputs.tag }}
+          ASSET: ${{ matrix.distro }}-${{ matrix.version }}.json.gz
         run: |
-          gh release upload "${{ steps.get_tag.outputs.tag }}" \
-            "${{ matrix.distro }}-${{ matrix.version }}.json.gz" \
-            --clobber
+          gh release upload "$RELEASE_TAG" "$ASSET" --clobber

--- a/.github/workflows/license-db.yaml
+++ b/.github/workflows/license-db.yaml
@@ -135,9 +135,9 @@ jobs:
           echo "Uploading to release: $(cat $GITHUB_OUTPUT | grep tag | cut -d= -f2)"
 
       - name: Upload to release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
-        with:
-          files: ${{ matrix.distro }}-${{ matrix.version }}.json.gz
-          tag_name: ${{ steps.get_tag.outputs.tag }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ steps.get_tag.outputs.tag }}" \
+            "${{ matrix.distro }}-${{ matrix.version }}.json.gz" \
+            --clobber


### PR DESCRIPTION
## Summary
- Removes the third-party `softprops/action-gh-release` action from the license-db workflow
- Replaces it with the `gh release upload` CLI command, which is pre-installed on GitHub runners
- Uses `--clobber` to preserve the existing behavior of overwriting duplicate assets

## Test plan
- [ ] Trigger a `workflow_dispatch` run of the `license-db` workflow and verify assets upload successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)