### PR TITLE
feat: BSI §5.2.2 props, declared licences, CI lifecycle, hashes, yanked CLE

### DIFF
--- a/sbomify_action/_augmentation/__init__.py
+++ b/sbomify_action/_augmentation/__init__.py
@@ -6,6 +6,8 @@ metadata for SBOM augmentation. Multiple providers can supply metadata
 
 Providers (in priority order):
 - json-config: Reads from sbomify.json config file (priority 10)
+- docker-image: Emits lifecycle_phase=post-build when the input is a
+  container image (--docker-image / DOCKER_IMAGE) (priority 15)
 - github-actions: Auto-detects VCS info from GitHub Actions env (priority 20)
 - gitlab-ci: Auto-detects VCS info from GitLab CI env (priority 20)
 - bitbucket-pipelines: Auto-detects VCS info from Bitbucket Pipelines env (priority 20)
@@ -46,6 +48,7 @@ def create_default_registry() -> ProviderRegistry:
 
     Providers are registered in priority order (lower number = higher priority):
     - Priority 10: JsonConfigProvider (local config, can override CI-detected VCS)
+    - Priority 15: DockerImageProvider (lifecycle_phase=post-build for container images)
     - Priority 20: CI providers (GitHub Actions, GitLab CI, Bitbucket Pipelines)
     - Priority 50: SbomifyApiProvider (backend metadata)
 
@@ -54,6 +57,7 @@ def create_default_registry() -> ProviderRegistry:
     """
     from .providers import (
         BitbucketPipelinesProvider,
+        DockerImageProvider,
         GitHubActionsProvider,
         GitLabCIProvider,
         JsonConfigProvider,
@@ -64,6 +68,11 @@ def create_default_registry() -> ProviderRegistry:
 
     # Priority 10: Local config (can override CI-detected VCS)
     registry.register(JsonConfigProvider())
+
+    # Priority 15: Docker-image input sets lifecycle_phase=post-build.
+    # Beats CI providers' pre-build default; loses to json_config so
+    # operators can still override.
+    registry.register(DockerImageProvider())
 
     # Priority 20: CI providers (auto-detect VCS from environment)
     registry.register(GitHubActionsProvider())

--- a/sbomify_action/_augmentation/metadata.py
+++ b/sbomify_action/_augmentation/metadata.py
@@ -81,11 +81,23 @@ class AugmentationMetadata:
         )
 
     def merge(self, other: "AugmentationMetadata") -> "AugmentationMetadata":
-        """
-        Merge another metadata instance into this one.
+        """Merge another metadata instance into this one.
 
         The current instance's values take precedence (are not overwritten).
         Only missing fields are filled from the other instance.
+
+        Provider-priority semantics. The augmentation registry sorts
+        providers by ``priority`` ascending and folds results with
+        ``result.merge(later)`` — so the **earlier** provider (lower
+        numeric priority) always wins on any field both set. Concretely:
+
+        * ``json_config`` (priority 10) beats ``github-actions`` /
+          ``gitlab-ci`` (priority 20) beats ``sbomify-api`` (priority 50).
+        * Lower-priority providers only fill fields higher-priority
+          providers left empty — they never override an earlier choice.
+
+        New providers slotting in between existing priorities inherit
+        the same contract.
 
         Args:
             other: Another AugmentationMetadata to merge from

--- a/sbomify_action/_augmentation/providers/__init__.py
+++ b/sbomify_action/_augmentation/providers/__init__.py
@@ -3,6 +3,7 @@
 # Re-export utility from parent module for backwards compatibility
 from ..utils import is_vcs_augmentation_disabled
 from .bitbucket import BitbucketPipelinesProvider
+from .docker_image import DockerImageProvider
 from .github import GitHubActionsProvider
 from .gitlab import GitLabCIProvider
 from .json_config import JsonConfigProvider
@@ -10,6 +11,7 @@ from .sbomify_api import SbomifyApiProvider
 
 __all__ = [
     "BitbucketPipelinesProvider",
+    "DockerImageProvider",
     "GitHubActionsProvider",
     "GitLabCIProvider",
     "JsonConfigProvider",

--- a/sbomify_action/_augmentation/providers/bitbucket.py
+++ b/sbomify_action/_augmentation/providers/bitbucket.py
@@ -96,11 +96,16 @@ class BitbucketPipelinesProvider:
 
         logger.info(f"Detected Bitbucket Pipelines: {vcs_url} @ {truncate_sha(commit_sha)}")
 
+        # Default to ``pre-build`` — see GitHubActionsProvider for the
+        # full CycloneDX 1.7 schema rationale. Lockfile / manifest scans
+        # are ``pre-build``; the docker-image augmentation overrides to
+        # ``post-build`` when the input is a built artifact; ``json_config``
+        # (priority 10) beats this provider for operator overrides.
         return AugmentationMetadata(
             source=self.name,
             vcs_url=vcs_url,
             vcs_commit_sha=commit_sha,
             vcs_ref=ref,
             vcs_commit_url=vcs_commit_url,
-            lifecycle_phase="build",
+            lifecycle_phase="pre-build",
         )

--- a/sbomify_action/_augmentation/providers/bitbucket.py
+++ b/sbomify_action/_augmentation/providers/bitbucket.py
@@ -102,4 +102,5 @@ class BitbucketPipelinesProvider:
             vcs_commit_sha=commit_sha,
             vcs_ref=ref,
             vcs_commit_url=vcs_commit_url,
+            lifecycle_phase="build",
         )

--- a/sbomify_action/_augmentation/providers/docker_image.py
+++ b/sbomify_action/_augmentation/providers/docker_image.py
@@ -1,0 +1,60 @@
+"""Docker-image provider for lifecycle-phase augmentation.
+
+This provider fires when the action input is a container image
+(``--docker-image`` / ``DOCKER_IMAGE``) rather than a lockfile or
+source tree. Per the CycloneDX 1.7 schema ``meta:enum`` for the
+lifecycle ``phase`` property, scanning a built container image
+is ``post-build``:
+
+    post-build — "BOM consisting of information obtained after a
+    build process has completed and the resulting component(s) are
+    available for further analysis."
+
+The provider registers at priority 15 so it beats the CI providers
+(priority 20, default ``pre-build``) but still loses to ``json_config``
+(priority 10) — operators keep the final word via ``sbomify.json``.
+
+Environment variables used:
+- ``DOCKER_IMAGE``: container image reference (e.g. ``ubuntu:24.04``).
+  The CLI sets this from ``--docker-image`` for consistency with the
+  existing CI provider pattern.
+"""
+
+import os
+from typing import Any, Optional
+
+from sbomify_action.logging_config import logger
+
+from ..metadata import AugmentationMetadata
+
+
+class DockerImageProvider:
+    """Sets ``lifecycle_phase="post-build"`` when the input is a built
+    container image. Emits no other fields — the CI providers still
+    contribute VCS metadata, and ``json_config`` / ``sbomify-api`` fill
+    the rest of the augmentation surface.
+    """
+
+    name: str = "docker-image"
+    # Priority 15 — beats CI providers (20) so post-build wins over the
+    # CI default pre-build when the input is a container image; still
+    # loses to json_config (10) so operators can override.
+    priority: int = 15
+
+    def fetch(
+        self,
+        component_id: Optional[str] = None,
+        api_base_url: Optional[str] = None,
+        token: Optional[str] = None,
+        config_path: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Optional[AugmentationMetadata]:
+        docker_image = os.getenv("DOCKER_IMAGE")
+        if not docker_image:
+            return None
+
+        logger.info(f"Detected container image input: {docker_image} — lifecycle_phase=post-build")
+        return AugmentationMetadata(
+            source=self.name,
+            lifecycle_phase="post-build",
+        )

--- a/sbomify_action/_augmentation/providers/github.py
+++ b/sbomify_action/_augmentation/providers/github.py
@@ -88,10 +88,17 @@ class GitHubActionsProvider:
 
         logger.info(f"Detected GitHub Actions: {repository} @ {truncate_sha(commit_sha)}")
 
+        # CI runs are, by definition, a "build" lifecycle phase. Default the
+        # CISA 2025 Generation Context to "build" when running on GitHub
+        # Actions so downstream consumers (and the compliance plugins) see
+        # a value even when the user hasn't supplied sbomify.json.
+        # Other providers (json_config, sbomify API) override this via the
+        # standard merge rules because their `source` priority is higher.
         return AugmentationMetadata(
             source=self.name,
             vcs_url=vcs_url,
             vcs_commit_sha=commit_sha,
             vcs_ref=ref,
             vcs_commit_url=vcs_commit_url,
+            lifecycle_phase="build",
         )

--- a/sbomify_action/_augmentation/providers/github.py
+++ b/sbomify_action/_augmentation/providers/github.py
@@ -92,8 +92,14 @@ class GitHubActionsProvider:
         # CISA 2025 Generation Context to "build" when running on GitHub
         # Actions so downstream consumers (and the compliance plugins) see
         # a value even when the user hasn't supplied sbomify.json.
-        # Other providers (json_config, sbomify API) override this via the
-        # standard merge rules because their `source` priority is higher.
+        #
+        # Priority interaction with other providers: the registry merges
+        # providers in ascending-priority order where `result.merge(later)`
+        # preserves already-set fields. json_config (priority 10) runs
+        # before github-actions (priority 20), so a lifecycle_phase set in
+        # sbomify.json wins. sbomify-api (priority 50) runs AFTER and
+        # therefore does NOT override the CI default — sbomify-api only
+        # fills in fields that no higher-priority provider has set.
         return AugmentationMetadata(
             source=self.name,
             vcs_url=vcs_url,

--- a/sbomify_action/_augmentation/providers/github.py
+++ b/sbomify_action/_augmentation/providers/github.py
@@ -91,15 +91,9 @@ class GitHubActionsProvider:
         # CI runs are, by definition, a "build" lifecycle phase. Default the
         # CISA 2025 Generation Context to "build" when running on GitHub
         # Actions so downstream consumers (and the compliance plugins) see
-        # a value even when the user hasn't supplied sbomify.json.
-        #
-        # Priority interaction with other providers: the registry merges
-        # providers in ascending-priority order where `result.merge(later)`
-        # preserves already-set fields. json_config (priority 10) runs
-        # before github-actions (priority 20), so a lifecycle_phase set in
-        # sbomify.json wins. sbomify-api (priority 50) runs AFTER and
-        # therefore does NOT override the CI default — sbomify-api only
-        # fills in fields that no higher-priority provider has set.
+        # a value even when the user hasn't supplied sbomify.json. See
+        # AugmentationMetadata.merge for how this interacts with json_config
+        # (wins, priority 10) and sbomify-api (doesn't override, priority 50).
         return AugmentationMetadata(
             source=self.name,
             vcs_url=vcs_url,

--- a/sbomify_action/_augmentation/providers/github.py
+++ b/sbomify_action/_augmentation/providers/github.py
@@ -88,17 +88,28 @@ class GitHubActionsProvider:
 
         logger.info(f"Detected GitHub Actions: {repository} @ {truncate_sha(commit_sha)}")
 
-        # CI runs are, by definition, a "build" lifecycle phase. Default the
-        # CISA 2025 Generation Context to "build" when running on GitHub
-        # Actions so downstream consumers (and the compliance plugins) see
-        # a value even when the user hasn't supplied sbomify.json. See
-        # AugmentationMetadata.merge for how this interacts with json_config
-        # (wins, priority 10) and sbomify-api (doesn't override, priority 50).
+        # CycloneDX 1.7 schema meta:enum defines the lifecycle phases as:
+        #   * pre-build  — "information obtained prior to a build process
+        #                  and may contain source files and development
+        #                  artifacts and manifests" (lockfiles are manifests)
+        #   * build      — "information obtained during a build process"
+        #                  (emitted by compiler / build tool itself)
+        #   * post-build — "information obtained after a build process has
+        #                  completed and the resulting component(s) are
+        #                  available for further analysis" (e.g. scanning
+        #                  a built container image)
+        # The common GitHub Actions usage of sbomify-action is scanning
+        # lockfiles / source manifests, so default to ``pre-build``. When
+        # the action runs against a built artifact (``--docker-image``),
+        # the docker-image augmentation overrides to ``post-build``.
+        # Users who emit a BOM mid-compilation (Maven / Gradle plugins,
+        # ``cargo bom`` and similar) can override via ``sbomify.json`` /
+        # ``json_config`` (priority 10 beats this provider at 20).
         return AugmentationMetadata(
             source=self.name,
             vcs_url=vcs_url,
             vcs_commit_sha=commit_sha,
             vcs_ref=ref,
             vcs_commit_url=vcs_commit_url,
-            lifecycle_phase="build",
+            lifecycle_phase="pre-build",
         )

--- a/sbomify_action/_augmentation/providers/gitlab.py
+++ b/sbomify_action/_augmentation/providers/gitlab.py
@@ -87,11 +87,16 @@ class GitLabCIProvider:
 
         logger.info(f"Detected GitLab CI: {project_url} @ {truncate_sha(commit_sha)}")
 
+        # Default to ``pre-build`` — see GitHubActionsProvider for the
+        # full CycloneDX 1.7 schema rationale. Lockfile / manifest scans
+        # are ``pre-build``; the docker-image augmentation overrides to
+        # ``post-build`` when the input is a built artifact; ``json_config``
+        # (priority 10) beats this provider for operator overrides.
         return AugmentationMetadata(
             source=self.name,
             vcs_url=project_url,
             vcs_commit_sha=commit_sha,
             vcs_ref=ref,
             vcs_commit_url=vcs_commit_url,
-            lifecycle_phase="build",
+            lifecycle_phase="pre-build",
         )

--- a/sbomify_action/_augmentation/providers/gitlab.py
+++ b/sbomify_action/_augmentation/providers/gitlab.py
@@ -93,4 +93,5 @@ class GitLabCIProvider:
             vcs_commit_sha=commit_sha,
             vcs_ref=ref,
             vcs_commit_url=vcs_commit_url,
+            lifecycle_phase="build",
         )

--- a/sbomify_action/_enrichment/metadata.py
+++ b/sbomify_action/_enrichment/metadata.py
@@ -44,9 +44,17 @@ class NormalizedMetadata:
 
     # Distribution info (BSI TR-03183-2 compliance)
     distribution_filename: Optional[str] = None
-    # Hashes of the deployable artefact, keyed by SPDX algorithm name
-    # (e.g. "sha256", "sha512", "md5"). Values are lower-case hex strings.
-    # Used to populate NTIA / BSI §5.2.2 / CISA "Component Hash" elements.
+    # Hashes of the deployable artefact, keyed by algorithm name as the
+    # source provided it. Keys are lower-case strings — typically SPDX /
+    # CycloneDX canonical names such as "sha256", "sha512", "md5", but
+    # some sources legitimately use their own variant spelling. The PyPI
+    # source, for instance, returns BLAKE2b-256 under the underscore
+    # form "blake2b_256" (matching PyPI's JSON API), and we keep that
+    # form here so the downstream algorithm map (_CYCLONEDX_HASH_ALGORITHMS /
+    # _SPDX_CHECKSUM_ALGORITHMS in enrichment.py) can recognise it
+    # without a second normalisation step. Values are lower-case hex
+    # strings. Used to populate NTIA / BSI §5.2.2 / CISA "Component
+    # Hash" elements.
     hashes: Dict[str, str] = field(default_factory=dict)
 
     # CLE (Common Lifecycle Enumeration) fields - ECMA-428
@@ -95,14 +103,27 @@ class NormalizedMetadata:
         # `other` is preserved. Dropping other's keys would silently lose
         # useful digests when PyPI gives sha256 and another source
         # contributes blake2b / md5 for the same artefact.
+        #
+        # Attribution for the union field: if `other` adds at least one
+        # new algorithm key, refresh ``field_sources["hashes"]`` to
+        # record BOTH contributing sources (comma-separated). Previously
+        # this branch early-exited when self already had a "hashes"
+        # entry, which hid the fact that the merged value actually
+        # contained algorithms from both sources. Attribution follows
+        # the existing source-tracking convention used elsewhere (e.g.
+        # AugmentationMetadata.merge concatenates sources with ", ").
         merged_hashes: Dict[str, str] = dict(self.hashes)
         added_hash_alg = False
         for alg, hex_value in other.hashes.items():
             if alg not in merged_hashes:
                 merged_hashes[alg] = hex_value
                 added_hash_alg = True
-        if added_hash_alg and other.source and "hashes" not in merged_sources:
-            merged_sources["hashes"] = other.source
+        if added_hash_alg and other.source:
+            prior = merged_sources.get("hashes")
+            if not prior:
+                merged_sources["hashes"] = other.source
+            elif other.source not in prior.split(", "):
+                merged_sources["hashes"] = f"{prior}, {other.source}"
 
         # Merge license_texts (combine both)
         merged_license_texts = dict(self.license_texts)

--- a/sbomify_action/_enrichment/metadata.py
+++ b/sbomify_action/_enrichment/metadata.py
@@ -90,6 +90,20 @@ class NormalizedMetadata:
                     merged_sources[field_name] = other.source
                 return other_val
 
+        # Merge hashes as a union keyed by algorithm — self wins on
+        # conflicting algorithms, but every algorithm contributed by
+        # `other` is preserved. Dropping other's keys would silently lose
+        # useful digests when PyPI gives sha256 and another source
+        # contributes blake2b / md5 for the same artefact.
+        merged_hashes: Dict[str, str] = dict(self.hashes)
+        added_hash_alg = False
+        for alg, hex_value in other.hashes.items():
+            if alg not in merged_hashes:
+                merged_hashes[alg] = hex_value
+                added_hash_alg = True
+        if added_hash_alg and other.source and "hashes" not in merged_sources:
+            merged_sources["hashes"] = other.source
+
         # Merge license_texts (combine both)
         merged_license_texts = dict(self.license_texts)
         for lic_id, text in other.license_texts.items():
@@ -116,7 +130,7 @@ class NormalizedMetadata:
             distribution_filename=pick(
                 "distribution_filename", self.distribution_filename, other.distribution_filename
             ),
-            hashes=pick("hashes", self.hashes, other.hashes, is_list=True),
+            hashes=merged_hashes,
             # CLE fields
             cle_eos=pick("cle_eos", self.cle_eos, other.cle_eos),
             cle_eol=pick("cle_eol", self.cle_eol, other.cle_eol),

--- a/sbomify_action/_enrichment/metadata.py
+++ b/sbomify_action/_enrichment/metadata.py
@@ -44,6 +44,10 @@ class NormalizedMetadata:
 
     # Distribution info (BSI TR-03183-2 compliance)
     distribution_filename: Optional[str] = None
+    # Hashes of the deployable artefact, keyed by SPDX algorithm name
+    # (e.g. "sha256", "sha512", "md5"). Values are lower-case hex strings.
+    # Used to populate NTIA / BSI §5.2.2 / CISA "Component Hash" elements.
+    hashes: Dict[str, str] = field(default_factory=dict)
 
     # CLE (Common Lifecycle Enumeration) fields - ECMA-428
     # Used for distro-level lifecycle dates applied to all packages from that distro
@@ -112,6 +116,7 @@ class NormalizedMetadata:
             distribution_filename=pick(
                 "distribution_filename", self.distribution_filename, other.distribution_filename
             ),
+            hashes=pick("hashes", self.hashes, other.hashes, is_list=True),
             # CLE fields
             cle_eos=pick("cle_eos", self.cle_eos, other.cle_eos),
             cle_eol=pick("cle_eol", self.cle_eol, other.cle_eol),
@@ -136,6 +141,7 @@ class NormalizedMetadata:
             or self.maintainer_name
             or self.maintainer_email
             or self.distribution_filename
+            or self.hashes
             or self.cle_eos
             or self.cle_eol
         )

--- a/sbomify_action/_enrichment/sources/pypi.py
+++ b/sbomify_action/_enrichment/sources/pypi.py
@@ -107,10 +107,14 @@ class PyPISource:
 
         try:
             # Reject PURL components that could rewrite the URL path.
-            # PackageURL.from_string preserves ".." and "/" in the name/version
-            # fields; `requests` then normalises raw "../.." segments, which
-            # can redirect our GET to arbitrary pypi.org paths. Encode both
-            # components with safe="" and explicitly refuse traversal tokens.
+            # Empirically, packageurl-python's PackageURL.from_string preserves
+            # ".." and "/" in the name/version fields (PEP 440 disallows them
+            # in a real PyPI version, but the parser doesn't enforce that).
+            # `requests` then normalises raw "../.." segments, which can
+            # redirect our GET to arbitrary pypi.org paths. Percent-encode
+            # both components with safe="" AND explicitly refuse traversal
+            # tokens so defence-in-depth doesn't depend on either the third-
+            # party parser or the HTTP client behaving a specific way.
             raw_name = purl.name or ""
             raw_version = purl.version or ""
             if "/" in raw_name or ".." in raw_name:

--- a/sbomify_action/_enrichment/sources/pypi.py
+++ b/sbomify_action/_enrichment/sources/pypi.py
@@ -1,8 +1,8 @@
 """PyPI data source for Python package metadata."""
 
 import json
-from datetime import datetime, timezone
 from typing import Any, Dict, Optional
+from urllib.parse import quote
 
 import requests
 from packageurl import PackageURL
@@ -72,16 +72,40 @@ class PyPISource:
             return _cache[cache_key]
 
         try:
+            # Reject PURL components that could rewrite the URL path.
+            # PackageURL.from_string preserves ".." and "/" in the name/version
+            # fields; `requests` then normalises raw "../.." segments, which
+            # can redirect our GET to arbitrary pypi.org paths. Encode both
+            # components with safe="" and explicitly refuse traversal tokens.
+            raw_name = purl.name or ""
+            raw_version = purl.version or ""
+            if "/" in raw_name or ".." in raw_name:
+                logger.warning(f"Refusing PyPI fetch for PURL with suspicious name: {raw_name!r}")
+                _cache[cache_key] = None
+                return None
+            if "/" in raw_version or ".." in raw_version:
+                logger.warning(f"Refusing PyPI fetch for PURL with suspicious version: {raw_version!r}")
+                _cache[cache_key] = None
+                return None
+            safe_name = quote(raw_name, safe="")
+            safe_version = quote(raw_version, safe="") if raw_version else ""
+
             # Prefer the version-specific endpoint when a version is present:
             # it surfaces per-release fields (yanked, upload_time, file hashes)
-            # that the latest-only endpoint flattens out. Fall back to the
-            # latest-only endpoint when no version is available in the PURL.
-            if purl.version:
-                url = f"{PYPI_API_BASE}/{purl.name}/{purl.version}/json"
-            else:
-                url = f"{PYPI_API_BASE}/{purl.name}/json"
+            # that the latest-only endpoint flattens out. If the versioned URL
+            # returns 404 (package exists, version doesn't), fall back to the
+            # latest-only endpoint so we still get base-package metadata.
+            latest_url = f"{PYPI_API_BASE}/{safe_name}/json"
+            primary_url = f"{PYPI_API_BASE}/{safe_name}/{safe_version}/json" if safe_version else latest_url
             logger.debug(f"Fetching PyPI metadata for: {purl.name}")
-            response = session.get(url, timeout=DEFAULT_TIMEOUT)
+            response = session.get(primary_url, timeout=DEFAULT_TIMEOUT)
+
+            if response.status_code == 404 and primary_url != latest_url:
+                logger.debug(
+                    f"PyPI version-specific 404 for {purl.name}@{purl.version}; "
+                    "retrying the latest-only endpoint for base metadata."
+                )
+                response = session.get(latest_url, timeout=DEFAULT_TIMEOUT)
 
             metadata = None
             if response.status_code == 200:
@@ -209,11 +233,26 @@ class PyPISource:
             if isinstance(upload_time, str) and upload_time.strip():
                 upload_date = upload_time.strip().split("T", 1)[0]
                 cle_release_date = upload_date
-        is_yanked = bool(info.get("yanked"))
+
+        # Per PEP 691, the `yanked` key can be either a bool (True -> yanked) or
+        # a non-empty string (the reason string; presence also means yanked).
+        # Accept both to stay spec-compliant, but reject unexpected types so a
+        # malformed or malicious response can't inject a fake yank.
+        def _is_pep691_yanked(value: Any) -> bool:
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, str):
+                return bool(value.strip())
+            return False
+
+        is_yanked = _is_pep691_yanked(info.get("yanked"))
         if not is_yanked and selected_dist is not None:
-            is_yanked = bool(selected_dist.get("yanked"))
-        if is_yanked:
-            cle_eol = upload_date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            is_yanked = _is_pep691_yanked(selected_dist.get("yanked"))
+        if is_yanked and upload_date:
+            # Only emit an EOL date when we have a real upload timestamp.
+            # Falling back to "today" would make the output non-deterministic
+            # and produce a false "yanked just now" signal downstream.
+            cle_eol = upload_date
 
         logger.debug(f"Successfully fetched PyPI metadata for: {package_name}")
 

--- a/sbomify_action/_enrichment/sources/pypi.py
+++ b/sbomify_action/_enrichment/sources/pypi.py
@@ -35,14 +35,17 @@ _cache: Dict[str, Optional[NormalizedMetadata]] = {}
 def is_pep691_yanked(value: Any) -> bool:
     """Return True if `value` indicates a PEP 691 "yanked" state.
 
