### PR TITLE
Add Chainguard base image detection and SBOM reuse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ ARG BUN_VERSION=1.3.10
 ARG BOMCTL_VERSION=0.4.3
 ARG SYFT_VERSION=1.42.3
 ARG CARGO_CYCLONEDX_VERSION=0.5.9
+ARG CRANE_VERSION=0.21.5
+ARG COSIGN_VERSION=3.0.6
 
 FROM python:3.13-slim-trixie AS fetcher
 
@@ -14,6 +16,8 @@ ARG TARGETARCH
 # Re-declare global ARGs needed in this stage
 ARG BOMCTL_VERSION
 ARG SYFT_VERSION
+ARG CRANE_VERSION
+ARG COSIGN_VERSION
 
 WORKDIR /tmp
 
@@ -47,6 +51,32 @@ RUN curl -sL \
     tar xvfz syft_${SYFT_VERSION}_linux_${TARGETARCH}.tar.gz && \
     chmod +x /tmp/syft && \
     mv syft /usr/local/bin && \
+    rm -rf /tmp/*
+
+# Install crane (uses Linux_x86_64 / Linux_arm64 naming)
+RUN CRANE_ARCH=$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "${TARGETARCH}") && \
+    curl -sL \
+        -o go-containerregistry_Linux_${CRANE_ARCH}.tar.gz \
+        "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_${CRANE_ARCH}.tar.gz" && \
+    curl -sL \
+        -o crane_checksums.txt \
+        "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/checksums.txt" && \
+    sha256sum --ignore-missing -c crane_checksums.txt && \
+    tar xvfz go-containerregistry_Linux_${CRANE_ARCH}.tar.gz crane && \
+    chmod +x /tmp/crane && \
+    mv crane /usr/local/bin && \
+    rm -rf /tmp/*
+
+# Install cosign (uses linux-amd64 / linux-arm64 naming)
+RUN curl -sL \
+        -o cosign-linux-${TARGETARCH} \
+        "https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-${TARGETARCH}" && \
+    curl -sL \
+        -o cosign_checksums.txt \
+        "https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign_checksums.txt" && \
+    sha256sum --ignore-missing -c cosign_checksums.txt && \
+    chmod +x cosign-linux-${TARGETARCH} && \
+    mv cosign-linux-${TARGETARCH} /usr/local/bin/cosign && \
     rm -rf /tmp/*
 
 # Node/Bun stage for cdxgen
@@ -149,6 +179,8 @@ LABEL com.sbomify.maintainer="sbomify <hello@sbomify.com>" \
 # Copy tools from fetcher
 COPY --from=fetcher /usr/local/bin/bomctl /usr/local/bin/
 COPY --from=fetcher /usr/local/bin/syft /usr/local/bin/
+COPY --from=fetcher /usr/local/bin/crane /usr/local/bin/
+COPY --from=fetcher /usr/local/bin/cosign /usr/local/bin/
 # cargo-cyclonedx: pre-built for amd64, compiled for arm64
 COPY --from=rust-builder /usr/local/cargo/bin/cargo-cyclonedx /usr/local/bin/
 COPY --from=node-fetcher /usr/local/bin/bun /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,10 +55,10 @@ RUN curl -sL \
 
 # Install crane (uses Linux_x86_64 / Linux_arm64 naming)
 RUN CRANE_ARCH=$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "${TARGETARCH}") && \
-    curl -sL \
+    curl -fsSL \
         -o go-containerregistry_Linux_${CRANE_ARCH}.tar.gz \
         "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_${CRANE_ARCH}.tar.gz" && \
-    curl -sL \
+    curl -fsSL \
         -o crane_checksums.txt \
         "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/checksums.txt" && \
     sha256sum --ignore-missing -c crane_checksums.txt && \
@@ -68,10 +68,10 @@ RUN CRANE_ARCH=$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "${TARGE
     rm -rf /tmp/*
 
 # Install cosign (uses linux-amd64 / linux-arm64 naming)
-RUN curl -sL \
+RUN curl -fsSL \
         -o cosign-linux-${TARGETARCH} \
         "https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-${TARGETARCH}" && \
-    curl -sL \
+    curl -fsSL \
         -o cosign_checksums.txt \
         "https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign_checksums.txt" && \
     sha256sum --ignore-missing -c cosign_checksums.txt && \

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Watch our FOSDEM 2026 talk for a real-world crash course on generating CRA-ready
 
 Generate, augment, enrich, and manage SBOMs in your CI/CD pipeline. Works standalone or with [sbomify](https://sbomify.com).
 
-**Recommended**: Use the GitHub Action or Docker image—they include the recommended SBOM generators pre-installed (Syft, cdxgen, cyclonedx-py, cargo-cyclonedx, and more). For other CI platforms, see [examples below](#other-cicd-platforms). A [pip package](#pip-advanced) is also available for advanced use cases.
+**Recommended**: Use the GitHub Action or Docker image—they include the recommended SBOM generators pre-installed (Syft, cdxgen, cyclonedx-py, cargo-cyclonedx, crane, cosign, and more). For other CI platforms, see [examples below](#other-cicd-platforms). A [pip package](#pip-advanced) is also available for advanced use cases.
 
 > **Note**: Trivy support is temporarily disabled due to recurring security vulnerabilities. Syft and cdxgen cover all supported ecosystems.
 
@@ -41,6 +41,7 @@ That's it! This generates a CycloneDX SBOM from your lockfile and enriches it wi
 
 - **Generate** SBOMs from lockfiles (Python, Node, Rust, Go, Ruby, Dart, C++) in CycloneDX or SPDX format
 - **Generate** SBOMs from Docker images
+- **Chainguard SBOM reuse** — Automatically detects Chainguard base images and uses their signed SBOMs instead of scanning
 - **Yocto/OpenEmbedded** — Batch process SPDX SBOMs from Yocto builds (extract, upload, release-tag)
 - **Inject** additional packages not in lockfiles (vendored code, runtime deps, system libraries)
 - **Augment** with business metadata (supplier, authors, licenses, lifecycle phase) from config file or sbomify
@@ -88,6 +89,39 @@ That's it! This generates a CycloneDX SBOM from your lockfile and enriches it wi
     UPLOAD: false
     ENRICH: true
 ```
+
+### Chainguard Images
+
+When `DOCKER_IMAGE` points to a [Chainguard](https://www.chainguard.dev/) image—or an image built `FROM` one—sbomify automatically detects it and uses the signed SBOM provided by Chainguard instead of scanning with Syft/cdxgen. This produces a more accurate SBOM because it comes directly from the image publisher.
+
+**Detection works two ways:**
+
+1. **Direct Chainguard images** (`cgr.dev/chainguard/...`) — detected by image reference and verified via image config
+2. **User-built images FROM Chainguard** — detected by parsing BuildKit SLSA provenance attestations embedded in the image
+
+No configuration needed—just point `DOCKER_IMAGE` at your image:
+
+```yaml
+- uses: sbomify/sbomify-action@master
+  env:
+    DOCKER_IMAGE: cgr.dev/chainguard/python:latest
+    OUTPUT_FILE: sbom.cdx.json
+    UPLOAD: false
+    ENRICH: true
+```
+
+**Important:** Chainguard SBOMs only cover the base image packages. If your Dockerfile uses `COPY --from=...` to add binaries (e.g., cosign, crane, osv-scanner), those will **not** appear in the SBOM. Use [`ADDITIONAL_PACKAGES`](#additional-packages) to declare them:
+
+```yaml
+- uses: sbomify/sbomify-action@master
+  env:
+    DOCKER_IMAGE: my-org/my-image:latest
+    ADDITIONAL_PACKAGES: "pkg:golang/github.com/sigstore/cosign@2.4.0"
+    OUTPUT_FILE: sbom.cdx.json
+    UPLOAD: false
+```
+
+> **Note:** Chainguard detection requires `crane` and `cosign` CLI tools. Both are bundled in the Docker image. For pip installations, install them separately (see [Required Tools](#required-tools)).
 
 <details>
 <summary><strong>More examples</strong> (augmentation, SPDX, attestation, additional packages...)</summary>
@@ -947,6 +981,8 @@ When installed via pip, sbomify-action requires external SBOM generators. The Do
 | **cyclonedx-py** | `pip install cyclonedx-bom`                                                                     | Native Python generator; `cyclonedx-py` is the CLI command provided by the `cyclonedx-bom` package (installed as a dependency) |
 | **Syft**         | [Installation guide](https://github.com/anchore/syft#installation)                              | macOS: `brew install syft`                                                                                                     |
 | **cdxgen**       | `npm install -g @cyclonedx/cdxgen`                                                              | Requires Node.js/Bun                                                                                                           |
+| **crane**        | [Installation guide](https://github.com/google/go-containerregistry#installation)               | Required for Chainguard image detection; macOS: `brew install crane`                                                           |
+| **cosign**       | [Installation guide](https://github.com/sigstore/cosign#installation)                           | Required for Chainguard SBOM retrieval; macOS: `brew install cosign`                                                           |
 
 **Minimum requirement**: At least one generator must be installed for SBOM generation. For Python projects, `cyclonedx-bom` (which provides the `cyclonedx-py` command) is installed as a dependency when you install sbomify-action via pip. For other ecosystems or Docker images, install `syft` or `cdxgen`.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ That's it! This generates a CycloneDX SBOM from your lockfile and enriches it wi
 
 - **Generate** SBOMs from lockfiles (Python, Node, Rust, Go, Ruby, Dart, C++) in CycloneDX or SPDX format
 - **Generate** SBOMs from Docker images
-- **Chainguard SBOM reuse** — Automatically detects Chainguard base images and uses their signed SBOMs instead of scanning
+- **Chainguard SBOM reuse** — Automatically detects Chainguard base images and uses their provided SBOMs instead of scanning
 - **Yocto/OpenEmbedded** — Batch process SPDX SBOMs from Yocto builds (extract, upload, release-tag)
 - **Inject** additional packages not in lockfiles (vendored code, runtime deps, system libraries)
 - **Augment** with business metadata (supplier, authors, licenses, lifecycle phase) from config file or sbomify
@@ -92,7 +92,7 @@ That's it! This generates a CycloneDX SBOM from your lockfile and enriches it wi
 
 ### Chainguard Images
 
-When `DOCKER_IMAGE` points to a [Chainguard](https://www.chainguard.dev/) image—or an image built `FROM` one—sbomify automatically detects it and uses the signed SBOM provided by Chainguard instead of scanning with Syft/cdxgen. This produces a more accurate SBOM because it comes directly from the image publisher.
+When `DOCKER_IMAGE` points to a [Chainguard](https://www.chainguard.dev/) image—or an image built `FROM` one—sbomify automatically detects it and uses the SBOM provided by Chainguard instead of scanning with Syft/cdxgen. This produces a more accurate SBOM because it comes directly from the image publisher.
 
 **Detection works two ways:**
 

--- a/sbomify_action/_generation/chainguard.py
+++ b/sbomify_action/_generation/chainguard.py
@@ -1,0 +1,461 @@
+"""Chainguard base image detection and SBOM reuse.
+
+Detects Chainguard images (direct or as base images in user-built images),
+downloads their SPDX SBOMs from cosign attestations, and converts to CycloneDX.
+"""
+
+import base64
+import json
+import platform
+import shutil
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from urllib.parse import unquote
+
+from cyclonedx.model import HashAlgorithm, HashType
+from cyclonedx.model.bom import Bom
+from cyclonedx.model.component import Component, ComponentType
+from cyclonedx.model.contact import OrganizationalEntity
+from cyclonedx.model.tool import Tool
+from packageurl import PackageURL
+
+from sbomify_action.logging_config import logger
+from sbomify_action.serialization import serialize_cyclonedx_bom
+
+
+@dataclass
+class ChainguardBaseImage:
+    """Information about a detected Chainguard base image."""
+
+    image_ref: str  # e.g., "cgr.dev/chainguard/python"
+    digest: str  # per-architecture digest, e.g., "sha256:242e08c..."
+
+
+def _get_current_platform() -> str:
+    """Get the current platform in OCI format (e.g., 'linux/amd64')."""
+    import os
+
+    # Check environment variable first (CI environments may set this)
+    target_arch = os.environ.get("TARGETARCH")
+    if target_arch:
+        return f"linux/{target_arch}"
+
+    machine = platform.machine()
+    arch_map = {
+        "x86_64": "amd64",
+        "aarch64": "arm64",
+        "arm64": "arm64",
+    }
+    arch = arch_map.get(machine, machine)
+    return f"linux/{arch}"
+
+
+def _run_crane(args: list[str]) -> str:
+    """Run a crane command and return stdout."""
+    cmd = ["crane"] + args
+    logger.debug(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=60)
+    return result.stdout
+
+
+def _run_cosign(args: list[str]) -> str:
+    """Run a cosign command and return stdout."""
+    cmd = ["cosign"] + args
+    logger.debug(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=120)
+    return result.stdout
+
+
+def _resolve_platform_digest(image_ref: str) -> str | None:
+    """Resolve an image reference to a platform-specific manifest digest.
+
+    If the image is a manifest list (multi-arch), resolves to the current platform.
+    If it's already a single manifest, returns its digest.
+    """
+    current_platform = _get_current_platform()
+    os_name, arch = current_platform.split("/")
+
+    try:
+        manifest_json = _run_crane(["manifest", image_ref])
+        manifest = json.loads(manifest_json)
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+        logger.debug(f"Failed to fetch manifest for {image_ref}: {e}")
+        return None
+
+    # Check if this is a manifest list / OCI image index
+    media_type = manifest.get("mediaType", "")
+    if "manifest.list" in media_type or "image.index" in media_type:
+        for entry in manifest.get("manifests", []):
+            p = entry.get("platform", {})
+            if p.get("os") == os_name and p.get("architecture") == arch:
+                return entry["digest"]
+        logger.debug(f"No matching platform {current_platform} in manifest list for {image_ref}")
+        return None
+
+    # Single manifest — get its digest
+    try:
+        digest = _run_crane(["digest", image_ref]).strip()
+        return digest
+    except subprocess.CalledProcessError:
+        return None
+
+
+def _is_chainguard_config(image_ref: str) -> bool:
+    """Check if an image config indicates a Chainguard image."""
+    try:
+        config_json = _run_crane(["config", image_ref])
+        config = json.loads(config_json)
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+        logger.debug(f"Failed to fetch config for {image_ref}: {e}")
+        return False
+
+    # Check author field (set by apko)
+    if config.get("author") == "github.com/chainguard-dev/apko":
+        return True
+
+    # Check labels
+    labels = config.get("config", {}).get("Labels", {})
+    if "dev.chainguard.image.title" in labels:
+        return True
+
+    return False
+
+
+def _detect_direct_chainguard(docker_image: str) -> ChainguardBaseImage | None:
+    """Detect if the image is directly from cgr.dev/chainguard/."""
+    if not docker_image.startswith("cgr.dev/chainguard/"):
+        return None
+
+    logger.debug(f"Image ref starts with cgr.dev/chainguard/, verifying: {docker_image}")
+
+    if not _is_chainguard_config(docker_image):
+        logger.debug(f"Image config does not match Chainguard pattern: {docker_image}")
+        return None
+
+    digest = _resolve_platform_digest(docker_image)
+    if not digest:
+        logger.warning(f"Could not resolve platform digest for {docker_image}")
+        return None
+
+    # Extract the image ref without tag/digest for the ChainguardBaseImage
+    image_ref = docker_image.split("@")[0].split(":")[0]
+    return ChainguardBaseImage(image_ref=image_ref, digest=digest)
+
+
+def _parse_purl_docker_uri(uri: str) -> tuple[str, str] | None:
+    """Parse a pkg:docker URI into (image_ref, digest).
+
+    Example: pkg:docker/cgr.dev/chainguard/python?digest=sha256:abc...&platform=linux%2Famd64
+    Returns: ("cgr.dev/chainguard/python", "sha256:abc...")
+    """
+    if not uri.startswith("pkg:docker/"):
+        return None
+
+    # Remove pkg:docker/ prefix
+    rest = uri[len("pkg:docker/") :]
+
+    # Split on ? to separate path from query
+    if "?" in rest:
+        path, query = rest.split("?", 1)
+    else:
+        return None
+
+    # Decode the path
+    image_ref = unquote(path)
+    # Remove @tag if present (e.g., pkg:docker/alpine@3.21)
+    if "@" in image_ref:
+        image_ref = image_ref.split("@")[0]
+
+    # Parse query parameters for digest
+    digest = None
+    for param in query.split("&"):
+        if param.startswith("digest="):
+            digest = unquote(param[len("digest=") :])
+            break
+
+    if not digest:
+        return None
+
+    return image_ref, digest
+
+
+def _detect_chainguard_from_provenance(docker_image: str) -> ChainguardBaseImage | None:
+    """Detect Chainguard base image by parsing BuildKit provenance attestation."""
+    try:
+        index_json = _run_crane(["manifest", docker_image])
+        index = json.loads(index_json)
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+        logger.debug(f"Failed to fetch manifest for {docker_image}: {e}")
+        return None
+
+    # Find attestation manifest in the image index
+    att_digest = None
+    for entry in index.get("manifests", []):
+        annotations = entry.get("annotations", {})
+        if annotations.get("vnd.docker.reference.type") == "attestation-manifest":
+            att_digest = entry["digest"]
+            break
+
+    if not att_digest:
+        logger.debug(f"No attestation manifest found for {docker_image}")
+        return None
+
+    # Fetch the attestation manifest to find the provenance layer
+    try:
+        att_manifest_json = _run_crane(["manifest", f"{docker_image.split(':')[0]}@{att_digest}"])
+        # Handle case where docker_image has @ instead of :
+        if "@" in docker_image:
+            registry_repo = docker_image.split("@")[0]
+            att_manifest_json = _run_crane(["manifest", f"{registry_repo}@{att_digest}"])
+        att_manifest = json.loads(att_manifest_json)
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+        logger.debug(f"Failed to fetch attestation manifest: {e}")
+        return None
+
+    # Find SLSA provenance layer
+    provenance_digest = None
+    for layer in att_manifest.get("layers", []):
+        annotations = layer.get("annotations", {})
+        if annotations.get("in-toto.io/predicate-type") == "https://slsa.dev/provenance/v1":
+            provenance_digest = layer["digest"]
+            break
+
+    if not provenance_digest:
+        logger.debug(f"No SLSA provenance layer found in attestation for {docker_image}")
+        return None
+
+    # Fetch and parse the provenance blob
+    try:
+        # Need to resolve the registry/repo for blob fetching
+        if "@" in docker_image:
+            registry_repo = docker_image.split("@")[0]
+        else:
+            registry_repo = docker_image.split(":")[0]
+        provenance_json = _run_crane(["blob", f"{registry_repo}@{provenance_digest}"])
+        provenance = json.loads(provenance_json)
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+        logger.debug(f"Failed to fetch provenance blob: {e}")
+        return None
+
+    # Search resolvedDependencies for Chainguard images
+    resolved_deps = provenance.get("predicate", {}).get("buildDefinition", {}).get("resolvedDependencies", [])
+
+    for dep in resolved_deps:
+        uri = dep.get("uri", "")
+        if "cgr.dev/chainguard/" not in uri:
+            continue
+
+        parsed = _parse_purl_docker_uri(uri)
+        if not parsed:
+            continue
+
+        image_ref, digest = parsed
+        logger.info(f"Found Chainguard base image in provenance: {image_ref}@{digest}")
+
+        # Resolve to per-architecture digest if this is an index digest
+        platform_digest = _resolve_platform_digest(f"{image_ref}@{digest}")
+        if not platform_digest:
+            platform_digest = digest
+
+        return ChainguardBaseImage(image_ref=image_ref, digest=platform_digest)
+
+    logger.debug(f"No Chainguard base image found in provenance for {docker_image}")
+    return None
+
+
+def detect_chainguard_image(docker_image: str) -> ChainguardBaseImage | None:
+    """Detect if a Docker image is or is built FROM a Chainguard image.
+
+    Tries two detection paths:
+    1. Direct: image ref starts with cgr.dev/chainguard/
+    2. Provenance: parse BuildKit SLSA provenance for Chainguard base images
+
+    Returns ChainguardBaseImage with the per-architecture digest, or None if not detected.
+    Requires crane to be available on PATH.
+    """
+    if not shutil.which("crane"):
+        logger.debug("crane not found on PATH, skipping Chainguard detection")
+        return None
+
+    # Path A: Direct Chainguard image
+    result = _detect_direct_chainguard(docker_image)
+    if result:
+        return result
+
+    # Path B: User-built image FROM Chainguard
+    return _detect_chainguard_from_provenance(docker_image)
+
+
+def fetch_chainguard_sbom(info: ChainguardBaseImage) -> dict:
+    """Download the SPDX SBOM from a Chainguard image's cosign attestation.
+
+    Args:
+        info: Detected Chainguard image info with per-architecture digest
+
+    Returns:
+        SPDX document as a dict
+
+    Raises:
+        RuntimeError: If SBOM cannot be fetched or parsed
+    """
+    if not shutil.which("cosign"):
+        raise RuntimeError("cosign not found on PATH, cannot fetch Chainguard SBOM")
+
+    image_with_digest = f"{info.image_ref}@{info.digest}"
+    logger.info(f"Fetching Chainguard SBOM for {image_with_digest}")
+
+    try:
+        output = _run_cosign(["download", "attestation", image_with_digest])
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"Failed to download attestation for {image_with_digest}: {e.stderr or e}") from e
+
+    # Parse each line as a JSON attestation envelope
+    for line in output.strip().split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+
+        try:
+            envelope = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        payload_b64 = envelope.get("payload", "")
+        if not payload_b64:
+            continue
+
+        try:
+            payload = json.loads(base64.b64decode(payload_b64))
+        except (json.JSONDecodeError, Exception):
+            continue
+
+        if payload.get("predicateType") == "https://spdx.dev/Document":
+            predicate = payload.get("predicate", {})
+            if predicate.get("spdxVersion"):
+                pkg_count = len(predicate.get("packages", []))
+                logger.info(f"Found Chainguard SPDX SBOM with {pkg_count} packages")
+                return predicate
+
+    raise RuntimeError(f"No SPDX SBOM found in attestations for {image_with_digest}")
+
+
+# CycloneDX hash algorithm mapping from SPDX algorithm names
+_SPDX_TO_CDX_HASH_ALG: dict[str, HashAlgorithm] = {
+    "SHA256": HashAlgorithm.SHA_256,
+    "SHA384": HashAlgorithm.SHA_384,
+    "SHA512": HashAlgorithm.SHA_512,
+    "SHA1": HashAlgorithm.SHA_1,
+    "MD5": HashAlgorithm.MD5,
+}
+
+
+def convert_spdx_to_cyclonedx(spdx_doc: dict, spec_version: str = "1.6") -> str:
+    """Convert a Chainguard SPDX SBOM to CycloneDX JSON.
+
+    Handles the simple structure of Chainguard SBOMs: packages with PURLs,
+    checksums, and supplier info.
+
+    Args:
+        spdx_doc: SPDX document dict (from fetch_chainguard_sbom)
+        spec_version: Target CycloneDX spec version (default "1.6")
+
+    Returns:
+        CycloneDX JSON string
+    """
+    bom = Bom()
+
+    # Set metadata
+    creation_info = spdx_doc.get("creationInfo", {})
+    created = creation_info.get("created")
+    if created:
+        try:
+            bom.metadata.timestamp = datetime.fromisoformat(created.replace("Z", "+00:00"))
+        except ValueError:
+            pass
+
+    # Add tool info from SPDX creators
+    for creator in creation_info.get("creators", []):
+        if creator.startswith("Tool:"):
+            tool_name = creator[len("Tool:") :].strip()
+            bom.metadata.tools.tools.add(Tool(name=tool_name))
+
+    # Track which SPDX IDs are "described" (top-level components)
+    described_ids = set(spdx_doc.get("documentDescribes", []))
+
+    # Build components from SPDX packages
+    components: list[Component] = []
+    main_component: Component | None = None
+
+    for pkg in spdx_doc.get("packages", []):
+        spdx_id = pkg.get("SPDXID", "")
+        name = pkg.get("name", "")
+        version = pkg.get("versionInfo", "")
+
+        # Extract PURL from external refs
+        purl_str = None
+        for ref in pkg.get("externalRefs", []):
+            if ref.get("referenceType") == "purl":
+                purl_str = ref.get("referenceLocator", "")
+                break
+
+        # Determine component type
+        purpose = pkg.get("primaryPackagePurpose", "")
+        if purpose == "CONTAINER":
+            comp_type = ComponentType.CONTAINER
+        elif purpose == "OPERATING_SYSTEM":
+            comp_type = ComponentType.OPERATING_SYSTEM
+        else:
+            comp_type = ComponentType.LIBRARY
+
+        # Build component
+        comp = Component(
+            type=comp_type,
+            name=name,
+            version=version if version else None,
+            bom_ref=spdx_id,
+        )
+
+        if purl_str:
+            try:
+                comp.purl = PackageURL.from_string(purl_str)
+            except ValueError:
+                pass
+
+        # Add supplier
+        supplier_str = pkg.get("supplier", "")
+        if supplier_str and supplier_str != "NOASSERTION":
+            # Parse "Organization: Chainguard, Inc." format
+            if supplier_str.startswith("Organization:"):
+                org_name = supplier_str[len("Organization:") :].strip()
+                comp.supplier = OrganizationalEntity(name=org_name)
+
+        # Add hashes
+        for checksum in pkg.get("checksums", []):
+            alg = checksum.get("algorithm", "")
+            value = checksum.get("checksumValue", "")
+            cdx_alg = _SPDX_TO_CDX_HASH_ALG.get(alg)
+            if cdx_alg and value:
+                comp.hashes.add(HashType(alg=cdx_alg, content=value))
+
+        # Add description
+        description = pkg.get("description", "")
+        if description:
+            comp.description = description
+
+        # Set as main component if it's the described package
+        if spdx_id in described_ids and main_component is None:
+            main_component = comp
+        else:
+            components.append(comp)
+
+    # Set main component in metadata
+    if main_component:
+        bom.metadata.component = main_component
+
+    # Add all other components
+    for comp in components:
+        bom.components.add(comp)
+
+    # Serialize
+    return serialize_cyclonedx_bom(bom, spec_version)

--- a/sbomify_action/_generation/chainguard.py
+++ b/sbomify_action/_generation/chainguard.py
@@ -6,6 +6,7 @@ downloads their SPDX SBOMs from cosign attestations, and converts to CycloneDX.
 
 import base64
 import json
+import os
 import platform
 import shutil
 import subprocess
@@ -54,8 +55,6 @@ def _extract_repo(image_ref: str) -> str:
 
 def _get_current_platform() -> str:
     """Get the current platform in OCI format (e.g., 'linux/amd64')."""
-    import os
-
     # Check environment variable first (CI environments may set this)
     target_arch = os.environ.get("TARGETARCH")
     if target_arch:
@@ -341,7 +340,7 @@ def fetch_chainguard_sbom(info: ChainguardBaseImage) -> dict[str, Any]:
 
         try:
             payload = json.loads(base64.b64decode(payload_b64))
-        except (json.JSONDecodeError, Exception):
+        except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
             continue
 
         if payload.get("predicateType") == "https://spdx.dev/Document":

--- a/sbomify_action/_generation/chainguard.py
+++ b/sbomify_action/_generation/chainguard.py
@@ -5,6 +5,7 @@ downloads their SPDX SBOMs from cosign attestations, and converts to CycloneDX.
 """
 
 import base64
+import binascii
 import json
 import os
 import platform
@@ -340,7 +341,7 @@ def fetch_chainguard_sbom(info: ChainguardBaseImage) -> dict[str, Any]:
 
         try:
             payload = json.loads(base64.b64decode(payload_b64))
-        except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+        except (json.JSONDecodeError, ValueError, UnicodeDecodeError, binascii.Error):
             continue
 
         if payload.get("predicateType") == "https://spdx.dev/Document":

--- a/sbomify_action/_generation/chainguard.py
+++ b/sbomify_action/_generation/chainguard.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 from urllib.parse import unquote
 
 from cyclonedx.model import HashAlgorithm, HashType
@@ -110,7 +111,7 @@ def _resolve_platform_digest(image_ref: str) -> str | None:
         for entry in manifest.get("manifests", []):
             p = entry.get("platform", {})
             if p.get("os") == os_name and p.get("architecture") == arch:
-                return entry["digest"]
+                return str(entry["digest"])
         logger.debug(f"No matching platform {current_platform} in manifest list for {image_ref}")
         return None
 
@@ -300,7 +301,7 @@ def detect_chainguard_image(docker_image: str) -> ChainguardBaseImage | None:
     return _detect_chainguard_from_provenance(docker_image)
 
 
-def fetch_chainguard_sbom(info: ChainguardBaseImage) -> dict:
+def fetch_chainguard_sbom(info: ChainguardBaseImage) -> dict[str, Any]:
     """Download the SPDX SBOM from a Chainguard image's cosign attestation.
 
     Args:
@@ -348,7 +349,7 @@ def fetch_chainguard_sbom(info: ChainguardBaseImage) -> dict:
             if predicate.get("spdxVersion"):
                 pkg_count = len(predicate.get("packages", []))
                 logger.info(f"Found Chainguard SPDX SBOM with {pkg_count} packages")
-                return predicate
+                return dict(predicate)
 
     raise RuntimeError(f"No SPDX SBOM found in attestations for {image_with_digest}")
 
@@ -363,7 +364,7 @@ _SPDX_TO_CDX_HASH_ALG: dict[str, HashAlgorithm] = {
 }
 
 
-def convert_spdx_to_cyclonedx(spdx_doc: dict, spec_version: str = "1.6") -> str:
+def convert_spdx_to_cyclonedx(spdx_doc: dict[str, Any], spec_version: str = "1.6") -> str:
     """Convert a Chainguard SPDX SBOM to CycloneDX JSON.
 
     Handles the simple structure of Chainguard SBOMs: packages with PURLs,

--- a/sbomify_action/_generation/chainguard.py
+++ b/sbomify_action/_generation/chainguard.py
@@ -32,6 +32,25 @@ class ChainguardBaseImage:
     digest: str  # per-architecture digest, e.g., "sha256:242e08c..."
 
 
+def _extract_repo(image_ref: str) -> str:
+    """Extract the repository (without tag or digest) from an image reference.
+
+    Handles registries with ports (e.g., localhost:5000/repo/image:tag)
+    by only stripping a :tag suffix when the colon appears after the last /.
+    """
+    # Strip @digest first
+    if "@" in image_ref:
+        image_ref = image_ref.split("@")[0]
+
+    # Strip :tag only if the colon is after the last /
+    last_slash = image_ref.rfind("/")
+    last_colon = image_ref.rfind(":")
+    if last_colon > last_slash:
+        image_ref = image_ref[:last_colon]
+
+    return image_ref
+
+
 def _get_current_platform() -> str:
     """Get the current platform in OCI format (e.g., 'linux/amd64')."""
     import os
@@ -41,11 +60,13 @@ def _get_current_platform() -> str:
     if target_arch:
         return f"linux/{target_arch}"
 
-    machine = platform.machine()
+    machine = platform.machine().lower()
     arch_map = {
         "x86_64": "amd64",
+        "amd64": "amd64",
         "aarch64": "arm64",
         "arm64": "arm64",
+        "armv7l": "arm",
     }
     arch = arch_map.get(machine, machine)
     return f"linux/{arch}"
@@ -139,7 +160,7 @@ def _detect_direct_chainguard(docker_image: str) -> ChainguardBaseImage | None:
         return None
 
     # Extract the image ref without tag/digest for the ChainguardBaseImage
-    image_ref = docker_image.split("@")[0].split(":")[0]
+    image_ref = _extract_repo(docker_image)
     return ChainguardBaseImage(image_ref=image_ref, digest=digest)
 
 
@@ -203,11 +224,8 @@ def _detect_chainguard_from_provenance(docker_image: str) -> ChainguardBaseImage
 
     # Fetch the attestation manifest to find the provenance layer
     try:
-        att_manifest_json = _run_crane(["manifest", f"{docker_image.split(':')[0]}@{att_digest}"])
-        # Handle case where docker_image has @ instead of :
-        if "@" in docker_image:
-            registry_repo = docker_image.split("@")[0]
-            att_manifest_json = _run_crane(["manifest", f"{registry_repo}@{att_digest}"])
+        registry_repo = _extract_repo(docker_image)
+        att_manifest_json = _run_crane(["manifest", f"{registry_repo}@{att_digest}"])
         att_manifest = json.loads(att_manifest_json)
     except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
         logger.debug(f"Failed to fetch attestation manifest: {e}")
@@ -227,11 +245,6 @@ def _detect_chainguard_from_provenance(docker_image: str) -> ChainguardBaseImage
 
     # Fetch and parse the provenance blob
     try:
-        # Need to resolve the registry/repo for blob fetching
-        if "@" in docker_image:
-            registry_repo = docker_image.split("@")[0]
-        else:
-            registry_repo = docker_image.split(":")[0]
         provenance_json = _run_crane(["blob", f"{registry_repo}@{provenance_digest}"])
         provenance = json.loads(provenance_json)
     except (subprocess.CalledProcessError, json.JSONDecodeError) as e:

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -1150,9 +1150,7 @@ def run_pipeline(config: Config) -> None:
                     spdx_sbom = fetch_chainguard_sbom(chainguard_info)
 
                     if config.sbom_format == "cyclonedx":
-                        cdx_json = convert_spdx_to_cyclonedx(
-                            spdx_sbom, config.spec_version or "1.6"
-                        )
+                        cdx_json = convert_spdx_to_cyclonedx(spdx_sbom, config.spec_version or "1.6")
                         with open(STEP_1_FILE, "w", encoding="utf-8") as f:
                             f.write(cdx_json)
                     else:
@@ -1162,8 +1160,7 @@ def run_pipeline(config: Config) -> None:
                     result = GenerationResult.success_result(
                         output_file=STEP_1_FILE,
                         sbom_format=config.sbom_format,
-                        spec_version=config.spec_version
-                        or ("1.6" if config.sbom_format == "cyclonedx" else "2.3"),
+                        spec_version=config.spec_version or ("1.6" if config.sbom_format == "cyclonedx" else "2.3"),
                         generator_name="chainguard-sbom",
                     )
                 else:

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -1136,25 +1136,19 @@ def run_pipeline(config: Config) -> None:
                     fetch_chainguard_sbom,
                 )
 
-                chainguard_info = detect_chainguard_image(config.docker_image)
-
-                # Check version compatibility before fetching the SBOM
-                if chainguard_info and config.sbom_format == "spdx" and config.spec_version == "3.0.1":
-                    logger.info(
-                        "SPDX 3.0.1 requested; Chainguard provides SPDX 2.x — falling back to normal generation"
-                    )
-                    chainguard_info = None
-
-                if chainguard_info and config.sbom_format == "cyclonedx":
+                # Check format/version compatibility before attempting detection
+                chainguard_compatible = True
+                if config.sbom_format == "spdx" and config.spec_version == "3.0.1":
+                    logger.debug("SPDX 3.0.1 requested; skipping Chainguard detection")
+                    chainguard_compatible = False
+                elif config.sbom_format == "cyclonedx":
                     spec = config.spec_version or "1.6"
-                    # Compare as tuples for correct numeric ordering (e.g. "1.10" > "1.3")
                     spec_parts = tuple(int(x) for x in spec.split("."))
                     if spec_parts < (1, 3):
-                        logger.info(
-                            f"CycloneDX {spec} requested; Chainguard conversion requires 1.3+ — "
-                            "falling back to normal generation"
-                        )
-                        chainguard_info = None
+                        logger.debug(f"CycloneDX {spec} requested; skipping Chainguard detection")
+                        chainguard_compatible = False
+
+                chainguard_info = detect_chainguard_image(config.docker_image) if chainguard_compatible else None
 
                 if chainguard_info:
                     logger.info(f"Detected Chainguard base image: {chainguard_info.image_ref}")

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -1137,6 +1137,14 @@ def run_pipeline(config: Config) -> None:
                 )
 
                 chainguard_info = detect_chainguard_image(config.docker_image)
+
+                # Skip Chainguard reuse for incompatible spec versions
+                if chainguard_info and config.sbom_format == "spdx" and config.spec_version == "3.0.1":
+                    logger.info(
+                        "SPDX 3.0.1 requested; Chainguard provides SPDX 2.x — falling back to normal generation"
+                    )
+                    chainguard_info = None
+
                 if chainguard_info:
                     logger.info(f"Detected Chainguard base image: {chainguard_info.image_ref}")
 
@@ -1155,17 +1163,27 @@ def run_pipeline(config: Config) -> None:
                             title="Chainguard Image Detected",
                         )
                         if config.sbom_format == "cyclonedx":
-                            cdx_json = convert_spdx_to_cyclonedx(spdx_sbom, config.spec_version or "1.6")
-                            with open(STEP_1_FILE, "w", encoding="utf-8") as f:
-                                f.write(cdx_json)
-                            actual_spec_version = config.spec_version or "1.6"
+                            spec = config.spec_version or "1.6"
+                            # Chainguard conversion requires CDX 1.3+; fall back for older versions
+                            if spec < "1.3":
+                                logger.info(
+                                    f"CycloneDX {spec} requested; Chainguard conversion requires 1.3+ — "
+                                    "falling back to normal generation"
+                                )
+                                chainguard_info = None
+                            else:
+                                cdx_json = convert_spdx_to_cyclonedx(spdx_sbom, spec)
+                                with open(STEP_1_FILE, "w", encoding="utf-8") as f:
+                                    f.write(cdx_json)
+                                actual_spec_version = spec
                         else:
                             with open(STEP_1_FILE, "w", encoding="utf-8") as f:
                                 json.dump(spdx_sbom, f, ensure_ascii=False)
-                            # Use the actual SPDX version from the document, not what user requested
+                            # Use the actual SPDX version from the document
                             spdx_version = str(spdx_sbom.get("spdxVersion", "SPDX-2.3"))
                             actual_spec_version = spdx_version.replace("SPDX-", "")
 
+                    if chainguard_info:
                         result = GenerationResult.success_result(
                             output_file=STEP_1_FILE,
                             sbom_format=config.sbom_format,

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -1139,13 +1139,6 @@ def run_pipeline(config: Config) -> None:
                 chainguard_info = detect_chainguard_image(config.docker_image)
                 if chainguard_info:
                     logger.info(f"Detected Chainguard base image: {chainguard_info.image_ref}")
-                    gha_warning(
-                        "Chainguard image detected. Using Chainguard-provided SBOM. "
-                        "Any binaries added via COPY --from=... (e.g. cosign, crane, osv-scanner) "
-                        "will NOT be included. Use ADDITIONAL_PACKAGES to declare them. "
-                        "See: https://github.com/sbomify/sbomify-action#additional-packages",
-                        title="Chainguard Image Detected",
-                    )
 
                     try:
                         spdx_sbom = fetch_chainguard_sbom(chainguard_info)
@@ -1154,6 +1147,13 @@ def run_pipeline(config: Config) -> None:
                         chainguard_info = None
 
                     if chainguard_info:
+                        gha_warning(
+                            "Chainguard image detected. Using Chainguard-provided SBOM. "
+                            "Any binaries added via COPY --from=... (e.g. cosign, crane, osv-scanner) "
+                            "will NOT be included. Use ADDITIONAL_PACKAGES to declare them. "
+                            "See: https://github.com/sbomify/sbomify-action#additional-packages",
+                            title="Chainguard Image Detected",
+                        )
                         if config.sbom_format == "cyclonedx":
                             cdx_json = convert_spdx_to_cyclonedx(spdx_sbom, config.spec_version or "1.6")
                             with open(STEP_1_FILE, "w", encoding="utf-8") as f:

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -1147,23 +1147,29 @@ def run_pipeline(config: Config) -> None:
                         title="Chainguard Image Detected",
                     )
 
-                    spdx_sbom = fetch_chainguard_sbom(chainguard_info)
+                    try:
+                        spdx_sbom = fetch_chainguard_sbom(chainguard_info)
+                    except RuntimeError as e:
+                        logger.warning(f"Failed to fetch Chainguard SBOM, falling back to normal generation: {e}")
+                        chainguard_info = None
 
-                    if config.sbom_format == "cyclonedx":
-                        cdx_json = convert_spdx_to_cyclonedx(spdx_sbom, config.spec_version or "1.6")
-                        with open(STEP_1_FILE, "w", encoding="utf-8") as f:
-                            f.write(cdx_json)
-                    else:
-                        with open(STEP_1_FILE, "w", encoding="utf-8") as f:
-                            json.dump(spdx_sbom, f, ensure_ascii=False)
+                    if chainguard_info:
+                        if config.sbom_format == "cyclonedx":
+                            cdx_json = convert_spdx_to_cyclonedx(spdx_sbom, config.spec_version or "1.6")
+                            with open(STEP_1_FILE, "w", encoding="utf-8") as f:
+                                f.write(cdx_json)
+                        else:
+                            with open(STEP_1_FILE, "w", encoding="utf-8") as f:
+                                json.dump(spdx_sbom, f, ensure_ascii=False)
 
-                    result = GenerationResult.success_result(
-                        output_file=STEP_1_FILE,
-                        sbom_format=config.sbom_format,
-                        spec_version=config.spec_version or ("1.6" if config.sbom_format == "cyclonedx" else "2.3"),
-                        generator_name="chainguard-sbom",
-                    )
-                else:
+                        result = GenerationResult.success_result(
+                            output_file=STEP_1_FILE,
+                            sbom_format=config.sbom_format,
+                            spec_version=config.spec_version or ("1.6" if config.sbom_format == "cyclonedx" else "2.3"),
+                            generator_name="chainguard-sbom",
+                        )
+
+                if not chainguard_info:
                     logger.info(f"Generating SBOM from Docker image: {config.docker_image}")
                     result = generate_sbom(
                         docker_image=config.docker_image,

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -1138,12 +1138,23 @@ def run_pipeline(config: Config) -> None:
 
                 chainguard_info = detect_chainguard_image(config.docker_image)
 
-                # Skip Chainguard reuse for incompatible spec versions
+                # Check version compatibility before fetching the SBOM
                 if chainguard_info and config.sbom_format == "spdx" and config.spec_version == "3.0.1":
                     logger.info(
                         "SPDX 3.0.1 requested; Chainguard provides SPDX 2.x — falling back to normal generation"
                     )
                     chainguard_info = None
+
+                if chainguard_info and config.sbom_format == "cyclonedx":
+                    spec = config.spec_version or "1.6"
+                    # Compare as tuples for correct numeric ordering (e.g. "1.10" > "1.3")
+                    spec_parts = tuple(int(x) for x in spec.split("."))
+                    if spec_parts < (1, 3):
+                        logger.info(
+                            f"CycloneDX {spec} requested; Chainguard conversion requires 1.3+ — "
+                            "falling back to normal generation"
+                        )
+                        chainguard_info = None
 
                 if chainguard_info:
                     logger.info(f"Detected Chainguard base image: {chainguard_info.image_ref}")
@@ -1154,47 +1165,38 @@ def run_pipeline(config: Config) -> None:
                         logger.warning(f"Failed to fetch Chainguard SBOM, falling back to normal generation: {e}")
                         chainguard_info = None
 
-                    if chainguard_info:
-                        gha_warning(
-                            "Chainguard image detected. Using Chainguard-provided SBOM. "
-                            "Any binaries added via COPY --from=... (e.g. cosign, crane, osv-scanner) "
-                            "will NOT be included. Use ADDITIONAL_PACKAGES to declare them. "
-                            "See: https://github.com/sbomify/sbomify-action#additional-packages",
-                            title="Chainguard Image Detected",
-                        )
-                        if config.sbom_format == "cyclonedx":
-                            spec = config.spec_version or "1.6"
-                            # Chainguard conversion requires CDX 1.3+; fall back for older versions
-                            if spec < "1.3":
-                                logger.info(
-                                    f"CycloneDX {spec} requested; Chainguard conversion requires 1.3+ — "
-                                    "falling back to normal generation"
-                                )
-                                chainguard_info = None
-                            else:
-                                cdx_json = convert_spdx_to_cyclonedx(spdx_sbom, spec)
-                                with open(STEP_1_FILE, "w", encoding="utf-8") as f:
-                                    f.write(cdx_json)
-                                actual_spec_version = spec
-                        else:
-                            with open(STEP_1_FILE, "w", encoding="utf-8") as f:
-                                json.dump(spdx_sbom, f, ensure_ascii=False)
-                            # Use the actual SPDX version from the document
-                            spdx_version = str(spdx_sbom.get("spdxVersion", "SPDX-2.3"))
-                            actual_spec_version = spdx_version.replace("SPDX-", "")
-                            if config.spec_version and config.spec_version != actual_spec_version:
-                                logger.warning(
-                                    f"Requested SPDX {config.spec_version} but Chainguard SBOM is "
-                                    f"SPDX {actual_spec_version}; using {actual_spec_version}"
-                                )
+                if chainguard_info:
+                    if config.sbom_format == "cyclonedx":
+                        cdx_spec = config.spec_version or "1.6"
+                        cdx_json = convert_spdx_to_cyclonedx(spdx_sbom, cdx_spec)
+                        with open(STEP_1_FILE, "w", encoding="utf-8") as f:
+                            f.write(cdx_json)
+                        actual_spec_version = cdx_spec
+                    else:
+                        with open(STEP_1_FILE, "w", encoding="utf-8") as f:
+                            json.dump(spdx_sbom, f, ensure_ascii=False)
+                        # Use the actual SPDX version from the document
+                        spdx_version = str(spdx_sbom.get("spdxVersion", "SPDX-2.3"))
+                        actual_spec_version = spdx_version.replace("SPDX-", "")
+                        if config.spec_version and config.spec_version != actual_spec_version:
+                            logger.warning(
+                                f"Requested SPDX {config.spec_version} but Chainguard SBOM is "
+                                f"SPDX {actual_spec_version}; using {actual_spec_version}"
+                            )
 
-                    if chainguard_info:
-                        result = GenerationResult.success_result(
-                            output_file=STEP_1_FILE,
-                            sbom_format=config.sbom_format,
-                            spec_version=actual_spec_version,
-                            generator_name="chainguard-sbom",
-                        )
+                    gha_warning(
+                        "Chainguard image detected. Using Chainguard-provided SBOM. "
+                        "Any binaries added via COPY --from=... (e.g. cosign, crane, osv-scanner) "
+                        "will NOT be included. Use ADDITIONAL_PACKAGES to declare them. "
+                        "See: https://github.com/sbomify/sbomify-action#additional-packages",
+                        title="Chainguard Image Detected",
+                    )
+                    result = GenerationResult.success_result(
+                        output_file=STEP_1_FILE,
+                        sbom_format=config.sbom_format,
+                        spec_version=actual_spec_version,
+                        generator_name="chainguard-sbom",
+                    )
 
                 if not chainguard_info:
                     logger.info(f"Generating SBOM from Docker image: {config.docker_image}")

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -1158,14 +1158,18 @@ def run_pipeline(config: Config) -> None:
                             cdx_json = convert_spdx_to_cyclonedx(spdx_sbom, config.spec_version or "1.6")
                             with open(STEP_1_FILE, "w", encoding="utf-8") as f:
                                 f.write(cdx_json)
+                            actual_spec_version = config.spec_version or "1.6"
                         else:
                             with open(STEP_1_FILE, "w", encoding="utf-8") as f:
                                 json.dump(spdx_sbom, f, ensure_ascii=False)
+                            # Use the actual SPDX version from the document, not what user requested
+                            spdx_version = str(spdx_sbom.get("spdxVersion", "SPDX-2.3"))
+                            actual_spec_version = spdx_version.replace("SPDX-", "")
 
                         result = GenerationResult.success_result(
                             output_file=STEP_1_FILE,
                             sbom_format=config.sbom_format,
-                            spec_version=config.spec_version or ("1.6" if config.sbom_format == "cyclonedx" else "2.3"),
+                            spec_version=actual_spec_version,
                             generator_name="chainguard-sbom",
                         )
 

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -23,6 +23,7 @@ from ..console import (
     get_audit_trail,
     gha_group,
     gha_notice,
+    gha_warning,
     print_component_not_found_error,
     print_duplicate_sbom_error,
     print_final_success,
@@ -44,6 +45,7 @@ from ..exceptions import (
 )
 from ..generation import (
     ALL_LOCK_FILES,
+    GenerationResult,
     SBOMFormat,
     generate_sbom,
     process_lock_file,
@@ -1127,15 +1129,53 @@ def run_pipeline(config: Config) -> None:
                     except (OSError, json.JSONDecodeError) as e:
                         logger.warning(f"Could not sanitize SPDX licenses in input SBOM: {e}")
             elif config.docker_image:
-                logger.info(f"Generating SBOM from Docker image: {config.docker_image}")
-                result = generate_sbom(
-                    docker_image=config.docker_image,
-                    output_file=STEP_1_FILE,
-                    output_format=config.sbom_format,
-                    spec_version=config.spec_version,
+                # Check if image is or is built FROM a Chainguard image
+                from .._generation.chainguard import (
+                    convert_spdx_to_cyclonedx,
+                    detect_chainguard_image,
+                    fetch_chainguard_sbom,
                 )
-                if not result.success:
-                    raise SBOMGenerationError(result.error_message or "SBOM generation failed")
+
+                chainguard_info = detect_chainguard_image(config.docker_image)
+                if chainguard_info:
+                    logger.info(f"Detected Chainguard base image: {chainguard_info.image_ref}")
+                    gha_warning(
+                        "Chainguard image detected. Using Chainguard-provided SBOM. "
+                        "Any binaries added via COPY --from=... (e.g. cosign, crane, osv-scanner) "
+                        "will NOT be included. Use ADDITIONAL_PACKAGES to declare them. "
+                        "See: https://github.com/sbomify/sbomify-action#additional-packages",
+                        title="Chainguard Image Detected",
+                    )
+
+                    spdx_sbom = fetch_chainguard_sbom(chainguard_info)
+
+                    if config.sbom_format == "cyclonedx":
+                        cdx_json = convert_spdx_to_cyclonedx(
+                            spdx_sbom, config.spec_version or "1.6"
+                        )
+                        with open(STEP_1_FILE, "w", encoding="utf-8") as f:
+                            f.write(cdx_json)
+                    else:
+                        with open(STEP_1_FILE, "w", encoding="utf-8") as f:
+                            json.dump(spdx_sbom, f, ensure_ascii=False)
+
+                    result = GenerationResult.success_result(
+                        output_file=STEP_1_FILE,
+                        sbom_format=config.sbom_format,
+                        spec_version=config.spec_version
+                        or ("1.6" if config.sbom_format == "cyclonedx" else "2.3"),
+                        generator_name="chainguard-sbom",
+                    )
+                else:
+                    logger.info(f"Generating SBOM from Docker image: {config.docker_image}")
+                    result = generate_sbom(
+                        docker_image=config.docker_image,
+                        output_file=STEP_1_FILE,
+                        output_format=config.sbom_format,
+                        spec_version=config.spec_version,
+                    )
+                    if not result.success:
+                        raise SBOMGenerationError(result.error_message or "SBOM generation failed")
             elif FILE_TYPE == "LOCK_FILE":
                 logger.info(f"Generating SBOM from lock file: {FILE}")
                 result = process_lock_file(

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -1182,6 +1182,11 @@ def run_pipeline(config: Config) -> None:
                             # Use the actual SPDX version from the document
                             spdx_version = str(spdx_sbom.get("spdxVersion", "SPDX-2.3"))
                             actual_spec_version = spdx_version.replace("SPDX-", "")
+                            if config.spec_version and config.spec_version != actual_spec_version:
+                                logger.warning(
+                                    f"Requested SPDX {config.spec_version} but Chainguard SBOM is "
+                                    f"SPDX {actual_spec_version}; using {actual_spec_version}"
+                                )
 
                     if chainguard_info:
                         result = GenerationResult.success_result(

--- a/sbomify_action/tool_checks.py
+++ b/sbomify_action/tool_checks.py
@@ -83,6 +83,28 @@ _TOOL_METADATA: dict[str, dict[str, object]] = {
         "homepage": "https://github.com/CycloneDX/cyclonedx-rust-cargo",
         "required_for": ["Rust lockfiles (Cargo.lock)"],
     },
+    "crane": {
+        "name": "crane",
+        "description": "OCI registry client for inspecting container images",
+        "install_instructions": (
+            "Install via package manager:\n"
+            "  - macOS: brew install crane\n"
+            "  - Linux: See https://github.com/google/go-containerregistry/releases"
+        ),
+        "homepage": "https://github.com/google/go-containerregistry",
+        "required_for": ["Chainguard image detection"],
+    },
+    "cosign": {
+        "name": "cosign",
+        "description": "Container image signing and attestation tool",
+        "install_instructions": (
+            "Install via package manager:\n"
+            "  - macOS: brew install cosign\n"
+            "  - Linux: See https://github.com/sigstore/cosign/releases"
+        ),
+        "homepage": "https://github.com/sigstore/cosign",
+        "required_for": ["Chainguard SBOM retrieval"],
+    },
 }
 
 

--- a/tests/test_chainguard.py
+++ b/tests/test_chainguard.py
@@ -346,6 +346,41 @@ class TestDetectFromProvenance:
 
     @patch("sbomify_action._generation.chainguard.shutil.which", return_value="/usr/local/bin/crane")
     @patch("sbomify_action._generation.chainguard._run_crane")
+    def test_detects_chainguard_with_registry_port(self, mock_crane, mock_which):
+        """Ensure provenance detection works with registry:port image refs."""
+        chainguard_manifest_list = json.dumps(
+            {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.image.index.v1+json",
+                "manifests": [
+                    {
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "digest": "sha256:platformdigest0000000000000000000000000000000000000000000000000",
+                        "platform": {"architecture": "amd64", "os": "linux"},
+                    },
+                ],
+            }
+        )
+
+        mock_crane.side_effect = [
+            MANIFEST_WITH_ATTESTATION,
+            ATTESTATION_MANIFEST,
+            PROVENANCE_WITH_CHAINGUARD,
+            chainguard_manifest_list,
+        ]
+
+        result = detect_chainguard_image("localhost:5000/myorg/myapp:v1.0")
+        assert result is not None
+        assert result.image_ref == "cgr.dev/chainguard/python"
+
+        # Verify crane was called with correct repo (port preserved, tag stripped)
+        calls = mock_crane.call_args_list
+        # Second call: crane manifest for attestation should use "localhost:5000/myorg/myapp@<digest>"
+        att_call_args = calls[1][0][0]  # first positional arg is the args list
+        assert att_call_args[1].startswith("localhost:5000/myorg/myapp@")
+
+    @patch("sbomify_action._generation.chainguard.shutil.which", return_value="/usr/local/bin/crane")
+    @patch("sbomify_action._generation.chainguard._run_crane")
     def test_no_chainguard_in_provenance(self, mock_crane, mock_which):
         mock_crane.side_effect = [
             MANIFEST_WITH_ATTESTATION,

--- a/tests/test_chainguard.py
+++ b/tests/test_chainguard.py
@@ -1,0 +1,465 @@
+"""Tests for Chainguard base image detection and SBOM reuse."""
+
+import base64
+import json
+from unittest.mock import patch
+
+import pytest
+
+from sbomify_action._generation.chainguard import (
+    ChainguardBaseImage,
+    _parse_purl_docker_uri,
+    convert_spdx_to_cyclonedx,
+    detect_chainguard_image,
+    fetch_chainguard_sbom,
+)
+
+# --- Fixtures ---
+
+
+CHAINGUARD_CONFIG = json.dumps(
+    {
+        "author": "github.com/chainguard-dev/apko",
+        "config": {
+            "Labels": {
+                "dev.chainguard.image.title": "python",
+                "org.opencontainers.image.authors": "Chainguard Team https://www.chainguard.dev/",
+            }
+        },
+    }
+)
+
+NON_CHAINGUARD_CONFIG = json.dumps(
+    {
+        "author": "docker.io",
+        "config": {"Labels": {"maintainer": "NGINX Docker Maintainers"}},
+    }
+)
+
+MANIFEST_LIST = json.dumps(
+    {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": [
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": "sha256:amd64digest000000000000000000000000000000000000000000000000000000",
+                "platform": {"architecture": "amd64", "os": "linux"},
+            },
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": "sha256:arm64digest000000000000000000000000000000000000000000000000000000",
+                "platform": {"architecture": "arm64", "os": "linux"},
+            },
+        ],
+    }
+)
+
+MANIFEST_WITH_ATTESTATION = json.dumps(
+    {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": [
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": "sha256:imagedigest0000000000000000000000000000000000000000000000000000",
+                "platform": {"architecture": "amd64", "os": "linux"},
+            },
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": "sha256:attdigest00000000000000000000000000000000000000000000000000000000",
+                "annotations": {
+                    "vnd.docker.reference.digest": "sha256:imagedigest0000000000000000000000000000000000000000000000000000",
+                    "vnd.docker.reference.type": "attestation-manifest",
+                },
+                "platform": {"architecture": "unknown", "os": "unknown"},
+            },
+        ],
+    }
+)
+
+ATTESTATION_MANIFEST = json.dumps(
+    {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "layers": [
+            {
+                "mediaType": "application/vnd.in-toto+json",
+                "digest": "sha256:provdigest00000000000000000000000000000000000000000000000000000",
+                "annotations": {
+                    "in-toto.io/predicate-type": "https://slsa.dev/provenance/v1",
+                },
+            }
+        ],
+    }
+)
+
+PROVENANCE_WITH_CHAINGUARD = json.dumps(
+    {
+        "_type": "https://in-toto.io/Statement/v0.1",
+        "predicateType": "https://slsa.dev/provenance/v1",
+        "predicate": {
+            "buildDefinition": {
+                "resolvedDependencies": [
+                    {
+                        "uri": "pkg:docker/cgr.dev/chainguard/python?digest=sha256:chainguarddigest000000000000000000000000000000000000000000000000&platform=linux%2Famd64",
+                        "digest": {"sha256": "chainguarddigest000000000000000000000000000000000000000000000000"},
+                    },
+                    {
+                        "uri": "pkg:docker/alpine@3.21?platform=linux%2Famd64",
+                        "digest": {"sha256": "alpinedigest0000000000000000000000000000000000000000000000000000"},
+                    },
+                ]
+            }
+        },
+    }
+)
+
+PROVENANCE_WITHOUT_CHAINGUARD = json.dumps(
+    {
+        "_type": "https://in-toto.io/Statement/v0.1",
+        "predicateType": "https://slsa.dev/provenance/v1",
+        "predicate": {
+            "buildDefinition": {
+                "resolvedDependencies": [
+                    {
+                        "uri": "pkg:docker/python@3.13-slim?platform=linux%2Famd64",
+                        "digest": {"sha256": "pythondigest000000000000000000000000000000000000000000000000000"},
+                    },
+                ]
+            }
+        },
+    }
+)
+
+SAMPLE_SPDX_SBOM = {
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "spdxVersion": "SPDX-2.3",
+    "creationInfo": {
+        "created": "2026-03-24T21:51:39Z",
+        "creators": ["Tool: apko (v1.1.14)", "Organization: Chainguard, Inc"],
+        "licenseListVersion": "3.27",
+    },
+    "dataLicense": "CC0-1.0",
+    "documentDescribes": ["SPDXRef-Package-image"],
+    "documentNamespace": "https://spdx.org/spdxdocs/apko/",
+    "name": "sbom-chainguard-python",
+    "packages": [
+        {
+            "SPDXID": "SPDXRef-Package-image",
+            "name": "sha256:abc123",
+            "versionInfo": "sha256:abc123",
+            "description": "Multi-arch image index",
+            "downloadLocation": "NOASSERTION",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceLocator": "pkg:oci/index@sha256:abc123?mediaType=application%2Fvnd.oci.image.index.v1%2Bjson",
+                    "referenceType": "purl",
+                }
+            ],
+            "filesAnalyzed": False,
+            "primaryPackagePurpose": "CONTAINER",
+            "supplier": "Organization: Chainguard, Inc.",
+        },
+        {
+            "SPDXID": "SPDXRef-Package-glibc",
+            "name": "glibc",
+            "versionInfo": "2.43-r3",
+            "downloadLocation": "NOASSERTION",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceLocator": "pkg:apk/wolfi/glibc@2.43-r3?arch=x86_64&distro=wolfi",
+                    "referenceType": "purl",
+                }
+            ],
+            "filesAnalyzed": False,
+            "checksums": [{"algorithm": "SHA256", "checksumValue": "deadbeef" * 8}],
+            "supplier": "Organization: Wolfi",
+        },
+        {
+            "SPDXID": "SPDXRef-Package-libssl3",
+            "name": "libssl3",
+            "versionInfo": "3.6.1-r4",
+            "downloadLocation": "NOASSERTION",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceLocator": "pkg:apk/wolfi/libssl3@3.6.1-r4?arch=x86_64&distro=wolfi",
+                    "referenceType": "purl",
+                }
+            ],
+            "filesAnalyzed": False,
+            "supplier": "Organization: Wolfi",
+        },
+    ],
+    "relationships": [
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-image",
+            "relationshipType": "DESCRIBES",
+        },
+    ],
+}
+
+
+def _make_cosign_attestation_output(spdx_doc: dict) -> str:
+    """Build cosign download attestation output for a given SPDX doc."""
+    payload = {
+        "predicateType": "https://spdx.dev/Document",
+        "predicate": spdx_doc,
+    }
+    encoded = base64.b64encode(json.dumps(payload).encode()).decode()
+    envelope = {"payloadType": "application/vnd.in-toto+json", "payload": encoded}
+    return json.dumps(envelope)
+
+
+# --- Tests ---
+
+
+class TestParseDockerPurl:
+    def test_chainguard_purl(self):
+        uri = "pkg:docker/cgr.dev/chainguard/python?digest=sha256:abc123&platform=linux%2Famd64"
+        result = _parse_purl_docker_uri(uri)
+        assert result == ("cgr.dev/chainguard/python", "sha256:abc123")
+
+    def test_purl_with_tag(self):
+        uri = "pkg:docker/alpine@3.21?platform=linux%2Famd64"
+        result = _parse_purl_docker_uri(uri)
+        assert result is None  # No digest
+
+    def test_purl_with_tag_and_digest(self):
+        uri = "pkg:docker/oven/bun@1.3-debian?digest=sha256:abc123&platform=linux%2Famd64"
+        result = _parse_purl_docker_uri(uri)
+        assert result == ("oven/bun", "sha256:abc123")
+
+    def test_non_docker_purl(self):
+        assert _parse_purl_docker_uri("pkg:npm/vue@3.0.0") is None
+
+    def test_no_query(self):
+        assert _parse_purl_docker_uri("pkg:docker/nginx") is None
+
+
+class TestDetectDirectChainguard:
+    @patch("sbomify_action._generation.chainguard.shutil.which", return_value="/usr/local/bin/crane")
+    @patch("sbomify_action._generation.chainguard._run_crane")
+    def test_direct_chainguard_image(self, mock_crane, mock_which):
+        mock_crane.side_effect = [
+            # 1. _is_chainguard_config: crane config
+            CHAINGUARD_CONFIG,
+            # 2. _resolve_platform_digest: crane manifest (manifest list)
+            MANIFEST_LIST,
+        ]
+
+        result = detect_chainguard_image("cgr.dev/chainguard/python:latest")
+        assert result is not None
+        assert result.image_ref == "cgr.dev/chainguard/python"
+        # Digest depends on current platform (amd64 or arm64)
+        assert result.digest.startswith("sha256:")
+
+    @patch("sbomify_action._generation.chainguard.shutil.which", return_value="/usr/local/bin/crane")
+    @patch("sbomify_action._generation.chainguard._run_crane")
+    def test_non_chainguard_returns_none(self, mock_crane, mock_which):
+        # Not cgr.dev prefix, so tries provenance path
+        # crane manifest for provenance detection — return simple manifest (no attestation)
+        simple_manifest = json.dumps(
+            {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.image.index.v1+json",
+                "manifests": [
+                    {
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "digest": "sha256:abc123",
+                        "platform": {"architecture": "amd64", "os": "linux"},
+                    },
+                ],
+            }
+        )
+        mock_crane.side_effect = [simple_manifest]
+
+        result = detect_chainguard_image("nginx:latest")
+        assert result is None
+
+    @patch("sbomify_action._generation.chainguard.shutil.which", return_value=None)
+    def test_crane_not_available(self, mock_which):
+        result = detect_chainguard_image("cgr.dev/chainguard/python:latest")
+        assert result is None
+
+
+class TestDetectFromProvenance:
+    @patch("sbomify_action._generation.chainguard.shutil.which", return_value="/usr/local/bin/crane")
+    @patch("sbomify_action._generation.chainguard._run_crane")
+    def test_detects_chainguard_base_in_provenance(self, mock_crane, mock_which):
+        # Resolve platform digest for the found Chainguard image
+        chainguard_manifest_list = json.dumps(
+            {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.image.index.v1+json",
+                "manifests": [
+                    {
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "digest": "sha256:platformdigest0000000000000000000000000000000000000000000000000",
+                        "platform": {"architecture": "amd64", "os": "linux"},
+                    },
+                ],
+            }
+        )
+
+        mock_crane.side_effect = [
+            # detect_chainguard_image -> _detect_chainguard_from_provenance:
+            # 1. crane manifest (image index with attestation)
+            MANIFEST_WITH_ATTESTATION,
+            # 2. crane manifest (attestation manifest)
+            ATTESTATION_MANIFEST,
+            # 3. crane blob (provenance)
+            PROVENANCE_WITH_CHAINGUARD,
+            # 4. _resolve_platform_digest: crane manifest for the Chainguard image
+            chainguard_manifest_list,
+        ]
+
+        result = detect_chainguard_image("sbomifyhub/sbomify:latest")
+        assert result is not None
+        assert result.image_ref == "cgr.dev/chainguard/python"
+        assert result.digest.startswith("sha256:")
+
+    @patch("sbomify_action._generation.chainguard.shutil.which", return_value="/usr/local/bin/crane")
+    @patch("sbomify_action._generation.chainguard._run_crane")
+    def test_no_chainguard_in_provenance(self, mock_crane, mock_which):
+        mock_crane.side_effect = [
+            MANIFEST_WITH_ATTESTATION,
+            ATTESTATION_MANIFEST,
+            PROVENANCE_WITHOUT_CHAINGUARD,
+        ]
+
+        result = detect_chainguard_image("myapp:latest")
+        assert result is None
+
+    @patch("sbomify_action._generation.chainguard.shutil.which", return_value="/usr/local/bin/crane")
+    @patch("sbomify_action._generation.chainguard._run_crane")
+    def test_no_attestation_manifest(self, mock_crane, mock_which):
+        # Image index without attestation manifest
+        simple_manifest = json.dumps(
+            {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.image.index.v1+json",
+                "manifests": [
+                    {
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "digest": "sha256:abc123",
+                        "platform": {"architecture": "amd64", "os": "linux"},
+                    },
+                ],
+            }
+        )
+        mock_crane.side_effect = [simple_manifest]
+
+        result = detect_chainguard_image("oldimage:latest")
+        assert result is None
+
+
+class TestFetchChainguardSbom:
+    @patch("sbomify_action._generation.chainguard.shutil.which", return_value="/usr/local/bin/cosign")
+    @patch("sbomify_action._generation.chainguard._run_cosign")
+    def test_fetches_spdx_sbom(self, mock_cosign, mock_which):
+        cosign_output = _make_cosign_attestation_output(SAMPLE_SPDX_SBOM)
+        mock_cosign.return_value = cosign_output
+
+        info = ChainguardBaseImage(
+            image_ref="cgr.dev/chainguard/python",
+            digest="sha256:abc123",
+        )
+        result = fetch_chainguard_sbom(info)
+
+        assert result["spdxVersion"] == "SPDX-2.3"
+        assert len(result["packages"]) == 3
+
+    @patch("sbomify_action._generation.chainguard.shutil.which", return_value="/usr/local/bin/cosign")
+    @patch("sbomify_action._generation.chainguard._run_cosign")
+    def test_no_spdx_attestation_raises(self, mock_cosign, mock_which):
+        # Return a non-SPDX attestation
+        payload = {"predicateType": "https://slsa.dev/provenance/v1", "predicate": {}}
+        encoded = base64.b64encode(json.dumps(payload).encode()).decode()
+        envelope = {"payload": encoded}
+        mock_cosign.return_value = json.dumps(envelope)
+
+        info = ChainguardBaseImage(image_ref="cgr.dev/chainguard/python", digest="sha256:abc")
+
+        with pytest.raises(RuntimeError, match="No SPDX SBOM found"):
+            fetch_chainguard_sbom(info)
+
+    @patch("sbomify_action._generation.chainguard.shutil.which", return_value=None)
+    def test_cosign_not_available_raises(self, mock_which):
+        info = ChainguardBaseImage(image_ref="cgr.dev/chainguard/python", digest="sha256:abc")
+        with pytest.raises(RuntimeError, match="cosign not found"):
+            fetch_chainguard_sbom(info)
+
+
+class TestConvertSpdxToCyclonedx:
+    def test_converts_basic_sbom(self):
+        result = convert_spdx_to_cyclonedx(SAMPLE_SPDX_SBOM, "1.6")
+
+        # Parse the result as JSON
+        cdx = json.loads(result)
+        assert cdx["bomFormat"] == "CycloneDX"
+        assert cdx["specVersion"] == "1.6"
+
+        # Should have components (glibc, libssl3 — image is metadata.component)
+        assert len(cdx.get("components", [])) == 2
+
+        # Check metadata.component is the described package
+        meta_comp = cdx.get("metadata", {}).get("component", {})
+        assert meta_comp.get("type") == "container"
+
+        # Check a component has the correct PURL
+        component_names = {c["name"] for c in cdx["components"]}
+        assert "glibc" in component_names
+        assert "libssl3" in component_names
+
+        # Check purl is set
+        for comp in cdx["components"]:
+            if comp["name"] == "glibc":
+                assert "pkg:apk/wolfi/glibc" in comp.get("purl", "")
+                assert comp["version"] == "2.43-r3"
+
+    def test_converts_with_supplier(self):
+        result = convert_spdx_to_cyclonedx(SAMPLE_SPDX_SBOM, "1.6")
+        cdx = json.loads(result)
+
+        for comp in cdx["components"]:
+            if comp["name"] == "glibc":
+                supplier = comp.get("supplier", {})
+                assert supplier.get("name") == "Wolfi"
+
+    def test_converts_with_hashes(self):
+        result = convert_spdx_to_cyclonedx(SAMPLE_SPDX_SBOM, "1.6")
+        cdx = json.loads(result)
+
+        for comp in cdx["components"]:
+            if comp["name"] == "glibc":
+                assert len(comp.get("hashes", [])) > 0
+                assert comp["hashes"][0]["alg"] == "SHA-256"
+
+    def test_converts_with_creation_info(self):
+        result = convert_spdx_to_cyclonedx(SAMPLE_SPDX_SBOM, "1.6")
+        cdx = json.loads(result)
+
+        metadata = cdx.get("metadata", {})
+        assert "timestamp" in metadata
+
+    def test_spec_version_1_5(self):
+        result = convert_spdx_to_cyclonedx(SAMPLE_SPDX_SBOM, "1.5")
+        cdx = json.loads(result)
+        assert cdx["specVersion"] == "1.5"
+
+    def test_empty_packages(self):
+        empty_sbom = {
+            "spdxVersion": "SPDX-2.3",
+            "creationInfo": {"created": "2026-01-01T00:00:00Z", "creators": []},
+            "packages": [],
+            "documentDescribes": [],
+        }
+        result = convert_spdx_to_cyclonedx(empty_sbom, "1.6")
+        cdx = json.loads(result)
+        assert cdx["bomFormat"] == "CycloneDX"
+        assert len(cdx.get("components", [])) == 0

--- a/tests/test_chainguard.py
+++ b/tests/test_chainguard.py
@@ -8,6 +8,7 @@ import pytest
 
 from sbomify_action._generation.chainguard import (
     ChainguardBaseImage,
+    _extract_repo,
     _parse_purl_docker_uri,
     convert_spdx_to_cyclonedx,
     detect_chainguard_image,
@@ -216,6 +217,26 @@ def _make_cosign_attestation_output(spdx_doc: dict) -> str:
 
 
 # --- Tests ---
+
+
+class TestExtractRepo:
+    def test_simple_tag(self):
+        assert _extract_repo("nginx:latest") == "nginx"
+
+    def test_registry_with_port(self):
+        assert _extract_repo("localhost:5000/repo/image:tag") == "localhost:5000/repo/image"
+
+    def test_digest_ref(self):
+        assert _extract_repo("nginx@sha256:abc123") == "nginx"
+
+    def test_registry_port_and_digest(self):
+        assert _extract_repo("localhost:5000/repo@sha256:abc123") == "localhost:5000/repo"
+
+    def test_no_tag_or_digest(self):
+        assert _extract_repo("cgr.dev/chainguard/python") == "cgr.dev/chainguard/python"
+
+    def test_tag_with_registry_port(self):
+        assert _extract_repo("myregistry.io:8443/org/app:v1.2.3") == "myregistry.io:8443/org/app"
 
 
 class TestParseDockerPurl:


### PR DESCRIPTION
## Summary

- Detects Chainguard images automatically — both direct (`cgr.dev/chainguard/...`) and as base images in user-built images via BuildKit SLSA provenance attestations
- Downloads the Chainguard-provided SPDX SBOM from cosign attestations (per-architecture, ~122 packages with `pkg:apk/wolfi/...` PURLs)
- Converts SPDX → CycloneDX when CDX format is requested (small SBOM, straightforward mapping)
- Warns users that binaries added via `COPY --from=...` need to be declared with `ADDITIONAL_PACKAGES`
- Bundles `crane` (v0.21.5) and `cosign` (v3.0.6) in the Docker image for registry inspection and attestation retrieval
- Falls through to normal cdxgen/syft generation when no Chainguard image is detected

## Test plan

- [ ] Unit tests pass: `uv run pytest tests/test_chainguard.py -v` (20 tests, all mocked)
- [ ] Full test suite passes with no regressions
- [ ] E2E: `sbomify-action --docker-image cgr.dev/chainguard/python:latest -o sbom.json` produces valid CycloneDX
- [ ] E2E: `sbomify-action --docker-image cgr.dev/chainguard/python:latest -f spdx -o sbom.spdx.json` uses SPDX directly
- [ ] E2E: `sbomify-action --docker-image sbomifyhub/sbomify:latest -o sbom.json` detects Chainguard base via provenance
- [ ] E2E: `sbomify-action --docker-image nginx:latest -o sbom.json` falls through to normal generation
- [ ] Docker build succeeds with crane + cosign installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)