### PR TITLE
Make ghcr.io the primary registry, Docker Hub the mirror

### DIFF
--- a/.github/workflows/sbomify.yaml
+++ b/.github/workflows/sbomify.yaml
@@ -1208,7 +1208,7 @@ jobs:
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
           COMPONENT_VERSION: ${{ steps.version.outputs.version }}
-          COMPONENT_PURL: ${{ matrix.component == 'action' && format('pkg:docker/sbomify/sbomify-action@{0}?repository_url=ghcr.io', steps.version.outputs.version) || '' }}
+          COMPONENT_PURL: ${{ matrix.component == 'action' && format('pkg:docker/sbomify/sbomify-action@{0}?repository_url=ghcr.io', steps.version.outputs.docker_tag) || '' }}
           LOCK_FILE: ${{ matrix.lock_file }}
           PRODUCT_RELEASE: ${{ matrix.has_product_release && format('["{0}:{1}"]', matrix.product_release_id, steps.version.outputs.version) || '' }}
           SBOM_FORMAT: ${{ matrix.format }}
@@ -1294,7 +1294,7 @@ jobs:
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
           COMPONENT_VERSION: ${{ steps.version.outputs.version }}
-          COMPONENT_PURL: ${{ matrix.component == 'action' && format('pkg:docker/sbomify/sbomify-action@{0}?repository_url=ghcr.io', steps.version.outputs.version) || '' }}
+          COMPONENT_PURL: ${{ matrix.component == 'action' && format('pkg:docker/sbomify/sbomify-action@{0}?repository_url=ghcr.io', steps.version.outputs.docker_tag) || '' }}
           LOCK_FILE: ${{ matrix.lock_file }}
           PRODUCT_RELEASE: ${{ matrix.has_product_release && format('["{0}:{1}"]', matrix.product_release_id, steps.version.outputs.version) || '' }}
           SBOM_FORMAT: ${{ matrix.format }}
@@ -1364,7 +1364,7 @@ jobs:
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
           COMPONENT_VERSION: ${{ steps.version.outputs.version }}
-          COMPONENT_PURL: pkg:docker/sbomify/sbomify-action@${{ steps.version.outputs.version }}?repository_url=ghcr.io
+          COMPONENT_PURL: pkg:docker/sbomify/sbomify-action@${{ steps.version.outputs.docker_tag }}?repository_url=ghcr.io
           DOCKER_IMAGE: ghcr.io/sbomify/sbomify-action:${{ steps.version.outputs.docker_tag }}
           ADDITIONAL_PACKAGES_FILE: container_additional_packages.txt
           PRODUCT_RELEASE: ${{ matrix.has_product_release && format('["{0}:{1}"]', matrix.product_release_id, steps.version.outputs.version) || '' }}
@@ -1434,7 +1434,7 @@ jobs:
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
           COMPONENT_VERSION: ${{ steps.version.outputs.version }}
-          COMPONENT_PURL: pkg:docker/sbomify/sbomify-action@${{ steps.version.outputs.version }}?repository_url=ghcr.io
+          COMPONENT_PURL: pkg:docker/sbomify/sbomify-action@${{ steps.version.outputs.docker_tag }}?repository_url=ghcr.io
           DOCKER_IMAGE: ghcr.io/sbomify/sbomify-action:${{ steps.version.outputs.docker_tag }}
           ADDITIONAL_PACKAGES_FILE: container_additional_packages.txt
           PRODUCT_RELEASE: ${{ matrix.has_product_release && format('["{0}:{1}"]', matrix.product_release_id, steps.version.outputs.version) || '' }}