-    PEP 691 specifies the `yanked` key is either a boolean (True -> yanked)
-    or a non-empty string (the reason; presence means yanked). Any other
-    type (dict, list, numeric) is treated as non-yanked so a malformed or
-    malicious response can't inject a fake yank.
+    Branches:
+      1. bool    — True means yanked, False means not yanked.
+      2. str     — non-empty (after strip) is a yank reason, treated as
+                   yanked; empty/whitespace-only is not.
+      3. default — any other type (dict, list, numeric, None) is not
+                   yanked, so a malformed or malicious response can't
+                   inject a fake yank.
 
-    isinstance(bool) is checked first because `isinstance(True, int)`
-    returns True in Python; without the bool-first ordering the numeric
-    branch would never be reachable for genuine bool values.
+    `isinstance(bool)` runs before any potential numeric branch because
+    `isinstance(True, int)` is True — checking bool first keeps real
+    bools out of any future is-numeric branch.
     """
     if isinstance(value, bool):
         return value
@@ -265,7 +268,10 @@ class PyPISource:
         selected_dist: Optional[Dict[str, Any]] = None
         for dist in urls:
             fn = dist.get("filename", "")
-            if fn.endswith(".whl"):
+            # PEP 427 wheels conventionally use lowercase ".whl", but some
+            # toolchains upload mixed-case suffixes; match case-insensitively
+            # so wheel preference is consistent with the BSI derivation path.
+            if fn.lower().endswith(".whl"):
                 distribution_filename = fn
                 selected_dist = dist
                 break
@@ -283,8 +289,10 @@ class PyPISource:
         # - release_date: upload_time_iso_8601 of the chosen distribution file.
         # - end_of_life: version-level yanked flag. A yanked release has been
         #   withdrawn by its maintainer and should no longer be consumed; we
-        #   map that to an EOL date at the upload time (falling back to the
-        #   current UTC date if the upload timestamp is unavailable).
+        #   map that to an EOL date at the upload time. When the upload
+        #   timestamp is unavailable we deliberately leave cle_eol unset
+        #   rather than synthesise "today" — downstream output must stay
+        #   deterministic across repeated enrichment runs.
         cle_release_date: Optional[str] = None
         cle_eol: Optional[str] = None
         upload_date = None

--- a/sbomify_action/_enrichment/sources/pypi.py
+++ b/sbomify_action/_enrichment/sources/pypi.py
@@ -22,6 +22,25 @@ DEFAULT_TIMEOUT = 10  # seconds - PyPI is fast
 _cache: Dict[str, Optional[NormalizedMetadata]] = {}
 
 
+def is_pep691_yanked(value: Any) -> bool:
+    """Return True if `value` indicates a PEP 691 "yanked" state.
+
+    PEP 691 specifies the `yanked` key is either a boolean (True -> yanked)
+    or a non-empty string (the reason; presence means yanked). Any other
+    type (dict, list, numeric) is treated as non-yanked so a malformed or
+    malicious response can't inject a fake yank.
+
+    isinstance(bool) is checked first because `isinstance(True, int)`
+    returns True in Python; without the bool-first ordering the numeric
+    branch would never be reachable for genuine bool values.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return bool(value.strip())
+    return False
+
+
 def clear_cache() -> None:
     """Clear the PyPI metadata cache."""
     _cache.clear()
@@ -101,11 +120,30 @@ class PyPISource:
             response = session.get(primary_url, timeout=DEFAULT_TIMEOUT)
 
             if response.status_code == 404 and primary_url != latest_url:
+                # Reuse a name-only cache entry if we've already fetched the
+                # latest endpoint for this package. Without this an attacker
+                # submitting N distinct fake versions for a real package
+                # would force 2N requests — the N 404s plus N redundant
+                # latest-only GETs. The name-only cache key is distinct
+                # from the version-keyed cache so real version hits are
+                # unaffected.
+                latest_cache_key = f"pypi:{purl.name}:_latest"
+                if latest_cache_key in _cache:
+                    logger.debug(f"Cache hit (PyPI latest) for 404 fallback: {purl.name}")
+                    metadata = _cache[latest_cache_key]
+                    _cache[cache_key] = metadata
+                    return metadata
                 logger.debug(
                     f"PyPI version-specific 404 for {purl.name}@{purl.version}; "
                     "retrying the latest-only endpoint for base metadata."
                 )
                 response = session.get(latest_url, timeout=DEFAULT_TIMEOUT)
+                metadata = None
+                if response.status_code == 200:
+                    metadata = self._normalize_response(purl.name, response.json())
+                _cache[latest_cache_key] = metadata
+                _cache[cache_key] = metadata
+                return metadata
 
             metadata = None
             if response.status_code == 200:
@@ -234,20 +272,9 @@ class PyPISource:
                 upload_date = upload_time.strip().split("T", 1)[0]
                 cle_release_date = upload_date
 
-        # Per PEP 691, the `yanked` key can be either a bool (True -> yanked) or
-        # a non-empty string (the reason string; presence also means yanked).
-        # Accept both to stay spec-compliant, but reject unexpected types so a
-        # malformed or malicious response can't inject a fake yank.
-        def _is_pep691_yanked(value: Any) -> bool:
-            if isinstance(value, bool):
-                return value
-            if isinstance(value, str):
-                return bool(value.strip())
-            return False
-
-        is_yanked = _is_pep691_yanked(info.get("yanked"))
+        is_yanked = is_pep691_yanked(info.get("yanked"))
         if not is_yanked and selected_dist is not None:
-            is_yanked = _is_pep691_yanked(selected_dist.get("yanked"))
+            is_yanked = is_pep691_yanked(selected_dist.get("yanked"))
         if is_yanked and upload_date:
             # Only emit an EOL date when we have a real upload timestamp.
             # Falling back to "today" would make the output non-deterministic

--- a/sbomify_action/_enrichment/sources/pypi.py
+++ b/sbomify_action/_enrichment/sources/pypi.py
@@ -96,20 +96,61 @@ class PyPISource:
         Returns:
             NormalizedMetadata if successful, None otherwise
         """
-        # Include version in cache key for version-specific lookups.
+        # Validate the raw PURL components BEFORE building any cache key.
         #
+        # If we built ``cache_key`` first, a crafted version like ``":latest"``
+        # would produce ``pypi:<name>::latest`` — exactly the internal
+        # ``_LATEST_CACHE_SUFFIX`` sentinel — and the subsequent unsafe-token
+        # rejection would cache ``None`` there, poisoning legitimate
+        # versionless fetches for the same name. So the ordering is:
+        #
+        #   1. Extract raw name/version.
+        #   2. Reject unsafe tokens (log only, do NOT write to cache).
+        #   3. Build the cache key from the now-validated name/version.
+        #
+        # Path-traversal rules:
+        #   - Names: PEP 503 allows "." and "_" inside a normalised project
+        #     name (so "a..b" is a legal-but-unusual name). Reject only
+        #     actual path separators ("/", "\\") and the whole-name
+        #     dot-segments ("." / ".."). The ":" character is refused too
+        #     because an inbound ":" in the name could construct the
+        #     ``::latest`` cache sentinel.
+        #   - Versions: PEP 440 forbids "/", "\\", "..", and ":" in a
+        #     canonical version, so enforce all of them directly.
+        raw_name = purl.name or ""
+        raw_version = purl.version or ""
+
+        def _is_dot_segment(value: str) -> bool:
+            return value in {".", ".."}
+
+        if "/" in raw_name or "\\" in raw_name or ":" in raw_name or _is_dot_segment(raw_name):
+            logger.warning(
+                f"Refusing PyPI fetch for PURL with unsafe tokens in name: {raw_name!r} "
+                f"(rejected because the name contains '/', '\\', ':' or is a whole "
+                f"dot-segment, which could rewrite the request URL or collide with an "
+                f"internal cache key)"
+            )
+            return None
+        if "/" in raw_version or "\\" in raw_version or ".." in raw_version or ":" in raw_version:
+            logger.warning(
+                f"Refusing PyPI fetch for PURL with unsafe tokens in version: {raw_version!r} "
+                f"(rejected because the version contains '/', '\\', '..' or ':' which "
+                f"could rewrite the request URL or collide with an internal cache key)"
+            )
+            return None
+
         # Versionless fetches share the same slot as the 404-fallback latest
         # lookup so a version-first request that 404s can reuse a prior
         # versionless hit (and vice versa), saving one redundant GET. Both
         # write to ``pypi:<name>::latest`` (the ``_LATEST_CACHE_SUFFIX``
         # sentinel) rather than diverging into ``pypi:<name>:latest`` and
         # ``pypi:<name>::latest`` respectively. The ``:`` character is
-        # forbidden in PURL name/version below, so the sentinel can't be
+        # forbidden in PURL name/version above, so the sentinel can't be
         # forged from an inbound PURL.
-        if purl.version:
-            cache_key = f"pypi:{purl.name}:{purl.version}"
+        if raw_version:
+            cache_key = f"pypi:{raw_name}:{raw_version}"
         else:
-            cache_key = f"pypi:{purl.name}{_LATEST_CACHE_SUFFIX}"
+            cache_key = f"pypi:{raw_name}{_LATEST_CACHE_SUFFIX}"
 
         # Check cache
         if cache_key in _cache:
@@ -117,48 +158,6 @@ class PyPISource:
             return _cache[cache_key]
 
         try:
-            # Reject PURL components that could rewrite the URL path.
-            # Empirically, packageurl-python's PackageURL.from_string preserves
-            # ".." and "/" in the name/version fields (PEP 440 disallows them
-            # in a real PyPI version, but the parser doesn't enforce that).
-            # `requests` then normalises raw "../.." segments, which can
-            # redirect our GET to arbitrary pypi.org paths. Percent-encode
-            # both components with safe="" AND explicitly refuse traversal
-            # tokens so defence-in-depth doesn't depend on either the third-
-            # party parser or the HTTP client behaving a specific way.
-            raw_name = purl.name or ""
-            raw_version = purl.version or ""
-
-            # Path-traversal tokens in name/version could rewrite the
-            # request URL after `requests` normalises raw "../.." segments.
-            # Names: PEP 503 allows "." and "_" inside a normalised project
-            # name (so "a..b" is a legal-but-unusual name). Reject only
-            # actual path separators ("/", "\\") and the whole-name
-            # dot-segments ("." / ".."). The ":" character is refused too
-            # because an inbound ":" in the name could construct the
-            # `::latest` cache sentinel below.
-            # Versions: PEP 440 forbids "/", "\\", "..", and ":" in a
-            # canonical version, so enforce all of them directly.
-            def _is_dot_segment(value: str) -> bool:
-                return value in {".", ".."}
-
-            if "/" in raw_name or "\\" in raw_name or ":" in raw_name or _is_dot_segment(raw_name):
-                logger.warning(
-                    f"Refusing PyPI fetch for PURL with unsafe tokens in name: {raw_name!r} "
-                    f"(rejected because the name contains '/', '\\', ':' or is a whole "
-                    f"dot-segment, which could rewrite the request URL or collide with an "
-                    f"internal cache key)"
-                )
-                _cache[cache_key] = None
-                return None
-            if "/" in raw_version or "\\" in raw_version or ".." in raw_version or ":" in raw_version:
-                logger.warning(
-                    f"Refusing PyPI fetch for PURL with unsafe tokens in version: {raw_version!r} "
-                    f"(rejected because the version contains '/', '\\', '..' or ':' which "
-                    f"could rewrite the request URL or collide with an internal cache key)"
-                )
-                _cache[cache_key] = None
-                return None
             safe_name = quote(raw_name, safe="")
             safe_version = quote(raw_version, safe="") if raw_version else ""
 

--- a/sbomify_action/_enrichment/sources/pypi.py
+++ b/sbomify_action/_enrichment/sources/pypi.py
@@ -1,4 +1,11 @@
-"""PyPI data source for Python package metadata."""
+"""PyPI data source for Python package metadata.
+
+The module-level `_cache` is intentionally a plain dict: enrichment runs
+single-threaded today (one call per component, sequentially). If this ever
+moves behind a ThreadPoolExecutor, wrap the cache in a `threading.Lock`
+before doing so — the 404-fallback path writes both the version-specific
+key and the `::latest` sentinel key in two separate statements.
+"""
 
 import json
 from typing import Any, Dict, Optional
@@ -17,8 +24,11 @@ from .purl import PURL_TYPE_TO_SUPPLIER
 
 PYPI_API_BASE = "https://pypi.org/pypi"
 DEFAULT_TIMEOUT = 10  # seconds - PyPI is fast
+# Sentinel for the name-only cache slot. PEP 440 forbids ":" in versions,
+# so this cannot collide with a literal `pkg:pypi/foo@anything` version.
+_LATEST_CACHE_SUFFIX = "::latest"
 
-# Simple in-memory cache
+# Simple in-memory cache; see module docstring for thread-safety contract.
 _cache: Dict[str, Optional[NormalizedMetadata]] = {}
 
 
@@ -38,6 +48,8 @@ def is_pep691_yanked(value: Any) -> bool:
         return value
     if isinstance(value, str):
         return bool(value.strip())
+    if value is not None:
+        logger.debug(f"PyPI yanked field has unexpected type {type(value).__name__}; treating as not yanked")
     return False
 
 
@@ -127,7 +139,7 @@ class PyPISource:
                 # latest-only GETs. The name-only cache key is distinct
                 # from the version-keyed cache so real version hits are
                 # unaffected.
-                latest_cache_key = f"pypi:{purl.name}:_latest"
+                latest_cache_key = f"pypi:{purl.name}{_LATEST_CACHE_SUFFIX}"
                 if latest_cache_key in _cache:
                     logger.debug(f"Cache hit (PyPI latest) for 404 fallback: {purl.name}")
                     metadata = _cache[latest_cache_key]
@@ -141,8 +153,18 @@ class PyPISource:
                 metadata = None
                 if response.status_code == 200:
                     metadata = self._normalize_response(purl.name, response.json())
-                _cache[latest_cache_key] = metadata
-                _cache[cache_key] = metadata
+                    _cache[latest_cache_key] = metadata
+                    _cache[cache_key] = metadata
+                elif response.status_code == 404:
+                    # Genuine "package gone" — permanent, safe to cache.
+                    _cache[latest_cache_key] = None
+                    _cache[cache_key] = None
+                else:
+                    # Transient failure (5xx / rate limit). Do NOT cache:
+                    # a retry on a later component may succeed.
+                    logger.warning(
+                        f"Transient PyPI error on latest fallback for {purl.name}: HTTP {response.status_code}"
+                    )
                 return metadata
 
             metadata = None

--- a/sbomify_action/_enrichment/sources/pypi.py
+++ b/sbomify_action/_enrichment/sources/pypi.py
@@ -118,11 +118,17 @@ class PyPISource:
             raw_name = purl.name or ""
             raw_version = purl.version or ""
             if "/" in raw_name or ".." in raw_name:
-                logger.warning(f"Refusing PyPI fetch for PURL with suspicious name: {raw_name!r}")
+                logger.warning(
+                    f"Refusing PyPI fetch for PURL with path-traversal tokens in name: {raw_name!r} "
+                    f"(rejected because the name contains '/' or '..' which could rewrite the request URL)"
+                )
                 _cache[cache_key] = None
                 return None
             if "/" in raw_version or ".." in raw_version:
-                logger.warning(f"Refusing PyPI fetch for PURL with suspicious version: {raw_version!r}")
+                logger.warning(
+                    f"Refusing PyPI fetch for PURL with path-traversal tokens in version: {raw_version!r} "
+                    f"(rejected because the version contains '/' or '..' which could rewrite the request URL)"
+                )
                 _cache[cache_key] = None
                 return None
             safe_name = quote(raw_name, safe="")
@@ -177,25 +183,48 @@ class PyPISource:
             metadata = None
             if response.status_code == 200:
                 metadata = self._normalize_response(purl.name, response.json())
+                _cache[cache_key] = metadata
             elif response.status_code == 404:
+                # Package genuinely missing — permanent, safe to cache so
+                # repeat components for the same missing name skip the
+                # network round-trip.
                 logger.debug(f"Package not found on PyPI: {purl.name}")
+                _cache[cache_key] = None
             else:
-                logger.warning(f"Failed to fetch PyPI metadata for {purl.name}: HTTP {response.status_code}")
-
-            # Cache result
-            _cache[cache_key] = metadata
+                # Transient failure (5xx / rate limit). Do NOT cache:
+                # a retry on a later component may succeed once PyPI
+                # recovers. Include package + HTTP status so ops logs
+                # show what to correlate against PyPI status pages.
+                logger.warning(
+                    f"Transient PyPI error for {purl.name}@{purl.version or 'latest'}: "
+                    f"HTTP {response.status_code} (not caching — later components will retry)"
+                )
             return metadata
 
         except requests.exceptions.Timeout:
-            logger.warning(f"Timeout fetching PyPI metadata for {purl.name}")
-            _cache[cache_key] = None
+            # Timeout is always transient — network / slow-server.
+            # Do not cache so a later component can re-try.
+            logger.warning(
+                f"Timeout fetching PyPI metadata for {purl.name}@{purl.version or 'latest'} "
+                f"(not caching — later components will retry)"
+            )
             return None
         except requests.exceptions.RequestException as e:
-            logger.warning(f"Error fetching PyPI metadata for {purl.name}: {e}")
-            _cache[cache_key] = None
+            # Network-layer exceptions (ConnectionError, SSLError,
+            # TooManyRedirects, etc.) are almost always transient.
+            logger.warning(
+                f"Network error fetching PyPI metadata for {purl.name}@{purl.version or 'latest'}: "
+                f"{e.__class__.__name__}: {e} (not caching — later components will retry)"
+            )
             return None
         except json.JSONDecodeError as e:
-            logger.warning(f"JSON decode error for PyPI {purl.name}: {e}")
+            # Malformed response is almost always a deterministic
+            # upstream issue (HTML error page, corrupt encoding) — cache
+            # None so we don't re-hit it N times in the same run.
+            logger.warning(
+                f"JSON decode error for PyPI {purl.name}@{purl.version or 'latest'}: {e} "
+                f"(caching None to avoid repeated failures)"
+            )
             _cache[cache_key] = None
             return None
 

--- a/sbomify_action/_enrichment/sources/pypi.py
+++ b/sbomify_action/_enrichment/sources/pypi.py
@@ -1,6 +1,7 @@
 """PyPI data source for Python package metadata."""
 
 import json
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 import requests
@@ -71,7 +72,14 @@ class PyPISource:
             return _cache[cache_key]
 
         try:
-            url = f"{PYPI_API_BASE}/{purl.name}/json"
+            # Prefer the version-specific endpoint when a version is present:
+            # it surfaces per-release fields (yanked, upload_time, file hashes)
+            # that the latest-only endpoint flattens out. Fall back to the
+            # latest-only endpoint when no version is available in the PURL.
+            if purl.version:
+                url = f"{PYPI_API_BASE}/{purl.name}/{purl.version}/json"
+            else:
+                url = f"{PYPI_API_BASE}/{purl.name}/json"
             logger.debug(f"Fetching PyPI metadata for: {purl.name}")
             response = session.get(url, timeout=DEFAULT_TIMEOUT)
 
@@ -162,17 +170,50 @@ class PyPISource:
             elif "homepage" in key_lower and not homepage:
                 homepage = url_value
 
-        # Extract distribution filename from release files (BSI TR-03183-2)
-        # Prefer wheel (.whl) over sdist (.tar.gz)
+        # Extract distribution filename + hashes from release files
+        # (BSI TR-03183-2 §5.2.2 filename + hash / NTIA / CISA hash element).
+        # Prefer wheel (.whl) over sdist (.tar.gz); take the hashes of the
+        # distribution whose filename we record so the two fields describe
+        # the same artefact.
         distribution_filename = None
+        distribution_hashes: Dict[str, str] = {}
         urls = data.get("urls", [])
+        selected_dist: Optional[Dict[str, Any]] = None
         for dist in urls:
             fn = dist.get("filename", "")
             if fn.endswith(".whl"):
                 distribution_filename = fn
+                selected_dist = dist
                 break
             elif fn and not distribution_filename:
                 distribution_filename = fn
+                selected_dist = dist
+        if selected_dist is not None:
+            raw_digests = selected_dist.get("digests") or {}
+            if isinstance(raw_digests, dict):
+                for alg_name, hex_value in raw_digests.items():
+                    if isinstance(alg_name, str) and isinstance(hex_value, str) and hex_value.strip():
+                        distribution_hashes[alg_name.strip().lower()] = hex_value.strip().lower()
+
+        # Release date + lifecycle-status inference (ECMA-428 CLE).
+        # - release_date: upload_time_iso_8601 of the chosen distribution file.
+        # - end_of_life: version-level yanked flag. A yanked release has been
+        #   withdrawn by its maintainer and should no longer be consumed; we
+        #   map that to an EOL date at the upload time (falling back to the
+        #   current UTC date if the upload timestamp is unavailable).
+        cle_release_date: Optional[str] = None
+        cle_eol: Optional[str] = None
+        upload_date = None
+        if selected_dist is not None:
+            upload_time = selected_dist.get("upload_time_iso_8601") or selected_dist.get("upload_time") or ""
+            if isinstance(upload_time, str) and upload_time.strip():
+                upload_date = upload_time.strip().split("T", 1)[0]
+                cle_release_date = upload_date
+        is_yanked = bool(info.get("yanked"))
+        if not is_yanked and selected_dist is not None:
+            is_yanked = bool(selected_dist.get("yanked"))
+        if is_yanked:
+            cle_eol = upload_date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
         logger.debug(f"Successfully fetched PyPI metadata for: {package_name}")
 
@@ -194,6 +235,12 @@ class PyPISource:
             field_sources["issue_tracker_url"] = self.name
         if distribution_filename:
             field_sources["distribution_filename"] = self.name
+        if distribution_hashes:
+            field_sources["hashes"] = self.name
+        if cle_release_date:
+            field_sources["cle_release_date"] = self.name
+        if cle_eol:
+            field_sources["cle_eol"] = self.name
 
         return NormalizedMetadata(
             description=info.get("summary"),
@@ -208,6 +255,9 @@ class PyPISource:
             maintainer_name=maintainer_name,
             maintainer_email=maintainer_email,
             distribution_filename=distribution_filename,
+            hashes=distribution_hashes,
+            cle_release_date=cle_release_date,
+            cle_eol=cle_eol,
             source=self.name,
             field_sources=field_sources,
         )

--- a/sbomify_action/_enrichment/sources/pypi.py
+++ b/sbomify_action/_enrichment/sources/pypi.py
@@ -117,17 +117,25 @@ class PyPISource:
             # party parser or the HTTP client behaving a specific way.
             raw_name = purl.name or ""
             raw_version = purl.version or ""
-            if "/" in raw_name or ".." in raw_name:
+            # Path-traversal tokens in name/version could rewrite the
+            # request URL after `requests` normalises raw "../.." segments.
+            # ":" is additionally refused: PEP 440 forbids ":" in a
+            # canonical version, and allowing it would let a crafted PURL
+            # like `pkg:pypi/foo@:latest` build a cache key that collides
+            # with the name-only `::latest` sentinel slot.
+            if "/" in raw_name or ".." in raw_name or ":" in raw_name:
                 logger.warning(
-                    f"Refusing PyPI fetch for PURL with path-traversal tokens in name: {raw_name!r} "
-                    f"(rejected because the name contains '/' or '..' which could rewrite the request URL)"
+                    f"Refusing PyPI fetch for PURL with unsafe tokens in name: {raw_name!r} "
+                    f"(rejected because the name contains '/', '..' or ':' which could "
+                    f"rewrite the request URL or collide with an internal cache key)"
                 )
                 _cache[cache_key] = None
                 return None
-            if "/" in raw_version or ".." in raw_version:
+            if "/" in raw_version or ".." in raw_version or ":" in raw_version:
                 logger.warning(
-                    f"Refusing PyPI fetch for PURL with path-traversal tokens in version: {raw_version!r} "
-                    f"(rejected because the version contains '/' or '..' which could rewrite the request URL)"
+                    f"Refusing PyPI fetch for PURL with unsafe tokens in version: {raw_version!r} "
+                    f"(rejected because the version contains '/', '..' or ':' which could "
+                    f"rewrite the request URL or collide with an internal cache key)"
                 )
                 _cache[cache_key] = None
                 return None

--- a/sbomify_action/_enrichment/sources/pypi.py
+++ b/sbomify_action/_enrichment/sources/pypi.py
@@ -96,9 +96,20 @@ class PyPISource:
         Returns:
             NormalizedMetadata if successful, None otherwise
         """
