### PR TITLE
Preserve PURLs without versions during enrichment

### DIFF
--- a/sbomify_action/serialization.py
+++ b/sbomify_action/serialization.py
@@ -150,20 +150,6 @@ def _extract_component_info_from_purl(
 _DOUBLE_ENCODED_AT_PATTERN = re.compile(r"(%40){2,}")  # %40%40... → %40
 _DOUBLE_AT_PATTERN = re.compile(r"@@+")  # @@... → @
 
-# Package types that require a version in the PURL
-# These ecosystems always have versioned packages in standard usage
-PURL_TYPES_REQUIRING_VERSION = frozenset(
-    {
-        "npm",  # JavaScript/Node.js
-        "maven",  # Java
-        "pypi",  # Python
-        "cargo",  # Rust
-        "gem",  # Ruby
-        "golang",  # Go
-        "nuget",  # .NET
-    }
-)
-
 
 def normalize_purl(purl_str: str | None) -> tuple[str | None, bool]:
     """
@@ -215,9 +201,10 @@ def _is_invalid_purl(purl_str: str | None) -> tuple[bool, str]:
     - PURLs with file: references in qualifiers (local workspace packages)
     - PURLs with path-based versions (e.g., @../../packages/foo)
     - PURLs with link: references (npm link)
-    - PURLs missing version (except for certain ecosystems where this is acceptable)
 
     Note: Double @@ encoding issues are fixed by normalize_purl() rather than rejected.
+    Per the PURL spec (ECMA-427), the version component is optional, so PURLs
+    without versions are preserved unmodified.
 
     Args:
         purl_str: The PURL string to check (may be None or empty)
@@ -254,11 +241,6 @@ def _is_invalid_purl(purl_str: str | None) -> tuple[bool, str]:
             for key, value in purl.qualifiers.items():
                 if isinstance(value, str) and ("file:" in value or "link:" in value):
                     return True, f"qualifier '{key}' contains file:/link: reference"
-
-        # Check for missing version in ecosystems that require it
-        if purl.type in PURL_TYPES_REQUIRING_VERSION:
-            if not purl.version:
-                return True, f"missing version for {purl.type} package"
 
     except ValueError as e:
         return True, f"malformed PURL: {e}"

--- a/sbomify_action/serialization.py
+++ b/sbomify_action/serialization.py
@@ -204,7 +204,8 @@ def _is_invalid_purl(purl_str: str | None) -> tuple[bool, str]:
 
     Note: Double @@ encoding issues are fixed by normalize_purl() rather than rejected.
     Per the PURL spec (ECMA-427), the version component is optional, so PURLs
-    without versions are preserved unmodified.
+    without versions are treated as valid (i.e. not rejected here). They may
+    still be normalized by normalize_purl() if they contain encoding bugs.
 
     Args:
         purl_str: The PURL string to check (may be None or empty)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -774,17 +774,20 @@ class TestIsInvalidPurl:
         assert is_invalid
         assert "root" in reason
 
-    def test_missing_version_npm(self):
-        """Test that npm packages without version are rejected."""
-        is_invalid, reason = _is_invalid_purl("pkg:npm/lodash")
-        assert is_invalid
-        assert "missing version" in reason
+    def test_missing_version_npm_allowed(self):
+        """PURLs without version are valid per the PURL spec (ECMA-427)."""
+        is_invalid, _ = _is_invalid_purl("pkg:npm/lodash")
+        assert not is_invalid
 
-    def test_missing_version_maven(self):
-        """Test that maven packages without version are rejected."""
-        is_invalid, reason = _is_invalid_purl("pkg:maven/org.apache/commons")
-        assert is_invalid
-        assert "missing version" in reason
+    def test_missing_version_maven_allowed(self):
+        """PURLs without version are valid per the PURL spec (ECMA-427)."""
+        is_invalid, _ = _is_invalid_purl("pkg:maven/org.apache/commons")
+        assert not is_invalid
+
+    def test_missing_version_pypi_allowed(self):
+        """Regression test for issue #227 — pypi PURLs without version must be preserved."""
+        is_invalid, _ = _is_invalid_purl("pkg:pypi/requests")
+        assert not is_invalid
 
     def test_empty_purl_rejected(self):
         """Test that empty PURL is rejected."""
@@ -908,12 +911,12 @@ class TestSanitizePurls:
         assert admin_ui.purl is None  # PURL cleared
         assert admin_ui.version == "1.0.0"  # Other fields preserved
 
-    def test_clears_purl_without_version(self):
-        """Test that PURLs without version are cleared but component kept."""
+    def test_preserves_purl_without_version(self):
+        """Regression test for issue #227 — version is optional per PURL spec ECMA-427."""
         from packageurl import PackageURL
 
         bom = Bom()
-        # Valid component
+        # Valid component with version
         valid_comp = Component(
             name="lodash",
             type=ComponentType.LIBRARY,
@@ -921,32 +924,32 @@ class TestSanitizePurls:
             bom_ref=BomRef("pkg:npm/lodash@4.17.21"),
             purl=PackageURL.from_string("pkg:npm/lodash@4.17.21"),
         )
-        # Component with PURL missing version
-        invalid_comp = Component(
-            name="no-version",
+        # Component with PURL missing version (still valid per spec)
+        no_version_comp = Component(
+            name="requests",
             type=ComponentType.LIBRARY,
-            version="1.0.0",  # Component has version, but PURL doesn't
-            bom_ref=BomRef("pkg:npm/no-version"),
-            purl=PackageURL.from_string("pkg:npm/no-version"),
+            version="2.31.0",
+            bom_ref=BomRef("pkg:pypi/requests"),
+            purl=PackageURL.from_string("pkg:pypi/requests"),
         )
         bom.components.add(valid_comp)
-        bom.components.add(invalid_comp)
+        bom.components.add(no_version_comp)
 
         normalized, cleared = sanitize_purls(bom)
-        assert cleared == 1
-        # Both components kept
+        assert normalized == 0
+        assert cleared == 0
         assert len(bom.components) == 2
 
-        # Find the sanitized component
-        no_version = None
+        # Find the no-version component
+        preserved = None
         for comp in bom.components:
-            if comp.name == "no-version":
-                no_version = comp
+            if comp.name == "requests":
+                preserved = comp
                 break
 
-        assert no_version is not None
-        assert no_version.purl is None  # PURL cleared
-        assert no_version.version == "1.0.0"  # Component version preserved
+        assert preserved is not None
+        assert preserved.purl is not None
+        assert str(preserved.purl) == "pkg:pypi/requests"
 
     def test_clears_invalid_metadata_component_purl(self):
         """Test that invalid PURLs are cleared from metadata component."""
@@ -1017,13 +1020,18 @@ class TestSanitizePurls:
             bom_ref=BomRef("pkg:npm/parent@1.0.0"),
             purl=PackageURL.from_string("pkg:npm/parent@1.0.0"),
         )
-        # Child component (invalid PURL - missing version)
+        # Child component (invalid PURL - file: reference in qualifier)
         child = Component(
             name="child",
             type=ComponentType.LIBRARY,
             version="2.0.0",
-            bom_ref=BomRef("pkg:npm/child"),
-            purl=PackageURL.from_string("pkg:npm/child"),
+            bom_ref=BomRef("pkg:npm/child@2.0.0"),
+            purl=PackageURL(
+                type="npm",
+                name="child",
+                version="2.0.0",
+                qualifiers={"vcs_url": "file:packages/child"},
+            ),
         )
         bom.components.add(parent)
         bom.components.add(child)
@@ -1082,12 +1090,17 @@ class TestSanitizePurls:
         valid_tool.group = "aquasecurity"
         bom.metadata.tools.components.add(valid_tool)
 
-        # Add a tool component with invalid PURL (missing version)
+        # Add a tool component with invalid PURL (file: reference)
         invalid_tool = Component(
             name="cdxgen",
             type=ComponentType.APPLICATION,
-            version="11.0.0",  # Component has version, but PURL doesn't
-            purl=PackageURL.from_string("pkg:npm/cdxgen"),
+            version="11.0.0",
+            purl=PackageURL(
+                type="npm",
+                name="cdxgen",
+                version="11.0.0",
+                qualifiers={"vcs_url": "file:tools/cdxgen"},
+            ),
         )
         bom.metadata.tools.components.add(invalid_tool)
 


### PR DESCRIPTION
## Summary
- Fixes #227 — PURLs without a version (e.g. `pkg:pypi/requests`) were being silently dropped during `--enrich`.
- Per the PURL spec (ECMA-427), the version component is optional, so we now preserve them unmodified.
- Removed `PURL_TYPES_REQUIRING_VERSION` and the corresponding check in `_is_invalid_purl()`. Other invalid-PURL checks (`file:`/`link:` refs, path-based versions, root namespace, malformed strings) are unchanged.

## Test plan
- [x] `uv run ruff check sbomify_action tests` clean
- [x] `uv run ruff format --check sbomify_action tests` clean
- [x] `uv run pytest` — 2194 passed
- [x] Added regression tests covering pypi/npm/maven version-less PURLs in `TestIsInvalidPurl` and `TestSanitizePurls`
- [x] Updated dependency-graph and tools.components tests to use a genuinely invalid PURL (`file:` qualifier) so they continue to exercise the clearing path

🤖 Generated with [Claude Code](https://claude.com/claude-code)