--- a/.github/workflows/sbomify.yaml
+++ b/.github/workflows/sbomify.yaml
@@ -1134,8 +1134,8 @@ jobs:
           docker push $DOCKER_HUB_IMAGE_ID:$VERSION
 
           echo \`\`\` >> ${GITHUB_STEP_SUMMARY}
-          echo "Use $GITHUB_IMAGE_ID:$VERSION within GitHub" >> ${GITHUB_STEP_SUMMARY}
-          echo "Use $DOCKER_HUB_IMAGE_ID:$VERSION outside of GitHub" >> ${GITHUB_STEP_SUMMARY}
+          echo "Primary: $GITHUB_IMAGE_ID:$VERSION" >> ${GITHUB_STEP_SUMMARY}
+          echo "Mirror:  $DOCKER_HUB_IMAGE_ID:$VERSION" >> ${GITHUB_STEP_SUMMARY}
           echo \`\`\` >> ${GITHUB_STEP_SUMMARY}
 
   # =========================================================================
@@ -1208,7 +1208,7 @@ jobs:
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
           COMPONENT_VERSION: ${{ steps.version.outputs.version }}
-          COMPONENT_PURL: ${{ matrix.component == 'action' && format('pkg:docker/sbomifyhub/sbomify-action@{0}', steps.version.outputs.version) || '' }}
+          COMPONENT_PURL: ${{ matrix.component == 'action' && format('pkg:docker/sbomify/sbomify-action@{0}?repository_url=ghcr.io', steps.version.outputs.version) || '' }}
           LOCK_FILE: ${{ matrix.lock_file }}
           PRODUCT_RELEASE: ${{ matrix.has_product_release && format('["{0}:{1}"]', matrix.product_release_id, steps.version.outputs.version) || '' }}
           SBOM_FORMAT: ${{ matrix.format }}
@@ -1294,7 +1294,7 @@ jobs:
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
           COMPONENT_VERSION: ${{ steps.version.outputs.version }}
-          COMPONENT_PURL: ${{ matrix.component == 'action' && format('pkg:docker/sbomifyhub/sbomify-action@{0}', steps.version.outputs.version) || '' }}
+          COMPONENT_PURL: ${{ matrix.component == 'action' && format('pkg:docker/sbomify/sbomify-action@{0}?repository_url=ghcr.io', steps.version.outputs.version) || '' }}
           LOCK_FILE: ${{ matrix.lock_file }}
           PRODUCT_RELEASE: ${{ matrix.has_product_release && format('["{0}:{1}"]', matrix.product_release_id, steps.version.outputs.version) || '' }}
           SBOM_FORMAT: ${{ matrix.format }}
@@ -1364,8 +1364,8 @@ jobs:
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
           COMPONENT_VERSION: ${{ steps.version.outputs.version }}
-          COMPONENT_PURL: pkg:docker/sbomifyhub/sbomify-action@${{ steps.version.outputs.version }}
-          DOCKER_IMAGE: sbomifyhub/sbomify-action:${{ steps.version.outputs.docker_tag }}
+          COMPONENT_PURL: pkg:docker/sbomify/sbomify-action@${{ steps.version.outputs.version }}?repository_url=ghcr.io
+          DOCKER_IMAGE: ghcr.io/sbomify/sbomify-action:${{ steps.version.outputs.docker_tag }}
           ADDITIONAL_PACKAGES_FILE: container_additional_packages.txt
           PRODUCT_RELEASE: ${{ matrix.has_product_release && format('["{0}:{1}"]', matrix.product_release_id, steps.version.outputs.version) || '' }}
           SBOM_FORMAT: ${{ matrix.format }}
@@ -1434,8 +1434,8 @@ jobs:
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
           COMPONENT_VERSION: ${{ steps.version.outputs.version }}
-          COMPONENT_PURL: pkg:docker/sbomifyhub/sbomify-action@${{ steps.version.outputs.version }}
-          DOCKER_IMAGE: sbomifyhub/sbomify-action:${{ steps.version.outputs.docker_tag }}
+          COMPONENT_PURL: pkg:docker/sbomify/sbomify-action@${{ steps.version.outputs.version }}?repository_url=ghcr.io
+          DOCKER_IMAGE: ghcr.io/sbomify/sbomify-action:${{ steps.version.outputs.docker_tag }}
           ADDITIONAL_PACKAGES_FILE: container_additional_packages.txt
           PRODUCT_RELEASE: ${{ matrix.has_product_release && format('["{0}:{1}"]', matrix.product_release_id, steps.version.outputs.version) || '' }}
           SBOM_FORMAT: ${{ matrix.format }}

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: 'docker'
   # Bump/pin this to release
-  image: 'docker://sbomifyhub/sbomify-action:latest'
+  image: 'docker://ghcr.io/sbomify/sbomify-action:latest'
   env:
     WORKING_DIR: ${{ inputs['working-dir'] }}
     COMPONENT_PURL: ${{ inputs['component-purl'] }}


### PR DESCRIPTION
## Summary

- `action.yml` now points at `docker://ghcr.io/sbomify/sbomify-action:latest` so the GitHub Action pulls from GHCR.
- Workflow build/push step labels GHCR as **Primary** and Docker Hub as **Mirror** in the job summary; push order and dual-registry logic are unchanged (Docker Hub still receives the same tags).
- Self-SBOM `DOCKER_IMAGE` and `COMPONENT_PURL` references repointed to the ghcr.io form (`pkg:docker/sbomify/sbomify-action@<v>?repository_url=ghcr.io`) so the canonical published artifact identity matches the new primary.

GHCR package visibility was confirmed public — anonymous `docker pull ghcr.io/sbomify/sbomify-action:latest` succeeds without auth.

## Test plan

- [ ] CI passes on this branch
- [ ] After merge, a downstream `uses: sbomify/sbomify-action@master` consumer pulls successfully without `docker login`
- [ ] Master push produces both `ghcr.io/sbomify/sbomify-action:latest` and `sbomifyhub/sbomify-action:latest` tags
- [ ] Self-SBOM generated for the action container resolves the new ghcr.io PURL/DOCKER_IMAGE

🤖 Generated with [Claude Code](https://claude.com/claude-code)