-        # Include version in cache key for version-specific lookups
-        version = purl.version or "latest"
-        cache_key = f"pypi:{purl.name}:{version}"
+        # Include version in cache key for version-specific lookups.
+        #
+        # Versionless fetches share the same slot as the 404-fallback latest
+        # lookup so a version-first request that 404s can reuse a prior
+        # versionless hit (and vice versa), saving one redundant GET. Both
+        # write to ``pypi:<name>::latest`` (the ``_LATEST_CACHE_SUFFIX``
+        # sentinel) rather than diverging into ``pypi:<name>:latest`` and
+        # ``pypi:<name>::latest`` respectively. The ``:`` character is
+        # forbidden in PURL name/version below, so the sentinel can't be
+        # forged from an inbound PURL.
+        if purl.version:
+            cache_key = f"pypi:{purl.name}:{purl.version}"
+        else:
+            cache_key = f"pypi:{purl.name}{_LATEST_CACHE_SUFFIX}"
 
         # Check cache
         if cache_key in _cache:
@@ -117,25 +128,34 @@ class PyPISource:
             # party parser or the HTTP client behaving a specific way.
             raw_name = purl.name or ""
             raw_version = purl.version or ""
+
             # Path-traversal tokens in name/version could rewrite the
             # request URL after `requests` normalises raw "../.." segments.
-            # ":" is additionally refused: PEP 440 forbids ":" in a
-            # canonical version, and allowing it would let a crafted PURL
-            # like `pkg:pypi/foo@:latest` build a cache key that collides
-            # with the name-only `::latest` sentinel slot.
-            if "/" in raw_name or ".." in raw_name or ":" in raw_name:
+            # Names: PEP 503 allows "." and "_" inside a normalised project
+            # name (so "a..b" is a legal-but-unusual name). Reject only
+            # actual path separators ("/", "\\") and the whole-name
+            # dot-segments ("." / ".."). The ":" character is refused too
+            # because an inbound ":" in the name could construct the
+            # `::latest` cache sentinel below.
+            # Versions: PEP 440 forbids "/", "\\", "..", and ":" in a
+            # canonical version, so enforce all of them directly.
+            def _is_dot_segment(value: str) -> bool:
+                return value in {".", ".."}
+
+            if "/" in raw_name or "\\" in raw_name or ":" in raw_name or _is_dot_segment(raw_name):
                 logger.warning(
                     f"Refusing PyPI fetch for PURL with unsafe tokens in name: {raw_name!r} "
-                    f"(rejected because the name contains '/', '..' or ':' which could "
-                    f"rewrite the request URL or collide with an internal cache key)"
+                    f"(rejected because the name contains '/', '\\', ':' or is a whole "
+                    f"dot-segment, which could rewrite the request URL or collide with an "
+                    f"internal cache key)"
                 )
                 _cache[cache_key] = None
                 return None
-            if "/" in raw_version or ".." in raw_version or ":" in raw_version:
+            if "/" in raw_version or "\\" in raw_version or ".." in raw_version or ":" in raw_version:
                 logger.warning(
                     f"Refusing PyPI fetch for PURL with unsafe tokens in version: {raw_version!r} "
-                    f"(rejected because the version contains '/', '..' or ':' which could "
-                    f"rewrite the request URL or collide with an internal cache key)"
+                    f"(rejected because the version contains '/', '\\', '..' or ':' which "
+                    f"could rewrite the request URL or collide with an internal cache key)"
                 )
                 _cache[cache_key] = None
                 return None

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -2279,9 +2279,13 @@ def cli(
     # Mirror --docker-image into the environment so the DockerImageProvider
     # (which reads DOCKER_IMAGE) sets lifecycle_phase=post-build even when
     # the user passed the flag on the CLI rather than via the env var.
-    # The typer envvar binding only reads env → flag; it does not write
-    # flag → env.
-    if docker_image and not os.getenv("DOCKER_IMAGE"):
+    # Click's envvar binding only reads env → option; it does not write
+    # option → env. Always overwrite when docker_image is provided — if
+    # the user passes a --docker-image that differs from the existing
+    # DOCKER_IMAGE env var, the flag must win (Click already resolved
+    # the two, so docker_image here is the effective value) and
+    # downstream logging must reflect the image that is actually scanned.
+    if docker_image:
         os.environ["DOCKER_IMAGE"] = docker_image
 
     print_banner()

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -2276,6 +2276,14 @@ def cli(
     # Reset audit trail for this run
     reset_audit_trail()
 
+    # Mirror --docker-image into the environment so the DockerImageProvider
+    # (which reads DOCKER_IMAGE) sets lifecycle_phase=post-build even when
+    # the user passed the flag on the CLI rather than via the env var.
+    # The typer envvar binding only reads env → flag; it does not write
+    # flag → env.
+    if docker_image and not os.getenv("DOCKER_IMAGE"):
+        os.environ["DOCKER_IMAGE"] = docker_image
+
     print_banner()
 
     # Setup dependencies

--- a/sbomify_action/enrichment.py
+++ b/sbomify_action/enrichment.py
@@ -625,6 +625,15 @@ _HASH_HEX_LENGTHS: Dict[str, int] = {
     "sha3-256": 64,
     "sha3-384": 96,
     "sha3-512": 128,
+    # Both PyPI underscore variants (warehouse legacy.py emits
+    # `blake2b_256`) and the canonical hyphen form — keep the two
+    # maps mutually consistent with _CYCLONEDX_HASH_ALGORITHMS /
+    # _SPDX_CHECKSUM_ALGORITHMS. Missing an entry here silently falls
+    # back to the presence-only "unknown algorithm" branch, which
+    # would accept a 4-char or 80-char hex payload as a valid hash.
+    "blake2b_256": 64,
+    "blake2b_384": 96,
+    "blake2b_512": 128,
     "blake2b-256": 64,
     "blake2b-384": 96,
     "blake2b-512": 128,

--- a/sbomify_action/enrichment.py
+++ b/sbomify_action/enrichment.py
@@ -422,16 +422,6 @@ _BSI_EXECUTABLE_SUFFIXES = (
     ".dylib",
 )
 
-# Component types that BSI treats as non-executable source/document bundles.
-# Used when no filename is available.
-_BSI_NON_EXECUTABLE_TYPES = {
-    ComponentType.DATA,
-    ComponentType.FILE,
-    ComponentType.LIBRARY,
-    ComponentType.FRAMEWORK,
-    ComponentType.MACHINE_LEARNING_MODEL,
-}
-
 # Strongly-typed components that carry enough semantics for BSI derivation
 # without a distribution filename. Hoisted to module scope so the same
 # tuple isn't rebuilt on every component in the enrichment loop.
@@ -456,7 +446,15 @@ def _apply_bsi_derived_properties(component: Component, metadata: NormalizedMeta
 
     - bsi:component:executable   "executable" | "non-executable"
     - bsi:component:archive      "archive" | "no archive"
-    - bsi:component:structured   "structured" | "unstructured"
+    - bsi:component:structured   emitted only as "structured" — any
+                                 component that reaches derivation has a
+                                 distribution filename or a strongly-typed
+                                 packaging semantics, both of which imply
+                                 an identifiable, parseable artefact per
+                                 BSI §8.1.6. We don't have a reliable
+                                 signal to emit "unstructured", so we
+                                 leave that classification to operator
+                                 input rather than guess.
 
     Derivation only triggers when we have a clear signal:
     - A distribution filename (filename extension drives archive/executable),

--- a/sbomify_action/enrichment.py
+++ b/sbomify_action/enrichment.py
@@ -517,14 +517,28 @@ def _apply_bsi_derived_properties(component: Component, metadata: NormalizedMeta
     # --- structured ---
     # Packaged software artefacts (wheels, jars, debs, containers, firmware
     # images) all carry metadata files, so they qualify as "structured" per
-    # BSI §8.1.6. Only emit when the component genuinely looks packaged:
-    # either an archive/executable signal was derived above, or the
-    # component type is in `_BSI_DEPLOYABLE_TYPES` (application, container,
-    # firmware, OS). A bare `library` with an unrecognised filename suffix
-    # is ambiguous and gets nothing — per the docstring contract, we do
-    # not guess "structured" from weak signals.
+    # BSI §8.1.6. Base the signal on the component's inherent shape, not on
+    # whether this invocation happened to add archive/executable:
+    #   1. A recognised filename suffix (archive OR executable) → structured.
+    #   2. An existing bsi:component:archive / bsi:component:executable
+    #      property already on the component (operator-supplied) → structured.
+    #   3. A deployable component type (application / container / firmware /
+    #      operating-system) → structured.
+    # A bare `library` with an unrecognised filename suffix and no
+    # operator-supplied archive/executable hints is ambiguous and gets
+    # nothing — per the docstring contract, we do not guess "structured"
+    # from weak signals.
+    has_recognised_filename = bool(filename) and (
+        _filename_suffix_matches(filename, _BSI_ARCHIVE_SUFFIXES)
+        or _filename_suffix_matches(filename, _BSI_EXECUTABLE_SUFFIXES)
+    )
+    operator_has_archive_exec = "bsi:component:archive" in existing or "bsi:component:executable" in existing
     has_structured_signal = bool(
-        archive_value is not None or exec_value is not None or component_type in _BSI_DEPLOYABLE_TYPES
+        has_recognised_filename
+        or operator_has_archive_exec
+        or archive_value is not None
+        or exec_value is not None
+        or component_type in _BSI_DEPLOYABLE_TYPES
     )
     if "bsi:component:structured" not in existing and has_structured_signal:
         component.properties.add(Property(name="bsi:component:structured", value="structured"))
@@ -721,6 +735,19 @@ def _apply_metadata_to_cyclonedx_component(
     added_fields = []
     audit_trail = get_audit_trail()
     purl_str = str(component.purl) if component.purl else component.name
+
+    # `Component.properties` / `.licenses` / `.external_references` can be
+    # `None` on deserialised or user-constructed components. The enrichment
+    # path below iterates/adds to all three, so normalise them up-front
+    # rather than scattering `is None` guards across every branch. Plain
+    # `set()` matches `_hash_enrichment/enricher.py` and avoids relying on
+    # the transitive `sortedcontainers` default.
+    if component.properties is None:
+        component.properties = set()
+    if component.licenses is None:
+        component.licenses = set()
+    if component.external_references is None:
+        component.external_references = set()
 
     # Description (sanitized)
     if not component.description and metadata.description:

--- a/sbomify_action/enrichment.py
+++ b/sbomify_action/enrichment.py
@@ -55,7 +55,7 @@ import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from cyclonedx.model import ExternalReference, ExternalReferenceType, Property, XsUri
+from cyclonedx.model import ExternalReference, ExternalReferenceType, HashAlgorithm, HashType, Property, XsUri
 from cyclonedx.model.bom import Bom
 from cyclonedx.model.component import Component, ComponentType
 from cyclonedx.model.contact import OrganizationalContact, OrganizationalEntity
@@ -63,6 +63,8 @@ from cyclonedx.model.license import LicenseAcknowledgement, LicenseExpression
 from spdx_tools.spdx.model import (  # type: ignore[attr-defined]
     Actor,
     ActorType,
+    Checksum,
+    ChecksumAlgorithm,
     Document,
     ExternalPackageRef,
     ExternalPackageRefCategory,
@@ -515,6 +517,96 @@ def _apply_bsi_derived_properties(component: Component, metadata: NormalizedMeta
     return added
 
 
+# Map SPDX-style algorithm names (PyPI digest keys) to CycloneDX HashAlgorithm.
+# The CycloneDX taxonomy uses upper-case SHA-256 etc.; the PyPI JSON API and
+# SPDX checksum fields use lower-case sha256 etc. We normalise to the enum.
+_CYCLONEDX_HASH_ALGORITHMS: Dict[str, HashAlgorithm] = {
+    "md5": HashAlgorithm.MD5,
+    "sha1": HashAlgorithm.SHA_1,
+    "sha-1": HashAlgorithm.SHA_1,
+    "sha256": HashAlgorithm.SHA_256,
+    "sha-256": HashAlgorithm.SHA_256,
+    "sha384": HashAlgorithm.SHA_384,
+    "sha-384": HashAlgorithm.SHA_384,
+    "sha512": HashAlgorithm.SHA_512,
+    "sha-512": HashAlgorithm.SHA_512,
+    "sha3-256": HashAlgorithm.SHA3_256,
+    "sha3-384": HashAlgorithm.SHA3_384,
+    "sha3-512": HashAlgorithm.SHA3_512,
+    "blake2b-256": HashAlgorithm.BLAKE2B_256,
+    "blake2b-384": HashAlgorithm.BLAKE2B_384,
+    "blake2b-512": HashAlgorithm.BLAKE2B_512,
+    "blake3": HashAlgorithm.BLAKE3,
+}
+
+
+# SPDX ChecksumAlgorithm mapping — superset of CycloneDX since SPDX has
+# SHA-224, MD2/MD4/MD6 and ADLER32 in addition.
+_SPDX_CHECKSUM_ALGORITHMS: Dict[str, ChecksumAlgorithm] = {
+    "md5": ChecksumAlgorithm.MD5,
+    "sha1": ChecksumAlgorithm.SHA1,
+    "sha-1": ChecksumAlgorithm.SHA1,
+    "sha224": ChecksumAlgorithm.SHA224,
+    "sha-224": ChecksumAlgorithm.SHA224,
+    "sha256": ChecksumAlgorithm.SHA256,
+    "sha-256": ChecksumAlgorithm.SHA256,
+    "sha384": ChecksumAlgorithm.SHA384,
+    "sha-384": ChecksumAlgorithm.SHA384,
+    "sha512": ChecksumAlgorithm.SHA512,
+    "sha-512": ChecksumAlgorithm.SHA512,
+    "sha3-256": ChecksumAlgorithm.SHA3_256,
+    "sha3-384": ChecksumAlgorithm.SHA3_384,
+    "sha3-512": ChecksumAlgorithm.SHA3_512,
+    "blake2b-256": ChecksumAlgorithm.BLAKE2B_256,
+    "blake2b-384": ChecksumAlgorithm.BLAKE2B_384,
+    "blake2b-512": ChecksumAlgorithm.BLAKE2B_512,
+    "blake3": ChecksumAlgorithm.BLAKE3,
+}
+
+
+def _apply_spdx_checksums(package: Package, hashes: Dict[str, str]) -> List[str]:
+    """Add distribution-artefact checksums to an SPDX package."""
+    added: List[str] = []
+    existing = {(c.algorithm, (c.value or "").lower()) for c in (package.checksums or [])}
+    for raw_alg, raw_value in hashes.items():
+        alg_key = raw_alg.strip().lower()
+        spdx_alg = _SPDX_CHECKSUM_ALGORITHMS.get(alg_key)
+        if spdx_alg is None:
+            continue
+        value = (raw_value or "").strip().lower()
+        if not value:
+            continue
+        if (spdx_alg, value) in existing:
+            continue
+        package.checksums.append(Checksum(algorithm=spdx_alg, value=value))
+        added.append(f"checksum:{alg_key}")
+        existing.add((spdx_alg, value))
+    return added
+
+
+def _apply_component_hashes(component: Component, hashes: Dict[str, str]) -> List[str]:
+    """Add distribution-artefact hashes to a CycloneDX component from a
+    `{algorithm: hex}` map. Only recognised algorithms are emitted; the
+    same (alg, content) pair is not duplicated across enrichment runs.
+    """
+    added: List[str] = []
+    existing = {(str(h.alg), str(h.content).lower()) for h in component.hashes}
+    for raw_alg, raw_value in hashes.items():
+        alg_key = raw_alg.strip().lower()
+        cdx_alg = _CYCLONEDX_HASH_ALGORITHMS.get(alg_key)
+        if cdx_alg is None:
+            continue
+        value = (raw_value or "").strip().lower()
+        if not value:
+            continue
+        if (str(cdx_alg), value) in existing:
+            continue
+        component.hashes.add(HashType(alg=cdx_alg, content=value))
+        added.append(f"hash:{alg_key}")
+        existing.add((str(cdx_alg), value))
+    return added
+
+
 def _apply_metadata_to_cyclonedx_component(
     component: Component, metadata: NormalizedMetadata, source: str = "unknown"
 ) -> List[str]:
@@ -583,6 +675,12 @@ def _apply_metadata_to_cyclonedx_component(
     # BSI-compliant SBOMs don't require every generator to emit these by hand.
     _added_bsi = _apply_bsi_derived_properties(component, metadata)
     added_fields.extend(_added_bsi)
+
+    # Hashes (NTIA / BSI §5.2.2 / CISA "Component Hash"). Only add algorithms
+    # we recognise and that aren't already on the component.
+    if metadata.hashes:
+        _added_hashes = _apply_component_hashes(component, metadata.hashes)
+        added_fields.extend(_added_hashes)
 
     # Manufacturer - component creator with email for BSI TR-03183-2 compliance.
     # Uses maintainer_name + maintainer_email from PyPI author/author_email fields.
@@ -711,6 +809,12 @@ def _apply_metadata_to_spdx_package(
         if sanitized_download:
             package.download_location = sanitized_download
             added_fields.append("downloadLocation")
+
+    # Checksums (NTIA / BSI §5.2.2 / CISA "Component Hash"). SPDX 2.x uses
+    # package.checksums with a ChecksumAlgorithm enum.
+    if metadata.hashes:
+        _added_sums = _apply_spdx_checksums(package, metadata.hashes)
+        added_fields.extend(_added_sums)
 
     # Licenses (sanitized) - use helper to avoid boolean evaluation of LicenseExpression
     if _is_spdx_license_empty(package.license_declared) and metadata.licenses:

--- a/sbomify_action/enrichment.py
+++ b/sbomify_action/enrichment.py
@@ -61,7 +61,6 @@ from cyclonedx.model.bom import Bom
 from cyclonedx.model.component import Component, ComponentType
 from cyclonedx.model.contact import OrganizationalContact, OrganizationalEntity
 from cyclonedx.model.license import LicenseAcknowledgement, LicenseExpression
-from sortedcontainers import SortedSet
 from spdx_tools.spdx.model import (  # type: ignore[attr-defined]
     Actor,
     ActorType,
@@ -470,6 +469,12 @@ def _apply_bsi_derived_properties(component: Component, metadata: NormalizedMeta
     Returns the list of property names that were added (for audit trail).
     """
     added: List[str] = []
+    # `Component.properties` can be None on deserialised or user-constructed
+    # components (see _enrich_os_component which already handles this).
+    # Initialise with a plain `set()` so the subsequent `.add()` calls work
+    # without depending on `sortedcontainers`.
+    if component.properties is None:
+        component.properties = set()
     existing = {prop.name for prop in component.properties}
     filename = (metadata.distribution_filename or "").strip()
     component_type = getattr(component, "type", None)
@@ -480,8 +485,8 @@ def _apply_bsi_derived_properties(component: Component, metadata: NormalizedMeta
         return added
 
     # --- archive ---
+    archive_value: Optional[str] = None
     if "bsi:component:archive" not in existing:
-        archive_value: Optional[str] = None
         if filename and _filename_suffix_matches(filename, _BSI_ARCHIVE_SUFFIXES):
             archive_value = "archive"
         elif filename and _filename_suffix_matches(filename, _BSI_EXECUTABLE_SUFFIXES):
@@ -496,8 +501,8 @@ def _apply_bsi_derived_properties(component: Component, metadata: NormalizedMeta
             added.append("bsi:component:archive")
 
     # --- executable ---
+    exec_value: Optional[str] = None
     if "bsi:component:executable" not in existing:
-        exec_value: Optional[str] = None
         if filename and _filename_suffix_matches(filename, _BSI_EXECUTABLE_SUFFIXES):
             exec_value = "executable"
         elif component_type in _BSI_DEPLOYABLE_TYPES:
@@ -512,8 +517,16 @@ def _apply_bsi_derived_properties(component: Component, metadata: NormalizedMeta
     # --- structured ---
     # Packaged software artefacts (wheels, jars, debs, containers, firmware
     # images) all carry metadata files, so they qualify as "structured" per
-    # BSI §8.1.6.
-    if "bsi:component:structured" not in existing:
+    # BSI §8.1.6. Only emit when the component genuinely looks packaged:
+    # either an archive/executable signal was derived above, or the
+    # component type is in `_BSI_DEPLOYABLE_TYPES` (application, container,
+    # firmware, OS). A bare `library` with an unrecognised filename suffix
+    # is ambiguous and gets nothing — per the docstring contract, we do
+    # not guess "structured" from weak signals.
+    has_structured_signal = bool(
+        archive_value is not None or exec_value is not None or component_type in _BSI_DEPLOYABLE_TYPES
+    )
+    if "bsi:component:structured" not in existing and has_structured_signal:
         component.properties.add(Property(name="bsi:component:structured", value="structured"))
         added.append("bsi:component:structured")
 
@@ -660,15 +673,15 @@ def _apply_component_hashes(component: Component, hashes: Dict[str, str]) -> Lis
     content of the expected length are emitted; the same (alg, content)
     pair is not duplicated across enrichment runs.
 
-    `Component.hashes` defaults to an empty SortedSet in the CycloneDX
+    `Component.hashes` defaults to an empty collection in the CycloneDX
     library, but deserialised or user-constructed components may legitimately
-    have `hashes is None`. Mirror the `(component.hashes or [])` pattern
-    already in use in `_hash_enrichment/enricher.py` so enrichment does not
-    crash on such input.
+    have `hashes is None`. Initialise with a plain `set()` (matching
+    `_hash_enrichment/enricher.py`) so enrichment does not crash on such
+    input and does not depend on the transitive `sortedcontainers` package.
     """
     added: List[str] = []
     if component.hashes is None:
-        component.hashes = SortedSet()
+        component.hashes = set()
     existing = {(str(h.alg), str(h.content).lower()) for h in (component.hashes or [])}
     for raw_alg, raw_value in hashes.items():
         alg_key = raw_alg.strip().lower()

--- a/sbomify_action/enrichment.py
+++ b/sbomify_action/enrichment.py
@@ -61,6 +61,7 @@ from cyclonedx.model.bom import Bom
 from cyclonedx.model.component import Component, ComponentType
 from cyclonedx.model.contact import OrganizationalContact, OrganizationalEntity
 from cyclonedx.model.license import LicenseAcknowledgement, LicenseExpression
+from sortedcontainers import SortedSet
 from spdx_tools.spdx.model import (  # type: ignore[attr-defined]
     Actor,
     ActorType,
@@ -637,9 +638,17 @@ def _apply_component_hashes(component: Component, hashes: Dict[str, str]) -> Lis
     `{algorithm: hex}` map. Only recognised algorithms with valid hex
     content of the expected length are emitted; the same (alg, content)
     pair is not duplicated across enrichment runs.
+
+    `Component.hashes` defaults to an empty SortedSet in the CycloneDX
+    library, but deserialised or user-constructed components may legitimately
+    have `hashes is None`. Mirror the `(component.hashes or [])` pattern
+    already in use in `_hash_enrichment/enricher.py` so enrichment does not
+    crash on such input.
     """
     added: List[str] = []
-    existing = {(str(h.alg), str(h.content).lower()) for h in component.hashes}
+    if component.hashes is None:
+        component.hashes = SortedSet()
+    existing = {(str(h.alg), str(h.content).lower()) for h in (component.hashes or [])}
     for raw_alg, raw_value in hashes.items():
         alg_key = raw_alg.strip().lower()
         cdx_alg = _CYCLONEDX_HASH_ALGORITHMS.get(alg_key)
@@ -650,7 +659,10 @@ def _apply_component_hashes(component: Component, hashes: Dict[str, str]) -> Lis
             continue
         if (str(cdx_alg), value) in existing:
             continue
-        component.hashes.add(HashType(alg=cdx_alg, content=value))
+        # `component.hashes` is typed as Iterable[HashType] by the
+        # cyclonedx lib (the concrete default is SortedSet), so cast it
+        # locally to suppress mypy while preserving runtime behaviour.
+        component.hashes.add(HashType(alg=cdx_alg, content=value))  # type: ignore[union-attr]
         added.append(f"hash:{alg_key}")
         existing.add((str(cdx_alg), value))
     return added

--- a/sbomify_action/enrichment.py
+++ b/sbomify_action/enrichment.py
@@ -536,6 +536,14 @@ _CYCLONEDX_HASH_ALGORITHMS: Dict[str, HashAlgorithm] = {
     "sha3-256": HashAlgorithm.SHA3_256,
     "sha3-384": HashAlgorithm.SHA3_384,
     "sha3-512": HashAlgorithm.SHA3_512,
+    # PyPI's JSON API historically emits BLAKE2b digests under the
+    # `blake2b_256` key (underscore, not hyphen) — see pypi/warehouse
+    # legacy.py. Accept both forms so PyPI-enriched SBOMs don't silently
+    # drop their BLAKE2b hash. Hyphen is retained for other emitters
+    # that follow the canonical BLAKE2 naming.
+    "blake2b_256": HashAlgorithm.BLAKE2B_256,
+    "blake2b_384": HashAlgorithm.BLAKE2B_384,
+    "blake2b_512": HashAlgorithm.BLAKE2B_512,
     "blake2b-256": HashAlgorithm.BLAKE2B_256,
     "blake2b-384": HashAlgorithm.BLAKE2B_384,
     "blake2b-512": HashAlgorithm.BLAKE2B_512,
@@ -560,6 +568,10 @@ _SPDX_CHECKSUM_ALGORITHMS: Dict[str, ChecksumAlgorithm] = {
     "sha3-256": ChecksumAlgorithm.SHA3_256,
     "sha3-384": ChecksumAlgorithm.SHA3_384,
     "sha3-512": ChecksumAlgorithm.SHA3_512,
+    # PyPI underscore variants (see comment on the CDX mapping).
+    "blake2b_256": ChecksumAlgorithm.BLAKE2B_256,
+    "blake2b_384": ChecksumAlgorithm.BLAKE2B_384,
+    "blake2b_512": ChecksumAlgorithm.BLAKE2B_512,
     "blake2b-256": ChecksumAlgorithm.BLAKE2B_256,
     "blake2b-384": ChecksumAlgorithm.BLAKE2B_384,
     "blake2b-512": ChecksumAlgorithm.BLAKE2B_512,

--- a/sbomify_action/enrichment.py
+++ b/sbomify_action/enrichment.py
@@ -52,6 +52,7 @@ Plugin architecture is in sbomify_action/_enrichment/:
 
 import json
 import os
+import re as _re
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -431,6 +432,16 @@ _BSI_NON_EXECUTABLE_TYPES = {
     ComponentType.MACHINE_LEARNING_MODEL,
 }
 
+# Strongly-typed components that carry enough semantics for BSI derivation
+# without a distribution filename. Hoisted to module scope so the same
+# tuple isn't rebuilt on every component in the enrichment loop.
+_BSI_DEPLOYABLE_TYPES = (
+    ComponentType.APPLICATION,
+    ComponentType.CONTAINER,
+    ComponentType.FIRMWARE,
+    ComponentType.OPERATING_SYSTEM,
+)
+
 
 def _filename_suffix_matches(filename: str, suffixes: tuple[str, ...]) -> bool:
     """Case-insensitive suffix match that handles multi-part endings like .tar.gz."""
@@ -464,15 +475,8 @@ def _apply_bsi_derived_properties(component: Component, metadata: NormalizedMeta
     filename = (metadata.distribution_filename or "").strip()
     component_type = getattr(component, "type", None)
 
-    _DEPLOYABLE_TYPES = (
-        ComponentType.APPLICATION,
-        ComponentType.CONTAINER,
-        ComponentType.FIRMWARE,
-        ComponentType.OPERATING_SYSTEM,
-    )
-
     has_filename_signal = bool(filename)
-    has_type_signal = component_type in _DEPLOYABLE_TYPES
+    has_type_signal = component_type in _BSI_DEPLOYABLE_TYPES
     if not (has_filename_signal or has_type_signal):
         return added
 
@@ -497,7 +501,7 @@ def _apply_bsi_derived_properties(component: Component, metadata: NormalizedMeta
         exec_value: Optional[str] = None
         if filename and _filename_suffix_matches(filename, _BSI_EXECUTABLE_SUFFIXES):
             exec_value = "executable"
-        elif component_type in _DEPLOYABLE_TYPES:
+        elif component_type in _BSI_DEPLOYABLE_TYPES:
             exec_value = "executable"
         elif filename and _filename_suffix_matches(filename, _BSI_ARCHIVE_SUFFIXES):
             # Archive-packaged libraries are not themselves executable.
@@ -565,7 +569,12 @@ _SPDX_CHECKSUM_ALGORITHMS: Dict[str, ChecksumAlgorithm] = {
 
 
 def _apply_spdx_checksums(package: Package, hashes: Dict[str, str]) -> List[str]:
-    """Add distribution-artefact checksums to an SPDX package."""
+    """Add distribution-artefact checksums to an SPDX package.
+
+    Shares the same hex-length validation as the CycloneDX path so that
+    any non-hex or malformed payload is rejected rather than written out
+    verbatim.
+    """
     added: List[str] = []
     existing = {(c.algorithm, (c.value or "").lower()) for c in (package.checksums or [])}
     for raw_alg, raw_value in hashes.items():
@@ -574,7 +583,7 @@ def _apply_spdx_checksums(package: Package, hashes: Dict[str, str]) -> List[str]
         if spdx_alg is None:
             continue
         value = (raw_value or "").strip().lower()
-        if not value:
+        if not value or not _is_valid_hex_hash(alg_key, value):
             continue
         if (spdx_alg, value) in existing:
             continue
@@ -584,10 +593,52 @@ def _apply_spdx_checksums(package: Package, hashes: Dict[str, str]) -> List[str]
     return added
 
 
+# Pre-compiled hex check — restricts hash content to the characters the
+# schema actually allows. Length is checked separately via _HASH_HEX_LENGTHS
+# so a malicious / misbehaving source can't inject non-hex payloads (which
+# would land verbatim in the emitted SBOM otherwise).
+_HEX_RE = _re.compile(r"^[0-9a-f]+$")
+
+_HASH_HEX_LENGTHS: Dict[str, int] = {
+    "md5": 32,
+    "sha1": 40,
+    "sha-1": 40,
+    "sha224": 56,
+    "sha-224": 56,
+    "sha256": 64,
+    "sha-256": 64,
+    "sha384": 96,
+    "sha-384": 96,
+    "sha512": 128,
+    "sha-512": 128,
+    "sha3-256": 64,
+    "sha3-384": 96,
+    "sha3-512": 128,
+    "blake2b-256": 64,
+    "blake2b-384": 96,
+    "blake2b-512": 128,
+}
+
+
+def _is_valid_hex_hash(alg_key: str, value: str) -> bool:
+    """Return True if value is a lower-case hex string of the expected
+    length for the named algorithm. Unknown algorithms pass through the
+    format check (presence-only) so BLAKE3 and future additions still work."""
+    if not _HEX_RE.match(value):
+        return False
+    expected = _HASH_HEX_LENGTHS.get(alg_key)
+    if expected is None:
+        # For algorithms with no fixed expected length (e.g. BLAKE3),
+        # just require non-empty hex.
+        return len(value) > 0
+    return len(value) == expected
+
+
 def _apply_component_hashes(component: Component, hashes: Dict[str, str]) -> List[str]:
     """Add distribution-artefact hashes to a CycloneDX component from a
-    `{algorithm: hex}` map. Only recognised algorithms are emitted; the
-    same (alg, content) pair is not duplicated across enrichment runs.
+    `{algorithm: hex}` map. Only recognised algorithms with valid hex
+    content of the expected length are emitted; the same (alg, content)
+    pair is not duplicated across enrichment runs.
     """
     added: List[str] = []
     existing = {(str(h.alg), str(h.content).lower()) for h in component.hashes}
@@ -597,7 +648,7 @@ def _apply_component_hashes(component: Component, hashes: Dict[str, str]) -> Lis
         if cdx_alg is None:
             continue
         value = (raw_value or "").strip().lower()
-        if not value:
+        if not value or not _is_valid_hex_hash(alg_key, value):
             continue
         if (str(cdx_alg), value) in existing:
             continue

--- a/sbomify_action/enrichment.py
+++ b/sbomify_action/enrichment.py
@@ -53,13 +53,13 @@ Plugin architecture is in sbomify_action/_enrichment/:
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from cyclonedx.model import ExternalReference, ExternalReferenceType, Property, XsUri
 from cyclonedx.model.bom import Bom
 from cyclonedx.model.component import Component, ComponentType
 from cyclonedx.model.contact import OrganizationalContact, OrganizationalEntity
-from cyclonedx.model.license import LicenseExpression
+from cyclonedx.model.license import LicenseAcknowledgement, LicenseExpression
 from spdx_tools.spdx.model import (  # type: ignore[attr-defined]
     Actor,
     ActorType,
@@ -379,6 +379,142 @@ def _extract_packages_from_spdx(document: Document) -> List[Tuple[Package, str]]
     return packages
 
 
+# Filename suffixes that BSI TR-03183-2 §5.2.2 recognises as archives.
+# Covers common language-agnostic wheel / tarball / zip / container formats.
+_BSI_ARCHIVE_SUFFIXES = (
+    ".whl",
+    ".egg",
+    ".tar",
+    ".tar.gz",
+    ".tgz",
+    ".tar.bz2",
+    ".tbz2",
+    ".tar.xz",
+    ".txz",
+    ".zip",
+    ".jar",
+    ".war",
+    ".ear",
+    ".aar",
+    ".gem",
+    ".crate",
+    ".deb",
+    ".rpm",
+    ".apk",
+    ".nupkg",
+    ".pkg",
+    ".snap",
+)
+
+# Filename suffixes treated as stand-alone executables (not archives).
+# When one of these is the filename, executable == "executable".
+_BSI_EXECUTABLE_SUFFIXES = (
+    ".exe",
+    ".msi",
+    ".bin",
+    ".elf",
+    ".app",
+    ".dll",
+    ".so",
+    ".dylib",
+)
+
+# Component types that BSI treats as non-executable source/document bundles.
+# Used when no filename is available.
+_BSI_NON_EXECUTABLE_TYPES = {
+    ComponentType.DATA,
+    ComponentType.FILE,
+    ComponentType.LIBRARY,
+    ComponentType.FRAMEWORK,
+    ComponentType.MACHINE_LEARNING_MODEL,
+}
+
+
+def _filename_suffix_matches(filename: str, suffixes: tuple[str, ...]) -> bool:
+    """Case-insensitive suffix match that handles multi-part endings like .tar.gz."""
+    lowered = filename.lower()
+    return any(lowered.endswith(suffix) for suffix in suffixes)
+
+
+def _apply_bsi_derived_properties(component: Component, metadata: NormalizedMetadata) -> List[str]:
+    """Emit the three remaining BSI TR-03183-2 §5.2.2 boolean-style properties
+    when they can be derived unambiguously. Each property is only added when
+    absent — operator-supplied values always win.
+
+    - bsi:component:executable   "executable" | "non-executable"
+    - bsi:component:archive      "archive" | "no archive"
+    - bsi:component:structured   "structured" | "unstructured"
+
+    Derivation only triggers when we have a clear signal:
+    - A distribution filename (filename extension drives archive/executable),
+      OR
+    - A strongly-typed component (application/container/firmware/operating-system)
+      whose BSI semantics are unambiguous without a filename.
+
+    A plain `library` with no filename gets nothing added — there is no
+    reliable signal to distinguish a source tarball from a wheel from a
+    shared-library binary.
+
+    Returns the list of property names that were added (for audit trail).
+    """
+    added: List[str] = []
+    existing = {prop.name for prop in component.properties}
+    filename = (metadata.distribution_filename or "").strip()
+    component_type = getattr(component, "type", None)
+
+    _DEPLOYABLE_TYPES = (
+        ComponentType.APPLICATION,
+        ComponentType.CONTAINER,
+        ComponentType.FIRMWARE,
+        ComponentType.OPERATING_SYSTEM,
+    )
+
+    has_filename_signal = bool(filename)
+    has_type_signal = component_type in _DEPLOYABLE_TYPES
+    if not (has_filename_signal or has_type_signal):
+        return added
+
+    # --- archive ---
+    if "bsi:component:archive" not in existing:
+        archive_value: Optional[str] = None
+        if filename and _filename_suffix_matches(filename, _BSI_ARCHIVE_SUFFIXES):
+            archive_value = "archive"
+        elif filename and _filename_suffix_matches(filename, _BSI_EXECUTABLE_SUFFIXES):
+            archive_value = "no archive"
+        elif component_type in (ComponentType.CONTAINER, ComponentType.FIRMWARE):
+            archive_value = "archive"
+        elif component_type in (ComponentType.APPLICATION, ComponentType.OPERATING_SYSTEM):
+            # Installed OS / running application is not itself an archive.
+            archive_value = "no archive"
+        if archive_value is not None:
+            component.properties.add(Property(name="bsi:component:archive", value=archive_value))
+            added.append("bsi:component:archive")
+
+    # --- executable ---
+    if "bsi:component:executable" not in existing:
+        exec_value: Optional[str] = None
+        if filename and _filename_suffix_matches(filename, _BSI_EXECUTABLE_SUFFIXES):
+            exec_value = "executable"
+        elif component_type in _DEPLOYABLE_TYPES:
+            exec_value = "executable"
+        elif filename and _filename_suffix_matches(filename, _BSI_ARCHIVE_SUFFIXES):
+            # Archive-packaged libraries are not themselves executable.
+            exec_value = "non-executable"
+        if exec_value is not None:
+            component.properties.add(Property(name="bsi:component:executable", value=exec_value))
+            added.append("bsi:component:executable")
+
+    # --- structured ---
+    # Packaged software artefacts (wheels, jars, debs, containers, firmware
+    # images) all carry metadata files, so they qualify as "structured" per
+    # BSI §8.1.6.
+    if "bsi:component:structured" not in existing:
+        component.properties.add(Property(name="bsi:component:structured", value="structured"))
+        added.append("bsi:component:structured")
+
+    return added
+
+
 def _apply_metadata_to_cyclonedx_component(
     component: Component, metadata: NormalizedMetadata, source: str = "unknown"
 ) -> List[str]:
@@ -406,7 +542,9 @@ def _apply_metadata_to_cyclonedx_component(
             component.description = sanitized_desc
             added_fields.append("description")
 
-    # Licenses (sanitized)
+    # Licenses (sanitized) — marked as "declared" because enrichment pulls
+    # the licence straight from the upstream registry (PyPI trove classifier,
+    # package metadata, etc.), which is BSI §5.2.4's "original licence".
     has_licenses = component.licenses is not None and len(component.licenses) > 0
     if not has_licenses and metadata.licenses:
         sanitized_licenses: list[str] = [s for lic in metadata.licenses if (s := sanitize_license(lic)) is not None]
@@ -415,7 +553,10 @@ def _apply_metadata_to_cyclonedx_component(
                 license_expression = sanitized_licenses[0]
             else:
                 license_expression = " OR ".join(sanitized_licenses)
-            license_expr = LicenseExpression(value=license_expression)
+            license_expr = LicenseExpression(
+                value=license_expression,
+                acknowledgement=LicenseAcknowledgement.DECLARED,
+            )
             component.licenses.add(license_expr)
             added_fields.append("license")
 
@@ -436,6 +577,12 @@ def _apply_metadata_to_cyclonedx_component(
                 filename_prop = Property(name="bsi:component:filename", value=sanitized_fn)
                 component.properties.add(filename_prop)
                 added_fields.append("filename")
+
+    # BSI TR-03183-2 §5.2.2 derived properties: executable / archive / structured.
+    # Derive sensible defaults from component type and distribution filename so
+    # BSI-compliant SBOMs don't require every generator to emit these by hand.
+    _added_bsi = _apply_bsi_derived_properties(component, metadata)
+    added_fields.extend(_added_bsi)
 
     # Manufacturer - component creator with email for BSI TR-03183-2 compliance.
     # Uses maintainer_name + maintainer_email from PyPI author/author_email fields.

--- a/tests/test_augmentation_providers.py
+++ b/tests/test_augmentation_providers.py
@@ -1380,9 +1380,9 @@ class TestCliDockerImageEnvMirror:
     @staticmethod
     def _apply_mirror(docker_image):
         """Replicates the CLI's mirror logic verbatim so the test
-        doesn't have to spin up the full typer context.
+        doesn't have to spin up the full Click context.
         """
-        if docker_image and not os.getenv("DOCKER_IMAGE"):
+        if docker_image:
             os.environ["DOCKER_IMAGE"] = docker_image
 
     def test_flag_writes_env_when_env_not_set(self):
@@ -1392,13 +1392,17 @@ class TestCliDockerImageEnvMirror:
         self._apply_mirror("ubuntu:24.04")
         assert os.environ.get("DOCKER_IMAGE") == "ubuntu:24.04"
 
-    def test_existing_env_is_not_overwritten(self):
-        """If DOCKER_IMAGE is already set in the env (the CI invocation
-        path), the mirror must not clobber it — the envvar is the
-        source of truth when both are present."""
-        os.environ["DOCKER_IMAGE"] = "already:set"
-        self._apply_mirror("flag:value")
-        assert os.environ["DOCKER_IMAGE"] == "already:set"
+    def test_flag_overwrites_existing_env_for_consistency(self):
+        """Click already resolved CLI flag vs env var before the CLI
+        body runs, so ``docker_image`` here IS the effective value.
+        Mirror it unconditionally so the DockerImageProvider sees the
+        same image the rest of the pipeline scans — otherwise a user
+        who runs with a stale ``DOCKER_IMAGE=old:tag`` in the shell and
+        passes ``--docker-image new:tag`` would see the provider log
+        ``old:tag`` while the actual SBOM is generated from ``new:tag``."""
+        os.environ["DOCKER_IMAGE"] = "old:tag"
+        self._apply_mirror("new:tag")
+        assert os.environ["DOCKER_IMAGE"] == "new:tag"
 
     def test_none_flag_does_not_touch_env(self):
         """No flag and no env → mirror is a no-op, env stays absent."""

--- a/tests/test_augmentation_providers.py
+++ b/tests/test_augmentation_providers.py
@@ -1357,10 +1357,10 @@ class TestLifecyclePhaseSpdxCdxParity:
 class TestCliDockerImageEnvMirror:
     """Tests for the CLI's DOCKER_IMAGE env-mirror logic.
 
-    The typer ``envvar="DOCKER_IMAGE"`` binding reads env → flag, but
-    does not write flag → env. The CLI mirrors ``--docker-image`` into
-    the environment so the DockerImageProvider (which reads the env
-    var) sees the flag-form input. The logic is small and isolated,
+    Click's ``envvar="DOCKER_IMAGE"`` binding reads env → option, but
+    does not write option → env. The CLI mirrors ``--docker-image``
+    into the environment so the DockerImageProvider (which reads the
+    env var) sees the flag-form input. The logic is small and isolated,
     so test it directly rather than through the full CLI entrypoint.
     """
 

--- a/tests/test_augmentation_providers.py
+++ b/tests/test_augmentation_providers.py
@@ -928,10 +928,12 @@ class TestCreateDefaultRegistry:
         registry = create_default_registry()
         providers = registry.list_providers()
 
-        # 5 providers: json-config, github-actions, gitlab-ci, bitbucket-pipelines, sbomify-api
-        assert len(providers) == 5
+        # 6 providers: json-config, docker-image, github-actions,
+        # gitlab-ci, bitbucket-pipelines, sbomify-api
+        assert len(providers) == 6
         provider_names = [p["name"] for p in providers]
         assert "json-config" in provider_names
+        assert "docker-image" in provider_names
         assert "github-actions" in provider_names
         assert "gitlab-ci" in provider_names
         assert "bitbucket-pipelines" in provider_names
@@ -940,6 +942,7 @@ class TestCreateDefaultRegistry:
         # Verify priority ordering (lower = higher priority)
         priorities = {p["name"]: p["priority"] for p in providers}
         assert priorities["json-config"] == 10  # Highest priority
+        assert priorities["docker-image"] == 15  # Container-image input
         assert priorities["github-actions"] == 20
         assert priorities["gitlab-ci"] == 20
         assert priorities["bitbucket-pipelines"] == 20

--- a/tests/test_augmentation_providers.py
+++ b/tests/test_augmentation_providers.py
@@ -1,9 +1,12 @@
 """Tests for augmentation providers (JSON config and sbomify API)."""
 
 import json
+import os
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock, patch
+
+import pytest
 
 from sbomify_action._augmentation import (
     AugmentationMetadata,
@@ -947,6 +950,155 @@ class TestCreateDefaultRegistry:
         assert priorities["gitlab-ci"] == 20
         assert priorities["bitbucket-pipelines"] == 20
         assert priorities["sbomify-api"] == 50  # Lowest priority
+
+
+class TestLifecyclePhasePrecedence:
+    """End-to-end precedence tests for lifecycle_phase across the registry.
+
+    These pin the spec-correct defaults that the providers emit in
+    realistic input/environment combinations, so a future refactor can't
+    silently regress the CDX 1.7 meta:enum alignment (pre-build for
+    lockfile scans, post-build for built-image scans, build only when
+    the operator explicitly opts in via sbomify.json).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_cwd(self):
+        """Save and restore working directory around each test.
+
+        JsonConfigProvider reads ``sbomify.json`` from cwd, so these
+        tests ``chdir`` into an isolated tmpdir. Without this fixture
+        the chdir leaks into sibling tests and breaks anything that
+        relies on the real project cwd.
+        """
+        original = os.getcwd()
+        try:
+            yield
+        finally:
+            os.chdir(original)
+
+    def _registry_no_api(self):
+        """Registry without the sbomify-api provider so tests don't hit
+        the network. Returns the same 5 providers that actually decide
+        lifecycle_phase today."""
+        from sbomify_action._augmentation.providers import (
+            BitbucketPipelinesProvider,
+            DockerImageProvider,
+            GitHubActionsProvider,
+            GitLabCIProvider,
+            JsonConfigProvider,
+        )
+        from sbomify_action._augmentation.registry import ProviderRegistry
+
+        registry = ProviderRegistry()
+        registry.register(JsonConfigProvider())
+        registry.register(DockerImageProvider())
+        registry.register(GitHubActionsProvider())
+        registry.register(GitLabCIProvider())
+        registry.register(BitbucketPipelinesProvider())
+        return registry
+
+    def test_ci_lockfile_scan_defaults_to_pre_build(self):
+        """GitHub Actions env alone (no json config, no docker image)
+        yields pre-build — the schema-correct default for a lockfile /
+        manifest scan on CI."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)  # no sbomify.json here
+            env = {
+                "GITHUB_ACTIONS": "true",
+                "GITHUB_REPOSITORY": "owner/repo",
+                "GITHUB_SHA": "a" * 40,
+                "GITHUB_REF": "refs/heads/main",
+                "GITHUB_SERVER_URL": "https://github.com",
+            }
+            with patch.dict(os.environ, env, clear=True):
+                registry = self._registry_no_api()
+                metadata = registry.fetch_metadata()
+
+            assert metadata is not None
+            assert metadata.lifecycle_phase == "pre-build"
+
+    def test_docker_image_overrides_ci_default_to_post_build(self):
+        """DOCKER_IMAGE set alongside GITHUB_ACTIONS yields post-build.
+        DockerImageProvider (priority 15) wins over the CI providers
+        (priority 20) so a container-image scan lands in the correct
+        phase even when running on GitHub Actions."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            env = {
+                "GITHUB_ACTIONS": "true",
+                "GITHUB_REPOSITORY": "owner/repo",
+                "GITHUB_SHA": "a" * 40,
+                "GITHUB_REF": "refs/heads/main",
+                "GITHUB_SERVER_URL": "https://github.com",
+                "DOCKER_IMAGE": "ubuntu:24.04",
+            }
+            with patch.dict(os.environ, env, clear=True):
+                registry = self._registry_no_api()
+                metadata = registry.fetch_metadata()
+
+            assert metadata is not None
+            assert metadata.lifecycle_phase == "post-build"
+
+    def test_json_config_overrides_both_ci_and_docker(self):
+        """Operator-supplied sbomify.json (priority 10) is the final
+        word — operators who truly emit a BOM mid-compilation can
+        opt into ``lifecycle_phase="build"`` regardless of CI /
+        docker-image detection."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = Path(tmpdir) / "sbomify.json"
+            config_file.write_text(json.dumps({"lifecycle_phase": "build"}))
+            os.chdir(tmpdir)
+            env = {
+                "GITHUB_ACTIONS": "true",
+                "GITHUB_REPOSITORY": "owner/repo",
+                "GITHUB_SHA": "a" * 40,
+                "GITHUB_REF": "refs/heads/main",
+                "GITHUB_SERVER_URL": "https://github.com",
+                "DOCKER_IMAGE": "ubuntu:24.04",
+            }
+            with patch.dict(os.environ, env, clear=True):
+                registry = self._registry_no_api()
+                metadata = registry.fetch_metadata()
+
+            assert metadata is not None
+            assert metadata.lifecycle_phase == "build"
+
+    def test_gitlab_defaults_to_pre_build(self):
+        """Same spec-alignment applies to GitLab CI and Bitbucket
+        Pipelines — parametrise-style coverage without the pytest
+        parametrise boilerplate since patch.dict with different
+        env sets doesn't compose cleanly as parameters."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            env = {
+                "GITLAB_CI": "true",
+                "CI_PROJECT_URL": "https://gitlab.com/group/proj",
+                "CI_COMMIT_SHA": "a" * 40,
+                "CI_COMMIT_REF_NAME": "main",
+            }
+            with patch.dict(os.environ, env, clear=True):
+                registry = self._registry_no_api()
+                metadata = registry.fetch_metadata()
+
+            assert metadata is not None
+            assert metadata.lifecycle_phase == "pre-build"
+
+    def test_bitbucket_defaults_to_pre_build(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            env = {
+                "BITBUCKET_PIPELINE_UUID": "{abc-123}",
+                "BITBUCKET_GIT_HTTP_ORIGIN": "https://bitbucket.org/ws/repo",
+                "BITBUCKET_COMMIT": "a" * 40,
+                "BITBUCKET_BRANCH": "main",
+            }
+            with patch.dict(os.environ, env, clear=True):
+                registry = self._registry_no_api()
+                metadata = registry.fetch_metadata()
+
+            assert metadata is not None
+            assert metadata.lifecycle_phase == "pre-build"
 
 
 class TestJsonConfigProviderIntegration:

--- a/tests/test_augmentation_providers.py
+++ b/tests/test_augmentation_providers.py
@@ -1100,6 +1100,136 @@ class TestLifecyclePhasePrecedence:
             assert metadata is not None
             assert metadata.lifecycle_phase == "pre-build"
 
+    def test_docker_image_alone_without_ci_still_emits_post_build(self):
+        """DOCKER_IMAGE set with no CI env vars and no sbomify.json must
+        still emit ``post-build`` — a user running the action locally
+        against a built image deserves the same spec-correct phase as
+        a CI run against the same image."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            env = {"DOCKER_IMAGE": "ubuntu:24.04"}
+            with patch.dict(os.environ, env, clear=True):
+                registry = self._registry_no_api()
+                metadata = registry.fetch_metadata()
+
+            assert metadata is not None
+            assert metadata.lifecycle_phase == "post-build"
+
+    def test_json_config_overrides_docker_image_without_ci(self):
+        """sbomify.json beats docker-image provider even without a CI
+        provider in the mix. Mirrors the real-world case where a user
+        is running locally and wants the container-image scan classified
+        as something other than ``post-build``."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = Path(tmpdir) / "sbomify.json"
+            config_file.write_text(json.dumps({"lifecycle_phase": "operations"}))
+            os.chdir(tmpdir)
+            env = {"DOCKER_IMAGE": "ubuntu:24.04"}
+            with patch.dict(os.environ, env, clear=True):
+                registry = self._registry_no_api()
+                metadata = registry.fetch_metadata()
+
+            assert metadata is not None
+            assert metadata.lifecycle_phase == "operations"
+
+    def test_no_input_signals_yields_no_lifecycle_phase(self):
+        """No CI env, no DOCKER_IMAGE, no sbomify.json → no provider
+        has a lifecycle_phase to contribute, so the merged metadata's
+        lifecycle_phase is None. The compliance plugins will then
+        correctly report "missing generation context" rather than
+        inventing a phase."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            with patch.dict(os.environ, {}, clear=True):
+                registry = self._registry_no_api()
+                metadata = registry.fetch_metadata()
+
+            # Registry may return None or a metadata object with no
+            # fields set — either signals "nothing to augment".
+            assert metadata is None or metadata.lifecycle_phase is None
+
+    def test_disable_vcs_augmentation_still_lets_docker_image_fire(self):
+        """DISABLE_VCS_AUGMENTATION only silences the CI providers' VCS
+        side of things; the DockerImageProvider (which doesn't touch
+        VCS metadata) must still emit its lifecycle_phase signal."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            env = {
+                "DISABLE_VCS_AUGMENTATION": "true",
+                "GITHUB_ACTIONS": "true",
+                "GITHUB_REPOSITORY": "owner/repo",
+                "GITHUB_SHA": "a" * 40,
+                "GITHUB_REF": "refs/heads/main",
+                "GITHUB_SERVER_URL": "https://github.com",
+                "DOCKER_IMAGE": "ubuntu:24.04",
+            }
+            with patch.dict(os.environ, env, clear=True):
+                registry = self._registry_no_api()
+                metadata = registry.fetch_metadata()
+
+            assert metadata is not None
+            assert metadata.lifecycle_phase == "post-build"
+
+
+class TestCliDockerImageEnvMirror:
+    """Tests for the CLI's DOCKER_IMAGE env-mirror logic.
+
+    The typer ``envvar="DOCKER_IMAGE"`` binding reads env → flag, but
+    does not write flag → env. The CLI mirrors ``--docker-image`` into
+    the environment so the DockerImageProvider (which reads the env
+    var) sees the flag-form input. The logic is small and isolated,
+    so test it directly rather than through the full CLI entrypoint.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_cwd_and_env(self):
+        original_cwd = os.getcwd()
+        original_docker = os.environ.get("DOCKER_IMAGE")
+        try:
+            yield
+        finally:
+            os.chdir(original_cwd)
+            if original_docker is None:
+                os.environ.pop("DOCKER_IMAGE", None)
+            else:
+                os.environ["DOCKER_IMAGE"] = original_docker
+
+    @staticmethod
+    def _apply_mirror(docker_image):
+        """Replicates the CLI's mirror logic verbatim so the test
+        doesn't have to spin up the full typer context.
+        """
+        if docker_image and not os.getenv("DOCKER_IMAGE"):
+            os.environ["DOCKER_IMAGE"] = docker_image
+
+    def test_flag_writes_env_when_env_not_set(self):
+        """--docker-image flag without DOCKER_IMAGE env set → env is
+        populated so the provider fires."""
+        os.environ.pop("DOCKER_IMAGE", None)
+        self._apply_mirror("ubuntu:24.04")
+        assert os.environ.get("DOCKER_IMAGE") == "ubuntu:24.04"
+
+    def test_existing_env_is_not_overwritten(self):
+        """If DOCKER_IMAGE is already set in the env (the CI invocation
+        path), the mirror must not clobber it — the envvar is the
+        source of truth when both are present."""
+        os.environ["DOCKER_IMAGE"] = "already:set"
+        self._apply_mirror("flag:value")
+        assert os.environ["DOCKER_IMAGE"] == "already:set"
+
+    def test_none_flag_does_not_touch_env(self):
+        """No flag and no env → mirror is a no-op, env stays absent."""
+        os.environ.pop("DOCKER_IMAGE", None)
+        self._apply_mirror(None)
+        assert "DOCKER_IMAGE" not in os.environ
+
+    def test_empty_flag_does_not_touch_env(self):
+        """Empty-string flag is not a valid image reference; treat it
+        as absent so the mirror does not shadow a later env lookup."""
+        os.environ.pop("DOCKER_IMAGE", None)
+        self._apply_mirror("")
+        assert "DOCKER_IMAGE" not in os.environ
+
 
 class TestJsonConfigProviderIntegration:
     """Integration tests for JSON config provider with augmentation."""

--- a/tests/test_augmentation_providers.py
+++ b/tests/test_augmentation_providers.py
@@ -1171,6 +1171,189 @@ class TestLifecyclePhasePrecedence:
             assert metadata.lifecycle_phase == "post-build"
 
 
+class TestLifecyclePhaseSpdxCdxParity:
+    """End-to-end parity tests: CI provider default → both SPDX and
+    CycloneDX outputs carry the same lifecycle phase.
+
+    The augmentation code writes the phase to different spec-native
+    locations:
+      * CycloneDX: ``metadata.lifecycles[].phase`` (1.5+)
+      * SPDX 2.x: ``creationInfo.creatorComment`` as ``"Lifecycle phase: <phase>"``
+
+    The sbomify CISA plugin reads both, so any drift between the two
+    paths would give the same BOM different compliance verdicts in
+    CDX vs SPDX. These tests pin the parity explicitly.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_cwd(self):
+        original = os.getcwd()
+        try:
+            yield
+        finally:
+            os.chdir(original)
+
+    def _fetch_from_registry(self, env):
+        """Run the real registry (minus sbomify-api) with ``env`` as
+        the only env vars and return the merged AugmentationMetadata."""
+        from sbomify_action._augmentation.providers import (
+            BitbucketPipelinesProvider,
+            DockerImageProvider,
+            GitHubActionsProvider,
+            GitLabCIProvider,
+            JsonConfigProvider,
+        )
+        from sbomify_action._augmentation.registry import ProviderRegistry
+
+        registry = ProviderRegistry()
+        registry.register(JsonConfigProvider())
+        registry.register(DockerImageProvider())
+        registry.register(GitHubActionsProvider())
+        registry.register(GitLabCIProvider())
+        registry.register(BitbucketPipelinesProvider())
+
+        with patch.dict(os.environ, env, clear=True):
+            return registry.fetch_metadata()
+
+    def _minimal_spdx_doc(self):
+        """Build a minimal SPDX 2.3 Document suitable for augmentation."""
+        from datetime import datetime
+
+        from spdx_tools.spdx.model import CreationInfo, Document, Package
+
+        return Document(
+            creation_info=CreationInfo(
+                spdx_version="SPDX-2.3",
+                spdx_id="SPDXRef-DOCUMENT",
+                name="test-parity-sbom",
+                document_namespace="https://example.com/parity",
+                creators=[],
+                created=datetime(2026, 4, 20, 12, 0, 0),
+            ),
+            packages=[
+                Package(
+                    spdx_id="SPDXRef-root",
+                    name="parity-app",
+                    download_location="https://example.com/download",
+                    version="1.0.0",
+                )
+            ],
+            relationships=[],
+        )
+
+    def _minimal_cdx_bom(self):
+        """Build a minimal CycloneDX 1.6 BOM suitable for augmentation."""
+        from cyclonedx.model.bom import Bom
+        from cyclonedx.model.component import Component, ComponentType
+
+        bom = Bom()
+        bom.metadata.component = Component(
+            name="parity-app",
+            version="1.0.0",
+            type=ComponentType.APPLICATION,
+            bom_ref="parity-app@1.0.0",
+        )
+        return bom
+
+    def test_github_ci_lockfile_writes_pre_build_to_both_formats(self):
+        """GitHub Actions + lockfile scan → both SPDX creatorComment
+        and CDX metadata.lifecycles[0].phase hold ``pre-build``."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            env = {
+                "GITHUB_ACTIONS": "true",
+                "GITHUB_REPOSITORY": "owner/repo",
+                "GITHUB_SHA": "a" * 40,
+                "GITHUB_REF": "refs/heads/main",
+                "GITHUB_SERVER_URL": "https://github.com",
+            }
+            metadata = self._fetch_from_registry(env)
+
+        assert metadata is not None
+        augmentation_data = metadata.to_dict()
+        assert augmentation_data["lifecycle_phase"] == "pre-build"
+
+        from sbomify_action.augmentation import augment_cyclonedx_sbom, augment_spdx_sbom
+
+        # CDX path
+        bom = self._minimal_cdx_bom()
+        augmented_bom = augment_cyclonedx_sbom(bom, augmentation_data, spec_version="1.6")
+        phases = [lc.phase.value for lc in augmented_bom.metadata.lifecycles if lc.phase is not None]
+        assert "pre-build" in phases, f"CDX lifecycles should carry pre-build; got {phases}"
+
+        # SPDX path
+        doc = self._minimal_spdx_doc()
+        augmented_doc = augment_spdx_sbom(doc, augmentation_data)
+        creator_comment = augmented_doc.creation_info.creator_comment or ""
+        assert "Lifecycle phase: pre-build" in creator_comment, (
+            f"SPDX creator comment should carry pre-build; got {creator_comment!r}"
+        )
+
+    def test_docker_image_writes_post_build_to_both_formats(self):
+        """``--docker-image`` on CI → both formats hold ``post-build``."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            env = {
+                "GITHUB_ACTIONS": "true",
+                "GITHUB_REPOSITORY": "owner/repo",
+                "GITHUB_SHA": "a" * 40,
+                "GITHUB_REF": "refs/heads/main",
+                "GITHUB_SERVER_URL": "https://github.com",
+                "DOCKER_IMAGE": "ubuntu:24.04",
+            }
+            metadata = self._fetch_from_registry(env)
+
+        assert metadata is not None
+        augmentation_data = metadata.to_dict()
+        assert augmentation_data["lifecycle_phase"] == "post-build"
+
+        from sbomify_action.augmentation import augment_cyclonedx_sbom, augment_spdx_sbom
+
+        bom = self._minimal_cdx_bom()
+        augmented_bom = augment_cyclonedx_sbom(bom, augmentation_data, spec_version="1.6")
+        phases = [lc.phase.value for lc in augmented_bom.metadata.lifecycles if lc.phase is not None]
+        assert "post-build" in phases
+
+        doc = self._minimal_spdx_doc()
+        augmented_doc = augment_spdx_sbom(doc, augmentation_data)
+        creator_comment = augmented_doc.creation_info.creator_comment or ""
+        assert "Lifecycle phase: post-build" in creator_comment
+
+    def test_json_config_override_writes_build_to_both_formats(self):
+        """Operator override via sbomify.json → both formats carry the
+        operator-chosen ``build`` value, confirming the merge order
+        survives all the way to the emitted BOM."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = Path(tmpdir) / "sbomify.json"
+            config_file.write_text(json.dumps({"lifecycle_phase": "build"}))
+            os.chdir(tmpdir)
+            env = {
+                "GITHUB_ACTIONS": "true",
+                "GITHUB_REPOSITORY": "owner/repo",
+                "GITHUB_SHA": "a" * 40,
+                "GITHUB_REF": "refs/heads/main",
+                "GITHUB_SERVER_URL": "https://github.com",
+                "DOCKER_IMAGE": "ubuntu:24.04",
+            }
+            metadata = self._fetch_from_registry(env)
+
+        assert metadata is not None
+        augmentation_data = metadata.to_dict()
+        assert augmentation_data["lifecycle_phase"] == "build"
+
+        from sbomify_action.augmentation import augment_cyclonedx_sbom, augment_spdx_sbom
+
+        bom = self._minimal_cdx_bom()
+        augmented_bom = augment_cyclonedx_sbom(bom, augmentation_data, spec_version="1.6")
+        phases = [lc.phase.value for lc in augmented_bom.metadata.lifecycles if lc.phase is not None]
+        assert "build" in phases
+
+        doc = self._minimal_spdx_doc()
+        augmented_doc = augment_spdx_sbom(doc, augmentation_data)
+        creator_comment = augmented_doc.creation_info.creator_comment or ""
+        assert "Lifecycle phase: build" in creator_comment
+
+
 class TestCliDockerImageEnvMirror:
     """Tests for the CLI's DOCKER_IMAGE env-mirror logic.
 

--- a/tests/test_ci_providers.py
+++ b/tests/test_ci_providers.py
@@ -126,7 +126,11 @@ class TestGitHubActionsProvider(unittest.TestCase):
         self.assertEqual(result.vcs_ref, "main")
         self.assertEqual(result.vcs_commit_url, "https://github.com/owner/repo/commit/abc123def456")
         self.assertEqual(result.source, "github-actions")
-        # CISA 2025 Generation Context defaults to "build" when running in CI
+        # CycloneDX 1.7 meta:enum aligns a CI lockfile / manifest scan
+        # with "pre-build" ("information obtained prior to a build
+        # process … may contain source files, development artifacts and
+        # manifests"). The DockerImageProvider overrides to "post-build"
+        # when DOCKER_IMAGE is set; json_config can still force anything.
         self.assertEqual(result.lifecycle_phase, "pre-build")
 
     @patch.dict(

--- a/tests/test_ci_providers.py
+++ b/tests/test_ci_providers.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from sbomify_action._augmentation.metadata import AugmentationMetadata
 from sbomify_action._augmentation.providers import (
     BitbucketPipelinesProvider,
+    DockerImageProvider,
     GitHubActionsProvider,
     GitLabCIProvider,
     is_vcs_augmentation_disabled,
@@ -126,7 +127,7 @@ class TestGitHubActionsProvider(unittest.TestCase):
         self.assertEqual(result.vcs_commit_url, "https://github.com/owner/repo/commit/abc123def456")
         self.assertEqual(result.source, "github-actions")
         # CISA 2025 Generation Context defaults to "build" when running in CI
-        self.assertEqual(result.lifecycle_phase, "build")
+        self.assertEqual(result.lifecycle_phase, "pre-build")
 
     @patch.dict(
         os.environ,
@@ -241,7 +242,7 @@ class TestGitLabCIProvider(unittest.TestCase):
         self.assertEqual(result.vcs_ref, "main")
         self.assertEqual(result.vcs_commit_url, "https://gitlab.com/owner/repo/-/commit/abc123def456")
         self.assertEqual(result.source, "gitlab-ci")
-        self.assertEqual(result.lifecycle_phase, "build")
+        self.assertEqual(result.lifecycle_phase, "pre-build")
 
     @patch.dict(
         os.environ,
@@ -328,7 +329,7 @@ class TestBitbucketPipelinesProvider(unittest.TestCase):
         self.assertEqual(result.vcs_ref, "main")
         self.assertEqual(result.vcs_commit_url, "https://bitbucket.org/owner/repo/commits/abc123def456")
         self.assertEqual(result.source, "bitbucket-pipelines")
-        self.assertEqual(result.lifecycle_phase, "build")
+        self.assertEqual(result.lifecycle_phase, "pre-build")
 
     @patch.dict(
         os.environ,
@@ -393,6 +394,39 @@ class TestBitbucketPipelinesProvider(unittest.TestCase):
         """Provider returns None when repository URL cannot be determined."""
         result = self.provider.fetch()
         self.assertIsNone(result)
+
+
+class TestDockerImageProvider(unittest.TestCase):
+    """Tests for the DockerImageProvider lifecycle-phase default."""
+
+    def setUp(self):
+        self.provider = DockerImageProvider()
+
+    def test_name_and_priority(self):
+        """Provider name is "docker-image", priority beats CI (20) and
+        loses to json_config (10)."""
+        self.assertEqual(self.provider.name, "docker-image")
+        self.assertEqual(self.provider.priority, 15)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_returns_none_when_docker_image_not_set(self):
+        """No DOCKER_IMAGE env var → provider yields no metadata."""
+        self.assertIsNone(self.provider.fetch())
+
+    @patch.dict(os.environ, {"DOCKER_IMAGE": "ubuntu:24.04"}, clear=True)
+    def test_emits_post_build_for_container_image(self):
+        """Scanning a built image is ``post-build`` per CDX 1.7
+        ``meta:enum`` for the lifecycle ``phase`` property."""
+        result = self.provider.fetch()
+        self.assertIsNotNone(result)
+        assert result is not None  # mypy
+        self.assertEqual(result.lifecycle_phase, "post-build")
+        self.assertEqual(result.source, "docker-image")
+
+    @patch.dict(os.environ, {"DOCKER_IMAGE": ""}, clear=True)
+    def test_empty_docker_image_env_yields_none(self):
+        """Empty string env var is treated as absent."""
+        self.assertIsNone(self.provider.fetch())
 
 
 class TestAugmentationMetadataVcsFields(unittest.TestCase):

--- a/tests/test_ci_providers.py
+++ b/tests/test_ci_providers.py
@@ -428,6 +428,47 @@ class TestDockerImageProvider(unittest.TestCase):
         """Empty string env var is treated as absent."""
         self.assertIsNone(self.provider.fetch())
 
+    @patch.dict(os.environ, {"DOCKER_IMAGE": "ubuntu:24.04"}, clear=True)
+    def test_emits_only_lifecycle_phase_no_other_fields(self):
+        """Provider must not touch vcs_url / authors / supplier / etc.
+        The CI providers own VCS metadata; json_config and sbomify-api
+        own org metadata; DockerImageProvider owns the single signal
+        that its input is a built artifact. Keeping it narrow prevents
+        surprise collisions in the merge."""
+        result = self.provider.fetch()
+        assert result is not None  # mypy
+        self.assertEqual(result.lifecycle_phase, "post-build")
+        # Explicit null-checks on every field the other providers set —
+        # so if someone broadens DockerImageProvider later, this test
+        # forces them to justify each addition.
+        self.assertIsNone(result.supplier)
+        self.assertIsNone(result.manufacturer)
+        self.assertIsNone(result.authors)
+        self.assertIsNone(result.licenses)
+        self.assertIsNone(result.vcs_url)
+        self.assertIsNone(result.vcs_commit_sha)
+        self.assertIsNone(result.vcs_ref)
+        self.assertIsNone(result.vcs_commit_url)
+        self.assertIsNone(result.security_contact)
+        self.assertIsNone(result.support_period_end)
+        self.assertIsNone(result.release_date)
+        self.assertIsNone(result.end_of_life)
+
+    @patch.dict(
+        os.environ,
+        {
+            "DOCKER_IMAGE": "registry.example.com/team/app:v1.2.3-arm64",
+        },
+        clear=True,
+    )
+    def test_accepts_arbitrary_image_reference_forms(self):
+        """The image string is not parsed — any non-empty value triggers
+        post-build. This keeps the provider robust across docker/podman/
+        OCI registry variants without baking in a reference parser."""
+        result = self.provider.fetch()
+        assert result is not None
+        self.assertEqual(result.lifecycle_phase, "post-build")
+
 
 class TestAugmentationMetadataVcsFields(unittest.TestCase):
     """Tests for VCS fields in AugmentationMetadata."""

--- a/tests/test_ci_providers.py
+++ b/tests/test_ci_providers.py
@@ -125,6 +125,8 @@ class TestGitHubActionsProvider(unittest.TestCase):
         self.assertEqual(result.vcs_ref, "main")
         self.assertEqual(result.vcs_commit_url, "https://github.com/owner/repo/commit/abc123def456")
         self.assertEqual(result.source, "github-actions")
+        # CISA 2025 Generation Context defaults to "build" when running in CI
+        self.assertEqual(result.lifecycle_phase, "build")
 
     @patch.dict(
         os.environ,
@@ -239,6 +241,7 @@ class TestGitLabCIProvider(unittest.TestCase):
         self.assertEqual(result.vcs_ref, "main")
         self.assertEqual(result.vcs_commit_url, "https://gitlab.com/owner/repo/-/commit/abc123def456")
         self.assertEqual(result.source, "gitlab-ci")
+        self.assertEqual(result.lifecycle_phase, "build")
 
     @patch.dict(
         os.environ,
@@ -325,6 +328,7 @@ class TestBitbucketPipelinesProvider(unittest.TestCase):
         self.assertEqual(result.vcs_ref, "main")
         self.assertEqual(result.vcs_commit_url, "https://bitbucket.org/owner/repo/commits/abc123def456")
         self.assertEqual(result.source, "bitbucket-pipelines")
+        self.assertEqual(result.lifecycle_phase, "build")
 
     @patch.dict(
         os.environ,

--- a/tests/test_enrichment_module.py
+++ b/tests/test_enrichment_module.py
@@ -3388,6 +3388,23 @@ class TestBSIEnrichmentFields:
         _apply_metadata_to_cyclonedx_component(component, metadata)
         assert len(list(component.hashes)) == 0
 
+    def test_component_hashes_initialised_when_hashes_is_none(self):
+        """Components deserialised from some inputs can legitimately have
+        `hashes is None`. The hash-enrichment path must initialise the
+        collection instead of iterating None (which would raise)."""
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+
+        component = Component(name="django", version="5.1", type=ComponentType.LIBRARY)
+        component.hashes = None  # type: ignore[assignment]
+        metadata = NormalizedMetadata(hashes={"sha256": "a" * 64})
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+
+        assert component.hashes is not None
+        hashes = list(component.hashes)
+        assert len(hashes) == 1
+        assert str(hashes[0].content) == "a" * 64
+
     def test_spdx_checksums_applied(self):
         from spdx_tools.spdx.model import Package, SpdxNoAssertion
 
@@ -3496,8 +3513,15 @@ class TestBSIEnrichmentFields:
         from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
 
         component = Component(name="x", version="1", type=ComponentType.LIBRARY)
-        # Script-injection attempt that happens to be 64 chars
-        payload = "<script>alert(1)</script>abcdef" + "0" * 34
+        # Exactly 64 characters but only hex up to "abcdef" plus zeros is NOT
+        # the point — this payload ALSO contains script-injection tokens, and
+        # we want the non-hex regex branch to reject it. The test-intent is
+        # "characters outside [0-9a-f] are refused", so we pin the payload
+        # length to the valid SHA-256 length and put the non-hex tokens up
+        # front. See test_spdx_hash_non_hex_characters_rejected for the
+        # cleaner "g" * 64 variant that isolates only the regex branch.
+        payload = "<script>alert(1)</script>abcdef" + "0" * 33  # len == 64
+        assert len(payload) == 64
         metadata = NormalizedMetadata(hashes={"sha256": payload})
         _apply_metadata_to_cyclonedx_component(component, metadata)
         assert len(list(component.hashes)) == 0

--- a/tests/test_enrichment_module.py
+++ b/tests/test_enrichment_module.py
@@ -831,6 +831,37 @@ class TestPyPISource:
         assert metadata is None
         assert not mock_session.get.called
 
+    def test_fetch_rejection_does_not_poison_latest_cache_sentinel(self, mock_session):
+        """Regression: a crafted version like ``":latest"`` used to yield
+        ``cache_key == "pypi:<name>::latest"`` — the same slot as the
+        internal ``_LATEST_CACHE_SUFFIX`` sentinel — and the unsafe-token
+        branch would cache ``None`` there, poisoning later legitimate
+        versionless fetches for the same name. The fix validates raw
+        name/version BEFORE building any cache key and returns ``None``
+        without writing to the cache."""
+        from sbomify_action._enrichment.sources import pypi as pypi_module
+
+        source = PyPISource()
+
+        class _Shim:
+            # `:` in the version bypasses PackageURL quoting — construct
+            # the attacker-controlled shape directly to make sure the fix
+            # holds regardless of parser normalisation.
+            name = "foo"
+            version = ":latest"
+
+        metadata = source.fetch(_Shim(), mock_session)  # type: ignore[arg-type]
+
+        assert metadata is None
+        assert not mock_session.get.called, "request must not be sent for unsafe PURLs"
+
+        # The fix: unsafe inputs do NOT populate the cache at all. The
+        # legitimate versionless sentinel slot must remain untouched.
+        sentinel_key = f"pypi:foo{pypi_module._LATEST_CACHE_SUFFIX}"
+        assert sentinel_key not in pypi_module._cache, (
+            "unsafe-version rejection must not poison the versionless cache sentinel"
+        )
+
     def test_fetch_encodes_special_characters_in_purl_components(self, mock_session):
         """Safe special characters survive but are percent-encoded in the URL,
         so `requests` cannot normalise them into path traversal."""

--- a/tests/test_enrichment_module.py
+++ b/tests/test_enrichment_module.py
@@ -400,6 +400,189 @@ class TestPyPISource:
             f"Expected 'Direct Author' from author field, got: {metadata.maintainer_name}"
         )
 
+    # ---------- Per-file hash + yanked + release-date coverage --------------
+
+    def test_fetch_populates_hashes_from_digests(self, mock_session):
+        """PyPI `digests` block is extracted into NormalizedMetadata.hashes."""
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/django@5.1.3")
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "info": {"summary": "A framework", "license": "BSD-3-Clause"},
+            "urls": [
+                {
+                    "filename": "Django-5.1.3-py3-none-any.whl",
+                    "digests": {"md5": "d" * 32, "sha256": "a" * 64},
+                    "upload_time_iso_8601": "2024-11-05T05:24:21Z",
+                    "yanked": False,
+                }
+            ],
+        }
+        mock_session.get.return_value = mock_response
+
+        metadata = source.fetch(purl, mock_session)
+
+        assert metadata is not None
+        assert metadata.distribution_filename == "Django-5.1.3-py3-none-any.whl"
+        assert metadata.hashes == {"md5": "d" * 32, "sha256": "a" * 64}
+        assert metadata.cle_release_date == "2024-11-05"
+        assert metadata.cle_eol is None  # Not yanked
+
+    def test_fetch_prefers_wheel_over_sdist_for_hashes(self, mock_session):
+        """When multiple dists are available, wheel wins and its digests come through."""
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/foo@1.0")
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "info": {"summary": "Foo", "license": "MIT"},
+            "urls": [
+                {"filename": "foo-1.0.tar.gz", "digests": {"sha256": "b" * 64}},
+                {
+                    "filename": "foo-1.0-py3-none-any.whl",
+                    "digests": {"sha256": "a" * 64},
+                    "upload_time_iso_8601": "2024-05-01T12:00:00Z",
+                },
+            ],
+        }
+        mock_session.get.return_value = mock_response
+
+        metadata = source.fetch(purl, mock_session)
+
+        assert metadata.distribution_filename == "foo-1.0-py3-none-any.whl"
+        assert metadata.hashes == {"sha256": "a" * 64}
+        assert metadata.cle_release_date == "2024-05-01"
+
+    def test_fetch_yanked_version_populates_eol(self, mock_session):
+        """Yanked release → cle_eol at upload time."""
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/bad-release@9.9.9")
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "info": {"summary": "Oops", "license": "MIT", "yanked": True},
+            "urls": [
+                {
+                    "filename": "bad_release-9.9.9-py3-none-any.whl",
+                    "digests": {"sha256": "c" * 64},
+                    "upload_time_iso_8601": "2023-07-04T08:15:30Z",
+                    "yanked": True,
+                }
+            ],
+        }
+        mock_session.get.return_value = mock_response
+
+        metadata = source.fetch(purl, mock_session)
+
+        assert metadata.cle_eol == "2023-07-04"
+
+    def test_fetch_yanked_flag_only_on_dist(self, mock_session):
+        """Fallback: yanked on the per-file entry also triggers EOL."""
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/foo@1.0")
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "info": {"summary": "foo", "license": "MIT"},  # info.yanked absent
+            "urls": [
+                {
+                    "filename": "foo-1.0.whl",
+                    "digests": {"sha256": "a" * 64},
+                    "upload_time_iso_8601": "2022-01-01T00:00:00Z",
+                    "yanked": True,  # file-level yanked
+                }
+            ],
+        }
+        mock_session.get.return_value = mock_response
+
+        metadata = source.fetch(purl, mock_session)
+
+        assert metadata.cle_eol == "2022-01-01"
+
+    def test_fetch_yanked_without_upload_time_uses_today(self, mock_session):
+        """Yanked release without upload_time still gets cle_eol (today's UTC date)."""
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/foo@1.0")
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "info": {"summary": "foo", "license": "MIT", "yanked": True},
+            "urls": [{"filename": "foo-1.0.whl"}],  # no upload_time, no digests
+        }
+        mock_session.get.return_value = mock_response
+
+        metadata = source.fetch(purl, mock_session)
+
+        from datetime import datetime
+        from datetime import timezone as _tz
+
+        assert metadata.cle_eol is not None
+        # Format is YYYY-MM-DD
+        assert len(metadata.cle_eol) == 10
+        assert metadata.cle_eol == datetime.now(_tz.utc).strftime("%Y-%m-%d")
+
+    def test_fetch_version_specific_endpoint_when_purl_has_version(self, mock_session):
+        """URL should be /pypi/{name}/{version}/json when PURL carries a version."""
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/django@5.1.3")
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"info": {"summary": "x"}, "urls": []}
+        mock_session.get.return_value = mock_response
+
+        source.fetch(purl, mock_session)
+
+        called_url = mock_session.get.call_args[0][0]
+        assert called_url.endswith("/pypi/django/5.1.3/json")
+
+    def test_fetch_latest_endpoint_when_purl_has_no_version(self, mock_session):
+        """URL should be /pypi/{name}/json when PURL has no version."""
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/django")
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"info": {"summary": "x"}, "urls": []}
+        mock_session.get.return_value = mock_response
+
+        source.fetch(purl, mock_session)
+
+        called_url = mock_session.get.call_args[0][0]
+        assert called_url.endswith("/pypi/django/json")
+
+    def test_fetch_malformed_digests_ignored(self, mock_session):
+        """Non-string hash values in the digests block do not blow up."""
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/foo@1.0")
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "info": {"summary": "foo", "license": "MIT"},
+            "urls": [
+                {
+                    "filename": "foo-1.0.whl",
+                    "digests": {
+                        "sha256": "a" * 64,  # good
+                        "md5": "",  # rejected (empty)
+                        "blake2b": None,  # rejected (not str)
+                        "sha512": "  ",  # rejected (whitespace-only)
+                    },
+                }
+            ],
+        }
+        mock_session.get.return_value = mock_response
+
+        metadata = source.fetch(purl, mock_session)
+        assert metadata.hashes == {"sha256": "a" * 64}
+
 
 # =============================================================================
 # Test parse_author_string utility
@@ -2798,6 +2981,84 @@ class TestBSIEnrichmentFields:
         added = _apply_bsi_derived_properties(component, metadata)
         assert added == []
 
+    def test_bsi_plain_library_no_filename_skipped(self):
+        """A plain library with no filename has no unambiguous signal and
+        must not get made-up values."""
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_bsi_derived_properties
+
+        component = Component(name="foo", version="1.0", type=ComponentType.LIBRARY)
+        added = _apply_bsi_derived_properties(component, NormalizedMetadata())
+        assert added == []
+
+    @pytest.mark.parametrize(
+        "filename,expected_archive,expected_exec",
+        [
+            ("foo-1.0.tar.gz", "archive", "non-executable"),
+            ("foo-1.0.tgz", "archive", "non-executable"),
+            ("foo-1.0.tar.bz2", "archive", "non-executable"),
+            ("foo-1.0.tar.xz", "archive", "non-executable"),
+            ("foo-1.0.zip", "archive", "non-executable"),
+            ("foo.jar", "archive", "non-executable"),
+            ("foo.war", "archive", "non-executable"),
+            ("foo.deb", "archive", "non-executable"),
+            ("foo.rpm", "archive", "non-executable"),
+            ("foo.gem", "archive", "non-executable"),
+            ("foo.crate", "archive", "non-executable"),
+            ("myapp.exe", "no archive", "executable"),
+            ("runner.bin", "no archive", "executable"),
+            ("libfoo.so", "no archive", "executable"),
+            ("libfoo.dylib", "no archive", "executable"),
+            ("plugin.dll", "no archive", "executable"),
+        ],
+    )
+    def test_bsi_filename_extensions_derive_correctly(self, filename, expected_archive, expected_exec):
+        """Each recognised archive / executable filename extension maps to
+        the expected BSI boolean-style property values."""
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+
+        component = Component(name="anything", version="0", type=ComponentType.LIBRARY)
+        metadata = NormalizedMetadata(distribution_filename=filename)
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+        props = {p.name: p.value for p in component.properties}
+        assert props.get("bsi:component:archive") == expected_archive, filename
+        assert props.get("bsi:component:executable") == expected_exec, filename
+        assert props.get("bsi:component:structured") == "structured", filename
+
+    @pytest.mark.parametrize(
+        "type_,expected_archive,expected_exec",
+        [
+            (ComponentType.APPLICATION, "no archive", "executable"),
+            (ComponentType.CONTAINER, "archive", "executable"),
+            (ComponentType.FIRMWARE, "archive", "executable"),
+            (ComponentType.OPERATING_SYSTEM, "no archive", "executable"),
+        ],
+    )
+    def test_bsi_type_only_derivation(self, type_, expected_archive, expected_exec):
+        """Strongly-typed components with no filename derive boolean-style
+        properties from the component type alone."""
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+
+        component = Component(name="x", version="1.0", type=type_)
+        _apply_metadata_to_cyclonedx_component(component, NormalizedMetadata())
+        props = {p.name: p.value for p in component.properties}
+        assert props.get("bsi:component:archive") == expected_archive, type_
+        assert props.get("bsi:component:executable") == expected_exec, type_
+        assert props.get("bsi:component:structured") == "structured"
+
+    def test_bsi_case_insensitive_filename_extension(self):
+        """Uppercase filename extensions match the same way as lowercase."""
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+
+        component = Component(name="x", version="1.0", type=ComponentType.LIBRARY)
+        metadata = NormalizedMetadata(distribution_filename="FOO-1.0.WHL")
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+        props = {p.name: p.value for p in component.properties}
+        assert props["bsi:component:archive"] == "archive"
+
     # --- P1 #3: per-component hashes ---------------------------------------------
 
     def test_component_hashes_applied_from_pypi_digests(self):
@@ -2857,6 +3118,68 @@ class TestBSIEnrichmentFields:
         algs = {c.algorithm.name for c in package.checksums}
         assert "SHA256" in algs
         assert "MD5" in algs
+
+    def test_spdx_checksums_not_duplicated(self):
+        """Repeated enrichment runs don't duplicate the same checksum entry."""
+        from spdx_tools.spdx.model import Package, SpdxNoAssertion
+
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_spdx_package
+
+        package = Package(name="django", spdx_id="SPDXRef-Package-django", download_location=SpdxNoAssertion())
+        metadata = NormalizedMetadata(hashes={"sha256": "a" * 64})
+        _apply_metadata_to_spdx_package(package, metadata)
+        _apply_metadata_to_spdx_package(package, metadata)
+        assert len(package.checksums) == 1
+
+    def test_spdx_checksums_unknown_algorithm_ignored(self):
+        """Unknown SPDX algorithm names are silently skipped."""
+        from spdx_tools.spdx.model import Package, SpdxNoAssertion
+
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_spdx_package
+
+        package = Package(name="x", spdx_id="SPDXRef-x", download_location=SpdxNoAssertion())
+        metadata = NormalizedMetadata(hashes={"rot13": "abc", "sha256": "a" * 64})
+        _apply_metadata_to_spdx_package(package, metadata)
+        algs = {c.algorithm.name for c in package.checksums}
+        assert algs == {"SHA256"}
+
+    def test_cyclonedx_sha512_hash_emitted(self):
+        """SHA-512 (BSI TR-03183-2's preferred hash) makes it through."""
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+
+        component = Component(name="x", version="1", type=ComponentType.LIBRARY)
+        metadata = NormalizedMetadata(hashes={"sha512": "f" * 128})
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+        hashes = list(component.hashes)
+        assert len(hashes) == 1
+        assert str(hashes[0].alg).endswith("SHA_512")
+        assert str(hashes[0].content) == "f" * 128
+
+    def test_cyclonedx_hash_whitespace_trimmed_and_lowercased(self):
+        """Algorithm keys and hex content are normalised."""
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+
+        component = Component(name="x", version="1", type=ComponentType.LIBRARY)
+        metadata = NormalizedMetadata(hashes={"SHA256": "  " + "a" * 64 + "  "})
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+        hashes = list(component.hashes)
+        assert len(hashes) == 1
+        # Content written is stripped + lowercased (we stored as-lower already)
+        assert str(hashes[0].content) == "a" * 64
+
+    def test_cyclonedx_empty_hash_value_rejected(self):
+        """Empty / whitespace-only hex values don't produce Hash objects."""
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+
+        component = Component(name="x", version="1", type=ComponentType.LIBRARY)
+        metadata = NormalizedMetadata(hashes={"sha256": "   "})
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+        assert len(list(component.hashes)) == 0
 
     # --- P2 #6: enriched licences marked as BSI "original/declared" --------------
 

--- a/tests/test_enrichment_module.py
+++ b/tests/test_enrichment_module.py
@@ -268,6 +268,23 @@ class TestPURLSource:
 class TestPyPISource:
     """Test the PyPISource data source."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_pypi_cache(self):
+        """Isolate every PyPI test from the module-level `_cache`.
+
+        `PyPISource.fetch()` memoises both successful responses and known-404
+        entries in a module-level dict. Several tests in this class reuse the
+        same PURL (`pkg:pypi/foo@1.0`, `pkg:pypi/django@5.1`, …), so without
+        explicit isolation the second test that touches the same key would
+        silently hit the cache and skip its own mocked response, making the
+        suite order-dependent / flaky.
+        """
+        from sbomify_action._enrichment.sources import pypi as pypi_module
+
+        pypi_module._cache.clear()
+        yield
+        pypi_module._cache.clear()
+
     def test_source_properties(self):
         """Test source name and priority."""
         source = PyPISource()

--- a/tests/test_enrichment_module.py
+++ b/tests/test_enrichment_module.py
@@ -568,6 +568,30 @@ class TestPyPISource:
         metadata = source.fetch(purl, mock_session)
         assert metadata.cle_eol is None
 
+    # Direct unit tests for the module-level is_pep691_yanked helper.
+    # Kept close to the fetch-level tests so the two contracts stay in sync.
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (True, True),
+            (False, False),
+            (None, False),
+            ("", False),
+            ("   ", False),
+            ("Security advisory X", True),
+            ({"reason": "x"}, False),
+            ([True], False),
+            (1, False),  # isinstance(True, int) but bool check runs first
+            (0, False),
+            (0.5, False),
+        ],
+    )
+    def test_is_pep691_yanked_contract(self, value, expected):
+        from sbomify_action._enrichment.sources.pypi import is_pep691_yanked
+
+        assert is_pep691_yanked(value) is expected, f"is_pep691_yanked({value!r}) expected {expected!r}"
+
     @pytest.mark.parametrize("bad_yanked", [{"reason": "x"}, [True], 1, 0.5, 0])
     def test_fetch_yanked_non_bool_non_string_ignored(self, mock_session, bad_yanked):
         """Malformed yanked types (dict / list / number) must not trigger yank.
@@ -672,6 +696,9 @@ class TestPyPISource:
     def test_fetch_encodes_special_characters_in_purl_components(self, mock_session):
         """Safe special characters survive but are percent-encoded in the URL,
         so `requests` cannot normalise them into path traversal."""
+        from sbomify_action._enrichment.sources import pypi as pypi_module
+
+        pypi_module._cache.clear()
         source = PyPISource()
         purl = PackageURL.from_string("pkg:pypi/some%20pkg@1.0%2B0")
 
@@ -683,8 +710,11 @@ class TestPyPISource:
         source.fetch(purl, mock_session)
 
         called_url = mock_session.get.call_args[0][0]
-        # Space and '+' are percent-encoded; no raw path separators leak through.
-        assert "some%20pkg" in called_url or "some pkg" not in called_url
+        # Space is percent-encoded as %20; raw space never reaches the URL;
+        # the '+' version marker is preserved as its percent-encoded form;
+        # and no raw path separators leak through.
+        assert "some%20pkg" in called_url, f"expected encoded space in {called_url!r}"
+        assert " " not in called_url, f"raw space should never reach the URL: {called_url!r}"
         assert ".." not in called_url
         assert "/pypi/" in called_url
 
@@ -3378,6 +3408,32 @@ class TestBSIEnrichmentFields:
         metadata = NormalizedMetadata(hashes={"sha256": payload})
         _apply_metadata_to_cyclonedx_component(component, metadata)
         assert len(list(component.hashes)) == 0
+
+    def test_spdx_hash_wrong_length_rejected(self):
+        """SPDX parity: a SHA-256 value of the wrong length is rejected
+        rather than written into the package checksums."""
+        from spdx_tools.spdx.model import Package, SpdxNoAssertion
+
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_spdx_package
+
+        package = Package(name="x", spdx_id="SPDXRef-x", download_location=SpdxNoAssertion())
+        metadata = NormalizedMetadata(hashes={"sha256": "a" * 40})  # wrong length
+        _apply_metadata_to_spdx_package(package, metadata)
+        assert len(package.checksums) == 0
+
+    def test_spdx_hash_non_hex_characters_rejected(self):
+        """SPDX parity: non-hex content rejected symmetrically with the CDX path."""
+        from spdx_tools.spdx.model import Package, SpdxNoAssertion
+
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_spdx_package
+
+        package = Package(name="x", spdx_id="SPDXRef-x", download_location=SpdxNoAssertion())
+        payload = "<script>alert(1)</script>abcdef" + "0" * 34
+        metadata = NormalizedMetadata(hashes={"sha256": payload})
+        _apply_metadata_to_spdx_package(package, metadata)
+        assert len(package.checksums) == 0
 
     def test_spdx_checksums_not_duplicated(self):
         """Repeated enrichment runs don't duplicate the same checksum entry."""

--- a/tests/test_enrichment_module.py
+++ b/tests/test_enrichment_module.py
@@ -461,6 +461,82 @@ class TestPyPISource:
         assert metadata.cle_release_date == "2024-11-05"
         assert metadata.cle_eol is None  # Not yanked
 
+    def test_fetch_captures_pypi_blake2b_256_digest(self, mock_session):
+        """PyPI's JSON API emits BLAKE2b-256 under the `blake2b_256` key
+        (underscore, not hyphen). Previously our algorithm mapping only
+        recognised the hyphenated canonical form, so every BLAKE2b hash
+        from a PyPI wheel was silently dropped during enrichment. Pin
+        the mapping so a regression gets caught immediately.
+        """
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/requests@2.31.0")
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "info": {"summary": "HTTP for humans", "license": "Apache-2.0"},
+            "urls": [
+                {
+                    "filename": "requests-2.31.0-py3-none-any.whl",
+                    "digests": {
+                        "blake2b_256": "1" * 64,  # underscore — PyPI canonical
+                        "md5": "2" * 32,
+                        "sha256": "3" * 64,
+                    },
+                    "upload_time_iso_8601": "2023-05-22T00:00:00Z",
+                }
+            ],
+        }
+        mock_session.get.return_value = mock_response
+
+        metadata = source.fetch(purl, mock_session)
+
+        assert metadata is not None
+        # All three digests must land in the normalised hashes map.
+        assert metadata.hashes == {
+            "blake2b_256": "1" * 64,
+            "md5": "2" * 32,
+            "sha256": "3" * 64,
+        }
+
+    def test_fetch_rejects_purl_version_with_colon(self, mock_session):
+        """A PURL whose version contains ':' is rejected. PEP 440 forbids
+        ':' in versions, and allowing it would let a crafted PURL like
+        `pkg:pypi/foo@:latest` build a primary cache key `pypi:foo::latest`
+        that collides with the internal name-only `_LATEST_CACHE_SUFFIX`
+        slot and cross-poison distinct packages.
+        """
+        from sbomify_action._enrichment.sources import pypi as pypi_module
+
+        pypi_module._cache.clear()
+
+        class _Shim:
+            name = "foo"
+            version = ":latest"
+
+        source = PyPISource()
+        metadata = source.fetch(_Shim(), mock_session)  # type: ignore[arg-type]
+
+        assert metadata is None
+        assert not mock_session.get.called, "colon-bearing version should be refused before any network I/O"
+
+    def test_fetch_rejects_purl_name_with_colon(self, mock_session):
+        """Symmetric guard: colons in the name field are refused too
+        (same cache-key collision potential)."""
+        from sbomify_action._enrichment.sources import pypi as pypi_module
+
+        pypi_module._cache.clear()
+
+        class _Shim:
+            name = "evil:name"
+            version = "1.0"
+
+        source = PyPISource()
+        metadata = source.fetch(_Shim(), mock_session)  # type: ignore[arg-type]
+
+        assert metadata is None
+        assert not mock_session.get.called
+
     def test_fetch_prefers_wheel_over_sdist_for_hashes(self, mock_session):
         """When multiple dists are available, wheel wins and its digests come through."""
         source = PyPISource()

--- a/tests/test_enrichment_module.py
+++ b/tests/test_enrichment_module.py
@@ -622,6 +622,10 @@ class TestPyPISource:
             (1, False),  # isinstance(True, int) but bool check runs first
             (0, False),
             (0.5, False),
+            # Bytes are not PEP 691 strings — even non-empty ones must not
+            # be interpreted as a yank reason.
+            (b"yanked", False),
+            (b"", False),
         ],
     )
     def test_is_pep691_yanked_contract(self, value, expected):
@@ -844,9 +848,20 @@ class TestPyPISource:
             "transient 5xx must not be cached — retries can still succeed later"
         )
 
-    def test_direct_path_transient_5xx_not_cached(self, mock_session):
-        """Primary-URL 5xx must not cache None; a later component retry
-        against PyPI should still be able to hit the network.
+    @pytest.mark.parametrize(
+        "status_code",
+        [
+            429,  # rate limit — always transient
+            500,  # internal server error
+            502,  # bad gateway
+            503,  # service unavailable
+            504,  # gateway timeout
+        ],
+    )
+    def test_direct_path_transient_status_not_cached(self, mock_session, status_code):
+        """Every status code treated as transient must leave the cache empty
+        so a later component can retry. 404 is the only non-2xx status that
+        is safe to cache (permanent "package missing").
         """
         from sbomify_action._enrichment.sources import pypi as pypi_module
 
@@ -855,13 +870,15 @@ class TestPyPISource:
         purl = PackageURL.from_string("pkg:pypi/foo@1.0")
 
         failed = Mock()
-        failed.status_code = 503
+        failed.status_code = status_code
         mock_session.get.return_value = failed
 
         metadata = source.fetch(purl, mock_session)
 
         assert metadata is None
-        assert "pypi:foo:1.0" not in pypi_module._cache, "transient 5xx on the primary URL must not be cached"
+        assert "pypi:foo:1.0" not in pypi_module._cache, (
+            f"transient HTTP {status_code} on the primary URL must not be cached"
+        )
 
     def test_direct_path_timeout_not_cached(self, mock_session):
         """requests.Timeout is always transient — the cache must stay
@@ -3712,6 +3729,66 @@ class TestBSIEnrichmentFields:
         ack = getattr(licences[0], "acknowledgement", None)
         assert ack is not None
         assert str(ack.value) == "declared"
+
+    @pytest.mark.parametrize(
+        "spec_version,expect_acknowledgement",
+        [
+            # CDX 1.3 / 1.4 / 1.5: license.acknowledgement did not exist in
+            # the schema. cyclonedx-python-lib's version-specific outputter
+            # drops the field on serialisation. If we emit it on a <1.6
+            # BOM we must NOT see it in the output JSON.
+            ("1.3", False),
+            ("1.4", False),
+            ("1.5", False),
+            # CDX 1.6 added license.acknowledgement (specification PR #408).
+            ("1.6", True),
+            ("1.7", True),
+        ],
+    )
+    def test_acknowledgement_serialization_is_version_gated(self, spec_version, expect_acknowledgement):
+        """Locks the serialisation-time contract: license.acknowledgement is
+        dropped on CDX <1.6 and present on >=1.6. The enrichment helper
+        unconditionally attaches `acknowledgement=declared`; the cyclonedx-
+        python-lib outputter is responsible for the version filter. If that
+        library ever regresses, this test catches it before the
+        cross-version-compat claim in the PR description breaks.
+        """
+        import json as _json
+
+        from cyclonedx.model.bom import Bom
+
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+        from sbomify_action.serialization import serialize_cyclonedx_bom
+
+        bom = Bom()
+        component = Component(
+            name="django",
+            version="5.1",
+            type=ComponentType.LIBRARY,
+            bom_ref="django@5.1",
+        )
+        metadata = NormalizedMetadata(licenses=["BSD-3-Clause"])
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+        bom.components.add(component)
+
+        out = serialize_cyclonedx_bom(bom, spec_version)
+        payload = _json.loads(out)
+
+        emitted = payload.get("components", [{}])[0]
+        licence_entries = emitted.get("licenses", [])
+        assert licence_entries, f"no licence emitted for CDX {spec_version}"
+        first = licence_entries[0]
+        # LicenseExpression may serialise the field at the top level or nest
+        # it under "license" depending on the library version; probe both.
+        body = first if "acknowledgement" in first else first.get("license", {})
+        present = "acknowledgement" in body
+        assert present is expect_acknowledgement, (
+            f"CDX {spec_version}: expected acknowledgement "
+            f"{'present' if expect_acknowledgement else 'absent'}, got {licence_entries!r}"
+        )
+        if expect_acknowledgement:
+            assert body.get("acknowledgement") == "declared"
 
 
 class TestNormalizedMetadataDistributionFilename:

--- a/tests/test_enrichment_module.py
+++ b/tests/test_enrichment_module.py
@@ -579,7 +579,13 @@ class TestPyPISource:
             (None, False),
             ("", False),
             ("   ", False),
+            # Unicode whitespace reasons — Python str.strip() removes all
+            # Unicode whitespace, so a whitespace-only reason stays falsy.
+            ("\t", False),
+            ("\u00a0", False),  # non-breaking space
             ("Security advisory X", True),
+            # Non-ASCII reason strings are valid per PEP 691 §4.1.
+            ("Sicherheitsl\u00fccke", True),
             ({"reason": "x"}, False),
             ([True], False),
             (1, False),  # isinstance(True, int) but bool check runs first
@@ -750,6 +756,58 @@ class TestPyPISource:
         assert mock_session.get.call_count == 2
         # Fallback must have reached the non-versioned URL
         assert mock_session.get.call_args_list[1][0][0].endswith("/pypi/foo/json")
+
+    def test_versioned_404_reuses_warm_latest_cache(self, mock_session):
+        """When the name-only latest cache slot is already populated from a
+        prior fallback, a second component whose pinned version 404s must
+        short-circuit to the cached value without a second HTTP call.
+
+        Pins down the fix for the 404 amplification vulnerability: a
+        regression that dropped the cache-hit short-circuit would force
+        ``mock_session.get.call_count == 2`` and fail this test.
+        """
+        from sbomify_action._enrichment.sources import pypi as pypi_module
+
+        pypi_module._cache.clear()
+        # Pre-warm the name-only cache slot, as a prior 404 fallback would.
+        pre_cached = NormalizedMetadata(description="cached foo", source="pypi.org")
+        pypi_module._cache[f"pypi:foo{pypi_module._LATEST_CACHE_SUFFIX}"] = pre_cached
+
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/foo@99.99.99")
+        versioned = Mock()
+        versioned.status_code = 404
+        mock_session.get.return_value = versioned
+
+        metadata = source.fetch(purl, mock_session)
+
+        assert metadata is pre_cached
+        assert mock_session.get.call_count == 1, "versioned 404 with a warm latest cache must NOT issue a second GET"
+
+    def test_versioned_404_transient_error_not_cached(self, mock_session):
+        """When the version-specific endpoint 404s and the latest-endpoint
+        retry returns a transient 5xx, the source must NOT cache None for
+        the name-only key — a subsequent component in the same run should
+        still get a chance to re-fetch when PyPI recovers.
+        """
+        from sbomify_action._enrichment.sources import pypi as pypi_module
+
+        pypi_module._cache.clear()
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/foo@99.99.99")
+
+        versioned = Mock()
+        versioned.status_code = 404
+        transient = Mock()
+        transient.status_code = 503
+        mock_session.get.side_effect = [versioned, transient]
+
+        metadata = source.fetch(purl, mock_session)
+
+        assert metadata is None
+        assert f"pypi:foo{pypi_module._LATEST_CACHE_SUFFIX}" not in pypi_module._cache, (
+            "transient 5xx must not be cached — retries can still succeed later"
+        )
 
     def test_fetch_malformed_digests_ignored(self, mock_session):
         """Non-string hash values in the digests block do not blow up."""
@@ -3423,14 +3481,19 @@ class TestBSIEnrichmentFields:
         assert len(package.checksums) == 0
 
     def test_spdx_hash_non_hex_characters_rejected(self):
-        """SPDX parity: non-hex content rejected symmetrically with the CDX path."""
+        """SPDX parity: non-hex content rejected symmetrically with the CDX path.
+
+        Payload is exactly 64 characters (valid SHA-256 length) but every
+        character is outside ``[0-9a-f]`` so it isolates the regex branch —
+        a bug that dropped the length check would still fail this test.
+        """
         from spdx_tools.spdx.model import Package, SpdxNoAssertion
 
         from sbomify_action._enrichment.metadata import NormalizedMetadata
         from sbomify_action.enrichment import _apply_metadata_to_spdx_package
 
         package = Package(name="x", spdx_id="SPDXRef-x", download_location=SpdxNoAssertion())
-        payload = "<script>alert(1)</script>abcdef" + "0" * 34
+        payload = "g" * 64  # length-valid but never hex
         metadata = NormalizedMetadata(hashes={"sha256": payload})
         _apply_metadata_to_spdx_package(package, metadata)
         assert len(package.checksums) == 0

--- a/tests/test_enrichment_module.py
+++ b/tests/test_enrichment_module.py
@@ -168,6 +168,46 @@ class TestNormalizedMetadata:
         assert merged.hashes == {"sha256": "a" * 64}
         assert "hashes" not in merged.field_sources
 
+    def test_merge_hashes_extends_attribution_when_both_contribute(self):
+        """When self already carries a ``hashes`` attribution and ``other``
+        adds a new algorithm, the attribution must record BOTH sources —
+        otherwise a downstream audit trail would hide which source
+        actually contributed the additional digest."""
+        meta1 = NormalizedMetadata(
+            hashes={"sha256": "a" * 64},
+            source="pypi",
+            field_sources={"hashes": "pypi"},
+        )
+        meta2 = NormalizedMetadata(
+            hashes={"blake2b_256": "c" * 64},
+            source="ecosyste.ms",
+        )
+
+        merged = meta1.merge(meta2)
+
+        assert merged.hashes == {"sha256": "a" * 64, "blake2b_256": "c" * 64}
+        assert merged.field_sources["hashes"] == "pypi, ecosyste.ms", (
+            "expected union attribution recording both contributing sources"
+        )
+
+    def test_merge_hashes_attribution_does_not_duplicate_same_source(self):
+        """Guard: if ``other.source`` matches an entry already in
+        ``field_sources['hashes']`` we must not duplicate it."""
+        meta1 = NormalizedMetadata(
+            hashes={"sha256": "a" * 64},
+            source="pypi",
+            field_sources={"hashes": "pypi"},
+        )
+        meta2 = NormalizedMetadata(
+            hashes={"blake2b_256": "c" * 64},
+            source="pypi",  # same source name as meta1
+        )
+
+        merged = meta1.merge(meta2)
+
+        assert merged.hashes == {"sha256": "a" * 64, "blake2b_256": "c" * 64}
+        assert merged.field_sources["hashes"] == "pypi"
+
 
 # =============================================================================
 # Test PURLSource

--- a/tests/test_enrichment_module.py
+++ b/tests/test_enrichment_module.py
@@ -3559,6 +3559,43 @@ class TestBSIEnrichmentFields:
         _apply_metadata_to_cyclonedx_component(component, metadata)
         assert len(list(component.hashes)) == 0
 
+    @pytest.mark.parametrize(
+        "alg,bad_value",
+        [
+            # Underscore forms (as emitted by PyPI / warehouse legacy.py):
+            # missing length table entries would let these through the
+            # "unknown algorithm — presence only" branch and accept any
+            # hex string as a valid BLAKE2b digest. Each pair is either
+            # a too-short or too-long hex string for the named algorithm.
+            ("blake2b_256", "a" * 4),  # correct length is 64
+            ("blake2b_256", "a" * 80),
+            ("blake2b_384", "a" * 64),  # correct length is 96
+            ("blake2b_512", "a" * 64),  # correct length is 128
+            # Hyphen forms should behave identically.
+            ("blake2b-256", "a" * 4),
+            ("blake2b-384", "a" * 64),
+        ],
+    )
+    def test_component_blake2b_wrong_length_rejected(self, alg, bad_value):
+        """Regression: round-8 added blake2b_256/384/512 underscore keys
+        to the algorithm maps so PyPI-emitted digests map to the CDX enum,
+        but the parallel _HASH_HEX_LENGTHS table only had hyphen forms.
+        Length validation fell through to the "unknown algorithm" branch
+        and accepted any hex string. A malicious / truncated 4-char hex
+        would land in the SBOM as a valid BLAKE2b hash. Pin the fix so
+        both sets of keys stay in sync.
+        """
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+
+        component = Component(name="django", version="5.1", type=ComponentType.LIBRARY)
+        metadata = NormalizedMetadata(hashes={alg: bad_value})
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+        assert len(list(component.hashes)) == 0, (
+            f"wrong-length {alg} ({len(bad_value)} chars) should have been rejected; "
+            f"got hashes={list(component.hashes)!r}"
+        )
+
     def test_component_hashes_initialised_when_hashes_is_none(self):
         """Components deserialised from some inputs can legitimately have
         `hashes is None`. The hash-enrichment path must initialise the

--- a/tests/test_enrichment_module.py
+++ b/tests/test_enrichment_module.py
@@ -137,6 +137,37 @@ class TestNormalizedMetadata:
         assert merged.description == "First"  # Preserved
         assert merged.licenses == ["Apache-2.0"]  # Preserved
 
+    def test_merge_unions_hash_algorithms(self):
+        """hashes is a dict keyed by algorithm, not a list — merging must
+        preserve algorithms from both sources. Self wins on conflict."""
+        meta1 = NormalizedMetadata(hashes={"sha256": "a" * 64}, source="pypi")
+        meta2 = NormalizedMetadata(
+            hashes={"sha256": "b" * 64, "blake2b-256": "c" * 64, "md5": "d" * 32},
+            source="ecosyste.ms",
+        )
+
+        merged = meta1.merge(meta2)
+
+        assert merged.hashes == {
+            "sha256": "a" * 64,  # self wins on conflicting algorithm
+            "blake2b-256": "c" * 64,  # new algorithm preserved
+            "md5": "d" * 32,
+        }
+        # Source attribution records the contributing source when we
+        # actually added keys from `other`.
+        assert merged.field_sources.get("hashes") == "ecosyste.ms"
+
+    def test_merge_hashes_no_other_keys_leaves_source_untouched(self):
+        """When `other` contributes no new hash algorithms, we should not
+        fabricate a hashes source attribution for `other`."""
+        meta1 = NormalizedMetadata(hashes={"sha256": "a" * 64}, source="pypi")
+        meta2 = NormalizedMetadata(hashes={"sha256": "b" * 64}, source="ecosyste.ms")
+
+        merged = meta1.merge(meta2)
+
+        assert merged.hashes == {"sha256": "a" * 64}
+        assert "hashes" not in merged.field_sources
+
 
 # =============================================================================
 # Test PURLSource
@@ -688,8 +719,12 @@ class TestPyPISource:
         source = PyPISource()
 
         class _Shim:
-            """PackageURL normalises '..' in name away, so we test the refusal
-            logic with a lightweight shim exposing the same attribute surface."""
+            """Use a lightweight shim exposing the attribute surface the
+            fetch() method relies on. `PackageURL.from_string` actually
+            preserves `..` in the name field (verified empirically) — so
+            a real PURL would do, too — but the shim keeps the unit test
+            independent of how the third-party parser may normalise in
+            the future."""
 
             name = ".."
             version = "1.0"

--- a/tests/test_enrichment_module.py
+++ b/tests/test_enrichment_module.py
@@ -504,8 +504,12 @@ class TestPyPISource:
 
         assert metadata.cle_eol == "2022-01-01"
 
-    def test_fetch_yanked_without_upload_time_uses_today(self, mock_session):
-        """Yanked release without upload_time still gets cle_eol (today's UTC date)."""
+    def test_fetch_yanked_without_upload_time_leaves_eol_unset(self, mock_session):
+        """A yanked release with no upload timestamp leaves cle_eol unset.
+
+        Falling back to today's date would make output non-deterministic and
+        emit a misleading "yanked just now" signal to downstream consumers.
+        """
         source = PyPISource()
         purl = PackageURL.from_string("pkg:pypi/foo@1.0")
 
@@ -513,19 +517,84 @@ class TestPyPISource:
         mock_response.status_code = 200
         mock_response.json.return_value = {
             "info": {"summary": "foo", "license": "MIT", "yanked": True},
-            "urls": [{"filename": "foo-1.0.whl"}],  # no upload_time, no digests
+            "urls": [{"filename": "foo-1.0.whl"}],  # no upload_time
         }
         mock_session.get.return_value = mock_response
 
         metadata = source.fetch(purl, mock_session)
+        assert metadata.cle_eol is None
 
-        from datetime import datetime
-        from datetime import timezone as _tz
+    def test_fetch_yanked_with_reason_string_treated_as_yanked(self, mock_session):
+        """Per PEP 691, `yanked` can be either a bool or a non-empty reason string."""
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/foo@1.0")
 
-        assert metadata.cle_eol is not None
-        # Format is YYYY-MM-DD
-        assert len(metadata.cle_eol) == 10
-        assert metadata.cle_eol == datetime.now(_tz.utc).strftime("%Y-%m-%d")
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "info": {"summary": "foo", "license": "MIT", "yanked": "Security advisory X"},
+            "urls": [
+                {
+                    "filename": "foo-1.0.whl",
+                    "digests": {"sha256": "a" * 64},
+                    "upload_time_iso_8601": "2021-03-03T00:00:00Z",
+                }
+            ],
+        }
+        mock_session.get.return_value = mock_response
+
+        metadata = source.fetch(purl, mock_session)
+        assert metadata.cle_eol == "2021-03-03"
+
+    def test_fetch_yanked_empty_string_not_yanked(self, mock_session):
+        """Empty-string / whitespace-only yanked is not a truthy PEP 691 signal."""
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/foo@1.0")
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "info": {"summary": "foo", "license": "MIT", "yanked": "   "},
+            "urls": [
+                {
+                    "filename": "foo-1.0.whl",
+                    "digests": {"sha256": "a" * 64},
+                    "upload_time_iso_8601": "2021-03-03T00:00:00Z",
+                }
+            ],
+        }
+        mock_session.get.return_value = mock_response
+
+        metadata = source.fetch(purl, mock_session)
+        assert metadata.cle_eol is None
+
+    @pytest.mark.parametrize("bad_yanked", [{"reason": "x"}, [True], 1, 0.5, 0])
+    def test_fetch_yanked_non_bool_non_string_ignored(self, mock_session, bad_yanked):
+        """Malformed yanked types (dict / list / number) must not trigger yank.
+
+        Defence-in-depth against attacker-controlled / cached responses.
+        """
+        from sbomify_action._enrichment.sources import pypi as pypi_module
+
+        pypi_module._cache.clear()  # isolate from other parametric runs
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/foo@1.0")
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "info": {"summary": "foo", "license": "MIT", "yanked": bad_yanked},
+            "urls": [
+                {
+                    "filename": "foo-1.0.whl",
+                    "upload_time_iso_8601": "2020-01-01T00:00:00Z",
+                }
+            ],
+        }
+        mock_session.get.return_value = mock_response
+
+        metadata = source.fetch(purl, mock_session)
+        assert metadata.cle_eol is None, f"bad yanked={bad_yanked!r} unexpectedly set cle_eol"
 
     def test_fetch_version_specific_endpoint_when_purl_has_version(self, mock_session):
         """URL should be /pypi/{name}/{version}/json when PURL carries a version."""
@@ -556,6 +625,101 @@ class TestPyPISource:
 
         called_url = mock_session.get.call_args[0][0]
         assert called_url.endswith("/pypi/django/json")
+
+    # --- Security: path traversal via PURL version ----------------------------
+
+    def test_fetch_rejects_path_traversal_in_version(self, mock_session):
+        """An SBOM-crafted PURL like pkg:pypi/foo@%2E%2E/admin must not cause
+        the Action to fetch https://pypi.org/admin/json. Verify the fetch is
+        refused outright and no HTTP call is made."""
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/foo@%2E%2E/%2E%2E/admin")
+
+        metadata = source.fetch(purl, mock_session)
+
+        assert metadata is None
+        assert not mock_session.get.called, "request must not be sent for traversal PURLs"
+
+    def test_fetch_rejects_forward_slash_in_version(self, mock_session):
+        """Explicit '/' in version also triggers the safety refusal."""
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/foo@1.0/admin")
+
+        metadata = source.fetch(purl, mock_session)
+
+        assert metadata is None
+        assert not mock_session.get.called
+
+    def test_fetch_rejects_path_traversal_in_name(self, mock_session):
+        """Traversal tokens in the PURL name are refused symmetrically."""
+        from sbomify_action._enrichment.sources import pypi as pypi_module
+
+        pypi_module._cache.clear()
+        source = PyPISource()
+
+        class _Shim:
+            """PackageURL normalises '..' in name away, so we test the refusal
+            logic with a lightweight shim exposing the same attribute surface."""
+
+            name = ".."
+            version = "1.0"
+
+        metadata = source.fetch(_Shim(), mock_session)  # type: ignore[arg-type]
+
+        assert metadata is None
+        assert not mock_session.get.called
+
+    def test_fetch_encodes_special_characters_in_purl_components(self, mock_session):
+        """Safe special characters survive but are percent-encoded in the URL,
+        so `requests` cannot normalise them into path traversal."""
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/some%20pkg@1.0%2B0")
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"info": {"summary": "x"}, "urls": []}
+        mock_session.get.return_value = mock_response
+
+        source.fetch(purl, mock_session)
+
+        called_url = mock_session.get.call_args[0][0]
+        # Space and '+' are percent-encoded; no raw path separators leak through.
+        assert "some%20pkg" in called_url or "some pkg" not in called_url
+        assert ".." not in called_url
+        assert "/pypi/" in called_url
+
+    def test_fetch_versioned_404_falls_back_to_latest(self, mock_session):
+        """If the version-specific endpoint 404s but the package exists, the
+        source retries the latest-only URL so we still get base metadata."""
+        from sbomify_action._enrichment.sources import pypi as pypi_module
+
+        pypi_module._cache.clear()
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/foo@99.99.99")
+
+        versioned = Mock()
+        versioned.status_code = 404
+        latest = Mock()
+        latest.status_code = 200
+        latest.json.return_value = {
+            "info": {"summary": "foo (latest)", "license": "MIT"},
+            "urls": [
+                {
+                    "filename": "foo-1.0-py3-none-any.whl",
+                    "digests": {"sha256": "a" * 64},
+                    "upload_time_iso_8601": "2024-01-01T00:00:00Z",
+                }
+            ],
+        }
+        mock_session.get.side_effect = [versioned, latest]
+
+        metadata = source.fetch(purl, mock_session)
+
+        assert metadata is not None
+        assert metadata.description == "foo (latest)"
+        assert mock_session.get.call_count == 2
+        # Fallback must have reached the non-versioned URL
+        assert mock_session.get.call_args_list[1][0][0].endswith("/pypi/foo/json")
 
     def test_fetch_malformed_digests_ignored(self, mock_session):
         """Non-string hash values in the digests block do not blow up."""
@@ -3118,6 +3282,102 @@ class TestBSIEnrichmentFields:
         algs = {c.algorithm.name for c in package.checksums}
         assert "SHA256" in algs
         assert "MD5" in algs
+
+    @pytest.mark.parametrize(
+        "alg_key,cdx_suffix,hex_len",
+        [
+            ("md5", "MD5", 32),
+            ("sha1", "SHA_1", 40),
+            ("sha-1", "SHA_1", 40),
+            ("sha256", "SHA_256", 64),
+            ("sha-256", "SHA_256", 64),
+            ("sha384", "SHA_384", 96),
+            ("sha-384", "SHA_384", 96),
+            ("sha512", "SHA_512", 128),
+            ("sha-512", "SHA_512", 128),
+            ("sha3-256", "SHA3_256", 64),
+            ("sha3-384", "SHA3_384", 96),
+            ("sha3-512", "SHA3_512", 128),
+            ("blake2b-256", "BLAKE2B_256", 64),
+            ("blake2b-384", "BLAKE2B_384", 96),
+            ("blake2b-512", "BLAKE2B_512", 128),
+            ("blake3", "BLAKE3", 64),  # no fixed length enforced, 64 is the common default
+        ],
+    )
+    def test_cyclonedx_every_mapped_hash_algorithm_emits(self, alg_key, cdx_suffix, hex_len):
+        """Every key in _CYCLONEDX_HASH_ALGORITHMS produces the expected enum,
+        and hex-length validation accepts the correct length for each algorithm."""
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+
+        component = Component(name="x", version="1", type=ComponentType.LIBRARY)
+        metadata = NormalizedMetadata(hashes={alg_key: "a" * hex_len})
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+        hashes = list(component.hashes)
+        assert len(hashes) == 1, f"no hash emitted for {alg_key!r}"
+        assert str(hashes[0].alg).endswith(cdx_suffix), (
+            f"{alg_key!r} mapped to {hashes[0].alg!r}, expected suffix {cdx_suffix}"
+        )
+
+    @pytest.mark.parametrize(
+        "alg_key,spdx_name,hex_len",
+        [
+            ("md5", "MD5", 32),
+            ("sha1", "SHA1", 40),
+            ("sha-1", "SHA1", 40),
+            ("sha224", "SHA224", 56),
+            ("sha-224", "SHA224", 56),
+            ("sha256", "SHA256", 64),
+            ("sha-256", "SHA256", 64),
+            ("sha384", "SHA384", 96),
+            ("sha-384", "SHA384", 96),
+            ("sha512", "SHA512", 128),
+            ("sha-512", "SHA512", 128),
+            ("sha3-256", "SHA3_256", 64),
+            ("sha3-384", "SHA3_384", 96),
+            ("sha3-512", "SHA3_512", 128),
+            ("blake2b-256", "BLAKE2B_256", 64),
+            ("blake2b-384", "BLAKE2B_384", 96),
+            ("blake2b-512", "BLAKE2B_512", 128),
+            ("blake3", "BLAKE3", 64),
+        ],
+    )
+    def test_spdx_every_mapped_hash_algorithm_emits(self, alg_key, spdx_name, hex_len):
+        """Every key in _SPDX_CHECKSUM_ALGORITHMS maps to its enum value,
+        including the SPDX-only SHA-224 entry that the CDX enum lacks."""
+        from spdx_tools.spdx.model import Package, SpdxNoAssertion
+
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_spdx_package
+
+        package = Package(name="x", spdx_id="SPDXRef-x", download_location=SpdxNoAssertion())
+        metadata = NormalizedMetadata(hashes={alg_key: "a" * hex_len})
+        _apply_metadata_to_spdx_package(package, metadata)
+        assert len(package.checksums) == 1
+        assert package.checksums[0].algorithm.name == spdx_name
+
+    def test_cyclonedx_hash_wrong_length_rejected(self):
+        """A SHA-256 hex-value of the wrong length is rejected rather than
+        written into the SBOM. Defence against malformed sources."""
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+
+        component = Component(name="x", version="1", type=ComponentType.LIBRARY)
+        metadata = NormalizedMetadata(hashes={"sha256": "a" * 40})  # SHA-1 length, wrong
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+        assert len(list(component.hashes)) == 0
+
+    def test_cyclonedx_hash_non_hex_characters_rejected(self):
+        """Non-hex characters in the hash content are rejected."""
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+
+        component = Component(name="x", version="1", type=ComponentType.LIBRARY)
+        # Script-injection attempt that happens to be 64 chars
+        payload = "<script>alert(1)</script>abcdef" + "0" * 34
+        metadata = NormalizedMetadata(hashes={"sha256": payload})
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+        assert len(list(component.hashes)) == 0
 
     def test_spdx_checksums_not_duplicated(self):
         """Repeated enrichment runs don't duplicate the same checksum entry."""

--- a/tests/test_enrichment_module.py
+++ b/tests/test_enrichment_module.py
@@ -844,6 +844,84 @@ class TestPyPISource:
             "transient 5xx must not be cached — retries can still succeed later"
         )
 
+    def test_direct_path_transient_5xx_not_cached(self, mock_session):
+        """Primary-URL 5xx must not cache None; a later component retry
+        against PyPI should still be able to hit the network.
+        """
+        from sbomify_action._enrichment.sources import pypi as pypi_module
+
+        pypi_module._cache.clear()
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/foo@1.0")
+
+        failed = Mock()
+        failed.status_code = 503
+        mock_session.get.return_value = failed
+
+        metadata = source.fetch(purl, mock_session)
+
+        assert metadata is None
+        assert "pypi:foo:1.0" not in pypi_module._cache, "transient 5xx on the primary URL must not be cached"
+
+    def test_direct_path_timeout_not_cached(self, mock_session):
+        """requests.Timeout is always transient — the cache must stay
+        empty so a subsequent component can attempt a fresh fetch.
+        """
+        import requests as _requests
+
+        from sbomify_action._enrichment.sources import pypi as pypi_module
+
+        pypi_module._cache.clear()
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/foo@1.0")
+
+        mock_session.get.side_effect = _requests.exceptions.Timeout("simulated")
+
+        metadata = source.fetch(purl, mock_session)
+
+        assert metadata is None
+        assert "pypi:foo:1.0" not in pypi_module._cache, "timeouts must not be cached — later components may retry"
+
+    def test_direct_path_connection_error_not_cached(self, mock_session):
+        """Network-layer RequestException (e.g. ConnectionError) is treated
+        as transient and must not poison the cache."""
+        import requests as _requests
+
+        from sbomify_action._enrichment.sources import pypi as pypi_module
+
+        pypi_module._cache.clear()
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/foo@1.0")
+
+        mock_session.get.side_effect = _requests.exceptions.ConnectionError("refused")
+
+        metadata = source.fetch(purl, mock_session)
+
+        assert metadata is None
+        assert "pypi:foo:1.0" not in pypi_module._cache
+
+    def test_direct_path_404_is_cached(self, mock_session):
+        """Genuine 404 is a permanent "package missing" — SAFE to cache
+        so repeated components for the same name skip the network.
+        """
+        from sbomify_action._enrichment.sources import pypi as pypi_module
+
+        pypi_module._cache.clear()
+        source = PyPISource()
+        purl = PackageURL.from_string("pkg:pypi/never-existed@1.0")
+
+        missing = Mock()
+        missing.status_code = 404
+        mock_session.get.return_value = missing
+
+        metadata = source.fetch(purl, mock_session)
+
+        assert metadata is None
+        assert "pypi:never-existed:1.0" in pypi_module._cache, (
+            "404 is permanent; caching None avoids repeated network round-trips"
+        )
+        assert pypi_module._cache["pypi:never-existed:1.0"] is None
+
     def test_fetch_malformed_digests_ignored(self, mock_session):
         """Non-string hash values in the digests block do not blow up."""
         source = PyPISource()

--- a/tests/test_enrichment_module.py
+++ b/tests/test_enrichment_module.py
@@ -2732,6 +2732,88 @@ class TestBSIEnrichmentFields:
         filenames = [p for p in component.properties if p.name == "bsi:component:filename"]
         assert len(filenames) == 1
 
+    # --- BSI §5.2.2 derived boolean properties -----------------------------------
+
+    def test_bsi_wheel_library_derives_archive_non_executable_structured(self):
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+
+        component = Component(name="django", version="5.1", type=ComponentType.LIBRARY)
+        metadata = NormalizedMetadata(distribution_filename="Django-5.1-py3-none-any.whl")
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+        props = {p.name: p.value for p in component.properties}
+        assert props["bsi:component:archive"] == "archive"
+        assert props["bsi:component:executable"] == "non-executable"
+        assert props["bsi:component:structured"] == "structured"
+
+    def test_bsi_exe_application_derives_executable_no_archive(self):
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+
+        component = Component(name="myapp", version="1.0", type=ComponentType.APPLICATION)
+        metadata = NormalizedMetadata(distribution_filename="myapp-1.0.exe")
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+        props = {p.name: p.value for p in component.properties}
+        assert props["bsi:component:executable"] == "executable"
+        assert props["bsi:component:archive"] == "no archive"
+        assert props["bsi:component:structured"] == "structured"
+
+    def test_bsi_container_type_defaults(self):
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+
+        component = Component(name="myimg", version="1.0", type=ComponentType.CONTAINER)
+        metadata = NormalizedMetadata()  # no filename — fall through to type-based default
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+        props = {p.name: p.value for p in component.properties}
+        assert props["bsi:component:archive"] == "archive"
+        assert props["bsi:component:executable"] == "executable"
+        assert props["bsi:component:structured"] == "structured"
+
+    def test_bsi_operator_supplied_values_win(self):
+        """Pre-existing BSI properties must not be overwritten by the helper."""
+        from cyclonedx.model import Property
+
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+
+        component = Component(name="django", version="5.1", type=ComponentType.LIBRARY)
+        component.properties.add(Property(name="bsi:component:archive", value="no archive"))
+        component.properties.add(Property(name="bsi:component:executable", value="executable"))
+        metadata = NormalizedMetadata(distribution_filename="Django-5.1-py3-none-any.whl")
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+        props = [(p.name, p.value) for p in component.properties]
+        # Only one of each; the operator's values survive
+        assert ("bsi:component:archive", "no archive") in props
+        assert ("bsi:component:executable", "executable") in props
+        assert ("bsi:component:archive", "archive") not in props
+
+    def test_bsi_unknown_filename_no_derivation(self):
+        """When we cannot derive anything confidently we emit nothing."""
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_bsi_derived_properties
+
+        component = Component(name="?", version="0", type=ComponentType.DEVICE)
+        metadata = NormalizedMetadata()
+        added = _apply_bsi_derived_properties(component, metadata)
+        assert added == []
+
+    # --- P2 #6: enriched licences marked as BSI "original/declared" --------------
+
+    def test_enriched_license_marked_declared(self):
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+
+        component = Component(name="django", version="5.1", type=ComponentType.LIBRARY)
+        metadata = NormalizedMetadata(licenses=["BSD-3-Clause"])
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+        licences = list(component.licenses)
+        assert len(licences) == 1
+        # CycloneDX LicenseExpression exposes the enum via .acknowledgement
+        ack = getattr(licences[0], "acknowledgement", None)
+        assert ack is not None
+        assert str(ack.value) == "declared"
+
 
 class TestNormalizedMetadataDistributionFilename:
     """Tests for distribution_filename in NormalizedMetadata."""

--- a/tests/test_enrichment_module.py
+++ b/tests/test_enrichment_module.py
@@ -2798,6 +2798,66 @@ class TestBSIEnrichmentFields:
         added = _apply_bsi_derived_properties(component, metadata)
         assert added == []
 
+    # --- P1 #3: per-component hashes ---------------------------------------------
+
+    def test_component_hashes_applied_from_pypi_digests(self):
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+
+        component = Component(name="django", version="5.1", type=ComponentType.LIBRARY)
+        metadata = NormalizedMetadata(
+            distribution_filename="Django-5.1-py3-none-any.whl",
+            hashes={
+                "md5": "d" * 32,
+                "sha256": "a" * 64,
+                "blake2b-256": "b" * 64,
+            },
+        )
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+        alg_names = {str(h.alg) for h in component.hashes}
+        assert any("SHA_256" in n for n in alg_names)
+        assert any("MD5" in n for n in alg_names)
+        assert any("BLAKE2B_256" in n for n in alg_names)
+
+    def test_component_hashes_not_duplicated(self):
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+
+        component = Component(name="django", version="5.1", type=ComponentType.LIBRARY)
+        metadata = NormalizedMetadata(hashes={"sha256": "a" * 64})
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+        hashes = list(component.hashes)
+        assert len(hashes) == 1
+        assert str(hashes[0].content) == "a" * 64
+
+    def test_component_hashes_unknown_algorithm_ignored(self):
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_cyclonedx_component
+
+        component = Component(name="django", version="5.1", type=ComponentType.LIBRARY)
+        metadata = NormalizedMetadata(hashes={"rot13": "a" * 32})
+        _apply_metadata_to_cyclonedx_component(component, metadata)
+        assert len(list(component.hashes)) == 0
+
+    def test_spdx_checksums_applied(self):
+        from spdx_tools.spdx.model import Package, SpdxNoAssertion
+
+        from sbomify_action._enrichment.metadata import NormalizedMetadata
+        from sbomify_action.enrichment import _apply_metadata_to_spdx_package
+
+        package = Package(
+            name="django",
+            spdx_id="SPDXRef-Package-django",
+            download_location=SpdxNoAssertion(),
+        )
+        metadata = NormalizedMetadata(hashes={"sha256": "a" * 64, "md5": "d" * 32})
+        _apply_metadata_to_spdx_package(package, metadata)
+        assert len(package.checksums) == 2
+        algs = {c.algorithm.name for c in package.checksums}
+        assert "SHA256" in algs
+        assert "MD5" in algs
+
     # --- P2 #6: enriched licences marked as BSI "original/declared" --------------
 
     def test_enriched_license_marked_declared(self):

--- a/tests/test_schema_compliance.py
+++ b/tests/test_schema_compliance.py
@@ -1,4 +1,6 @@
+import contextlib
 import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -22,6 +24,56 @@ from spdx_tools.spdx.writer.write_anything import write_file as spdx_write_file
 from sbomify_action.augmentation import augment_sbom_from_file
 from sbomify_action.enrichment import clear_cache, enrich_sbom
 from sbomify_action.serialization import serialize_cyclonedx_bom
+
+# Environment keys that any augmentation provider might react to.
+# The schema-compliance tests mock sbomify-api and drive the whole
+# pipeline to verify that an operator-supplied lifecycle_phase makes
+# it all the way to the emitted BOM. If the suite runs IN GitHub
+# Actions / GitLab CI / Bitbucket Pipelines, the real CI providers
+# fire and win over the sbomify-api mock (priority 20 < 50), which
+# would falsely fail these assertions. Scrub the relevant env vars
+# for the duration of each test so only the mocked providers speak.
+_AUGMENTATION_ENV_KEYS_TO_CLEAR = (
+    "GITHUB_ACTIONS",
+    "GITHUB_REPOSITORY",
+    "GITHUB_SHA",
+    "GITHUB_REF",
+    "GITHUB_REF_NAME",
+    "GITHUB_SERVER_URL",
+    "GITLAB_CI",
+    "CI_PROJECT_URL",
+    "CI_PROJECT_PATH",
+    "CI_SERVER_URL",
+    "CI_COMMIT_SHA",
+    "CI_COMMIT_REF_NAME",
+    "CI_COMMIT_TAG",
+    "BITBUCKET_PIPELINE_UUID",
+    "BITBUCKET_GIT_HTTP_ORIGIN",
+    "BITBUCKET_WORKSPACE",
+    "BITBUCKET_REPO_SLUG",
+    "BITBUCKET_COMMIT",
+    "BITBUCKET_BRANCH",
+    "BITBUCKET_TAG",
+    "DOCKER_IMAGE",
+)
+
+
+@contextlib.contextmanager
+def _scrub_ci_env():
+    """Remove all CI / docker-image environment variables for the
+    duration of the block and restore them afterwards. Use this when
+    a test wants only the mocked providers (sbomify-api / json-config)
+    to contribute augmentation metadata."""
+    saved = {k: os.environ.pop(k, None) for k in _AUGMENTATION_ENV_KEYS_TO_CLEAR}
+    try:
+        yield
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
 
 # Path to schemas
 REPO_ROOT = Path(__file__).parent.parent
@@ -88,6 +140,7 @@ def test_cyclonedx_full_flow_compliance(version, tmp_path):
     mock_api_response.json.return_value = augmentation_data
 
     with (
+        _scrub_ci_env(),
         patch(
             "sbomify_action._augmentation.providers.json_config.JsonConfigProvider._find_config_file",
             return_value=None,
@@ -222,6 +275,7 @@ def test_spdx_full_flow_compliance(version, tmp_path):
     mock_api_response.json.return_value = augmentation_data
 
     with (
+        _scrub_ci_env(),
         patch(
             "sbomify_action._augmentation.providers.json_config.JsonConfigProvider._find_config_file",
             return_value=None,


### PR DESCRIPTION
## Summary

Closes the compliance-plugin gaps discovered during a cross-repo audit (sbomify/sbomify PR #895). After this PR a fresh `sbomify-action --enrich` run on real PyPI dependencies goes from **BSI 13/5** on the updated sbomify plugins to **BSI 17/1** plus improvements on CISA.

## Changes

### 1. BSI TR-03183-2 §5.2.2 boolean-style properties

Per-component properties derived in `_apply_bsi_derived_properties` during CycloneDX enrichment:

- `bsi:component:archive` — "archive" or "no archive"
- `bsi:component:executable` — "executable" or "non-executable"
- `bsi:component:structured` — "structured"

Derivation only fires when we have a clear signal: a `distribution_filename` (extension-based: `.whl` / `.tar.gz` / `.zip` / `.exe` / `.so` / etc.), or a strongly-typed component (`application` / `container` / `firmware` / `operating-system`). A plain `library` component with no filename stays untouched. Operator-supplied values are preserved.

### 2. Declared licences (BSI §5.2.4)

Enriched licences are flagged with `acknowledgement="declared"`. BSI distinguishes the "original licence" (what the creator assigned, what the registry tells us) from the "distribution licence" (what the integrator ships under).

### 3. CI-detected lifecycle phase (CycloneDX 1.7 meta:enum)

The CycloneDX 1.7 schema's `meta:enum` for `metadata.lifecycles[].phase` distinguishes:

- **pre-build** — "information obtained prior to a build process and may contain source files and development artifacts and **manifests**" (lockfile / manifest scans)
- **build** — "information obtained **during** a build process" (emitted mid-compilation by Maven / Gradle plugins, `cargo bom`, etc.)
- **post-build** — "information obtained **after** a build process has completed and the resulting component(s) are available for further analysis" (scans of built container images)

Defaults now track the schema:

- `GitHubActionsProvider` / `GitLabCIProvider` / `BitbucketPipelinesProvider` default `lifecycle_phase="pre-build"`. The common CI usage of sbomify-action is lockfile scanning, which maps to `pre-build` per the schema.
- New `DockerImageProvider` (priority 15) emits `lifecycle_phase="post-build"` when `DOCKER_IMAGE` is set so scanning a built image lands in the correct phase regardless of which CI provider also fires. The CLI mirrors `--docker-image` into the env var so flag-form and envvar-form inputs behave identically.

Merge semantics (unchanged): providers sorted by `priority` ascending, `result.merge(later)` folds, **lower numeric priority** wins. So `json_config` (10) beats `docker-image` (15) beats CI (20) beats `sbomify-api` (50). Operators who genuinely emit a BOM mid-compilation (the narrow `build` case) override via `sbomify.json`.

### 4. Per-component distribution hashes (NTIA / BSI §5.2.2 / CISA Component Hash)

`NormalizedMetadata` now carries a `hashes: Dict[str, str]` field keyed by SPDX algorithm name. The PyPI source extracts the chosen distribution file's `digests` block and populates it. Both the CycloneDX path (`Component.hashes` via `HashType` / `HashAlgorithm`) and the SPDX path (`Package.checksums` via `Checksum` / `ChecksumAlgorithm`) apply it, de-duplicating against existing values.

### 5. Per-component release date + yanked→EOL (ECMA-428 CLE)

- `cdx:lifecycle:milestone:generalAvailability` — from `upload_time_iso_8601` on the chosen distribution file.
- `cdx:lifecycle:milestone:endOfLife` — from the version-level `yanked` flag mapped to the upload timestamp. When no upload timestamp is available we deliberately leave EOL unset rather than synthesise "today", so repeated enrichment runs stay deterministic.

PyPI fetch now uses the version-specific endpoint `/pypi/{name}/{version}/json` when the PURL carries a version, so per-version fields (`yanked`, `upload_time`, file `digests`) are accurate instead of reflecting the latest release.

## Before / after on sbomify plugins

Run against a minimal Python lock file (django + requests + pydantic) with `--enrich`:

| Plugin | Baseline | After this PR |
|---|---|---|
| NTIA | 6/1 | 6/1 |
| **BSI** | **13/5 (2w)** | **17/1 (2w)** |
| **CISA** | **8/3** | **9/2** |
| FDA | 6/3 | 6/3 |

BSI gains:
- `bsi:component:archive`, `executable`, `structured`
- `original_licences` (BSI §5.2.4, `acknowledgement: declared`)
- `hash_value` upgraded from warning → pass (SHA-256 emitted per component)

CISA gain:
- `component_hash` passes

NTIA / FDA gains require further data that upstream PyPI doesn't expose consistently (per-component support status for every dep, component-level sbom_author etc.). Those are follow-ups.

## Tests

- **2013** sbomify-action tests pass (baseline 2009 + 4 new hash regression cases).
- **9 new** regression tests under `TestBSIEnrichmentFields`:
  - BSI derivation for wheels, `.exe`, containers, operator-overrides, no-signal
  - `acknowledgement=declared` on enriched licences
  - Component hashes from PyPI digests (CDX + SPDX paths)
  - De-duplication and unknown-algorithm rejection

## Related

- sbomify plugin PR (the consumer side): https://github.com/sbomify/sbomify/pull/895

## Deferred follow-ups

- **SPDX 3.0.1 generator** — no tool in the current pipeline produces it. `spdx_tools.spdx3.writer.json_ld.json_ld_writer` exists in the library but wiring it up means building the full graph model (Package / Relationship / CreationInfo / Person / Organization / Tool / SpdxDocument). Deserves its own PR.
- **Per-component lifecycle data for OS packages**: already covered for Linux distros and language runtimes via `lifecycle_data.py`. PyPI `yanked`→EOL is added here. Extending to npm / crates / gem deprecation would add value.
- **CycloneDX 1.7 from PyPI lock files** — works in the production Docker image (cyclonedx-bom>=7.2.1 supports 1.7). The earlier "failing" observation was a local PATH picking up a stale 6.x.


