### PR TITLE
Add missing deptrack upload options

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Add business metadata without a sbomify account using a local config file:
     LOCK_FILE: requirements.txt
     OUTPUT_FILE: sbom.cdx.json
     UPLOAD: false
-    AUGMENT: true # Uses sbomify.json in project root
+    AUGMENT: true  # Uses sbomify.json in project root
     ENRICH: true
 ```
 
@@ -264,17 +264,12 @@ Setting `LOCK_FILE` (or `SBOM_FILE`) to `none` creates an empty SBOM and injects
 
 When uploading to Dependency Track (`UPLOAD_DESTINATIONS=dependency-track`), configure with `DTRACK_*` prefixed environment variables:
 
-| Variable                | Required | Description                                                              |
-| ----------------------- | -------- | ------------------------------------------------------------------------ |
-| `DTRACK_API_KEY`        | Yes      | Dependency Track API key                                                 |
-| `DTRACK_API_URL`        | Yes      | Full API base URL (e.g., `https://dtrack.example.com/api`)               |
-| `DTRACK_PROJECT_ID`     | §        | Project UUID (alternative to using `COMPONENT_NAME`/`COMPONENT_VERSION`) |
-| `DTRACK_AUTO_CREATE`    | No       | Auto-create project if it doesn't exist (default: false)                 |
-| `DTRACK_PROJECT_TAGS`   | No       | Tags to add to the project (comma seperated)                             |
-| `DTRACK_PARENT_ID`      | No       | Id of the parent project                                                 |
-| `DTRACK_PARENT_NAME`    | No       | Name of the parent project                                               |
-| `DTRACK_PARENT_VERSION` | No       | Version of the parent project                                            |
-| `DTRACK_IS_LATEST`      | No       | Mark the uploaded BOM as the latest version (default: false)             |
+| Variable             | Required | Description                                                              |
+| -------------------- | -------- | ------------------------------------------------------------------------ |
+| `DTRACK_API_KEY`     | Yes      | Dependency Track API key                                                 |
+| `DTRACK_API_URL`     | Yes      | Full API base URL (e.g., `https://dtrack.example.com/api`)               |
+| `DTRACK_PROJECT_ID`  | §        | Project UUID (alternative to using `COMPONENT_NAME`/`COMPONENT_VERSION`) |
+| `DTRACK_AUTO_CREATE` | No       | Auto-create project if it doesn't exist (default: false)                 |
 
 § Either `DTRACK_PROJECT_ID` **or** both `COMPONENT_NAME` and `COMPONENT_VERSION` are required
 
@@ -294,10 +289,6 @@ When uploading to Dependency Track (`UPLOAD_DESTINATIONS=dependency-track`), con
     DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}
     DTRACK_API_URL: https://dtrack.example.com/api
     DTRACK_AUTO_CREATE: true
-    DTRACK_IS_LATEST: true
-    DTRACK_PROJECT_TAGS: nightly,alpine
-    DTRACK_PARENT_NAME: parent-example
-    DTRACK_PARENT_VERSION: 1.0.0
     ENRICH: true
 ```
 
@@ -354,15 +345,15 @@ sbomify-action --token $SBOMIFY_TOKEN \
   --release "my-product:1.0.0"
 ```
 
-| Option                    | Required | Description                                                     |
-| ------------------------- | -------- | --------------------------------------------------------------- |
-| `SBOM_INPUT` (positional) | Yes      | Path to `.spdx.tar.zst` or `.tar.gz` archive                    |
-| `--token` (root option)   | Yes      | sbomify API token (pass before `yocto`, or set `TOKEN` env var) |
-| `--release`               | Yes      | Product release in `product_id:version` format                  |
-| `--augment/--no-augment`  | No       | Run augmentation per SBOM (default: off)                        |
-| `--enrich/--no-enrich`    | No       | Run enrichment per SBOM (default: off)                          |
-| `--dry-run`               | No       | Show what would happen without making API calls                 |
-| `--verbose`               | No       | Enable verbose logging                                          |
+| Option | Required | Description |
+| --- | --- | --- |
+| `SBOM_INPUT` (positional) | Yes | Path to `.spdx.tar.zst` or `.tar.gz` archive |
+| `--token` (root option) | Yes | sbomify API token (pass before `yocto`, or set `TOKEN` env var) |
+| `--release` | Yes | Product release in `product_id:version` format |
+| `--augment/--no-augment` | No | Run augmentation per SBOM (default: off) |
+| `--enrich/--no-enrich` | No | Run enrichment per SBOM (default: off) |
+| `--dry-run` | No | Show what would happen without making API calls |
+| `--verbose` | No | Enable verbose logging |
 
 **How it works:**
 
@@ -409,9 +400,11 @@ Create `sbomify.json` in your project root to provide augmentation metadata:
   "supplier": {
     "name": "My Company",
     "url": ["https://example.com"],
-    "contacts": [{ "name": "Support", "email": "support@example.com" }]
+    "contacts": [{"name": "Support", "email": "support@example.com"}]
   },
-  "authors": [{ "name": "John Doe", "email": "john@example.com" }],
+  "authors": [
+    {"name": "John Doe", "email": "john@example.com"}
+  ],
   "licenses": ["MIT"],
   "security_contact": "https://example.com/.well-known/security.txt",
   "release_date": "2024-06-15",
@@ -612,12 +605,9 @@ Operating system components (CycloneDX `type: operating-system`) are enriched wi
   "name": "debian",
   "version": "12.12",
   "properties": [
-    {
-      "name": "cdx:lifecycle:milestone:generalAvailability",
-      "value": "2023-06-10"
-    },
-    { "name": "cdx:lifecycle:milestone:endOfSupport", "value": "2026-06-10" },
-    { "name": "cdx:lifecycle:milestone:endOfLife", "value": "2028-06-30" }
+    {"name": "cdx:lifecycle:milestone:generalAvailability", "value": "2023-06-10"},
+    {"name": "cdx:lifecycle:milestone:endOfSupport", "value": "2026-06-10"},
+    {"name": "cdx:lifecycle:milestone:endOfLife", "value": "2028-06-30"}
   ]
 }
 ```
@@ -961,7 +951,7 @@ Generators are tried in priority order. Native tools (optimized for specific eco
 | 10       | **cyclonedx-py**    | Python only                                                                                                    | CycloneDX 1.0–1.7               |
 | 10       | **cargo-cyclonedx** | Rust only                                                                                                      | CycloneDX 1.4–1.6               |
 | 20       | **cdxgen**          | Python, JavaScript, **Java/Gradle**, Go, Rust, Ruby, Dart, C++, PHP, .NET, Swift, Elixir, Scala, Docker images | CycloneDX 1.4–1.7               |
-| ~~30~~   | ~~**Trivy**~~       | ~~Temporarily disabled due to security vulnerabilities~~                                                       | ~~CycloneDX 1.6, SPDX 2.3~~     |
+| ~~30~~   | ~~**Trivy**~~       | ~~Temporarily disabled due to security vulnerabilities~~                                                        | ~~CycloneDX 1.6, SPDX 2.3~~     |
 | 35       | **Syft**            | Python, JavaScript, Go, Rust, Ruby, Dart, C++, PHP, .NET, Swift, Elixir, Terraform, Docker images              | CycloneDX 1.2–1.6, SPDX 2.2–2.3 |
 
 #### How It Works
@@ -988,13 +978,13 @@ Generated SBOMs are validated against their JSON schemas before output.
 
 When installed via pip, sbomify-action requires external SBOM generators. The Docker image includes all tools pre-installed.
 
-| Tool             | Install Command                                                                   | Notes                                                                                                                          |
-| ---------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| **cyclonedx-py** | `pip install cyclonedx-bom`                                                       | Native Python generator; `cyclonedx-py` is the CLI command provided by the `cyclonedx-bom` package (installed as a dependency) |
-| **Syft**         | [Installation guide](https://github.com/anchore/syft#installation)                | macOS: `brew install syft`                                                                                                     |
-| **cdxgen**       | `npm install -g @cyclonedx/cdxgen`                                                | Requires Node.js/Bun                                                                                                           |
-| **crane**        | [Installation guide](https://github.com/google/go-containerregistry#installation) | Required for Chainguard image detection; macOS: `brew install crane`                                                           |
-| **cosign**       | [Installation guide](https://github.com/sigstore/cosign#installation)             | Required for Chainguard SBOM retrieval; macOS: `brew install cosign`                                                           |
+| Tool             | Install Command                                                                                 | Notes                                                                                                                          |
+| ---------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| **cyclonedx-py** | `pip install cyclonedx-bom`                                                                     | Native Python generator; `cyclonedx-py` is the CLI command provided by the `cyclonedx-bom` package (installed as a dependency) |
+| **Syft**         | [Installation guide](https://github.com/anchore/syft#installation)                              | macOS: `brew install syft`                                                                                                     |
+| **cdxgen**       | `npm install -g @cyclonedx/cdxgen`                                                              | Requires Node.js/Bun                                                                                                           |
+| **crane**        | [Installation guide](https://github.com/google/go-containerregistry#installation)               | Required for Chainguard image detection; macOS: `brew install crane`                                                           |
+| **cosign**       | [Installation guide](https://github.com/sigstore/cosign#installation)                           | Required for Chainguard SBOM retrieval; macOS: `brew install cosign`                                                           |
 
 **Minimum requirement**: At least one generator must be installed for SBOM generation. For Python projects, `cyclonedx-bom` (which provides the `cyclonedx-py` command) is installed as a dependency when you install sbomify-action via pip. For other ecosystems or Docker images, install `syft` or `cdxgen`.
 
@@ -1028,11 +1018,11 @@ After sbomify enrichment, the same component includes supplier, license, and ref
   "purl": "pkg:pypi/django@5.1",
   "publisher": "Django Software Foundation",
   "description": "A high-level Python web framework...",
-  "licenses": [{ "expression": "BSD-3-Clause" }],
+  "licenses": [{"expression": "BSD-3-Clause"}],
   "externalReferences": [
-    { "type": "website", "url": "https://www.djangoproject.com/" },
-    { "type": "vcs", "url": "https://github.com/django/django" },
-    { "type": "distribution", "url": "https://pypi.org/project/Django/" }
+    {"type": "website", "url": "https://www.djangoproject.com/"},
+    {"type": "vcs", "url": "https://github.com/django/django"},
+    {"type": "distribution", "url": "https://pypi.org/project/Django/"}
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Add business metadata without a sbomify account using a local config file:
     LOCK_FILE: requirements.txt
     OUTPUT_FILE: sbom.cdx.json
     UPLOAD: false
-    AUGMENT: true  # Uses sbomify.json in project root
+    AUGMENT: true # Uses sbomify.json in project root
     ENRICH: true
 ```
 
@@ -264,12 +264,17 @@ Setting `LOCK_FILE` (or `SBOM_FILE`) to `none` creates an empty SBOM and injects
 
 When uploading to Dependency Track (`UPLOAD_DESTINATIONS=dependency-track`), configure with `DTRACK_*` prefixed environment variables:
 
-| Variable             | Required | Description                                                              |
-| -------------------- | -------- | ------------------------------------------------------------------------ |
-| `DTRACK_API_KEY`     | Yes      | Dependency Track API key                                                 |
-| `DTRACK_API_URL`     | Yes      | Full API base URL (e.g., `https://dtrack.example.com/api`)               |
-| `DTRACK_PROJECT_ID`  | §        | Project UUID (alternative to using `COMPONENT_NAME`/`COMPONENT_VERSION`) |
-| `DTRACK_AUTO_CREATE` | No       | Auto-create project if it doesn't exist (default: false)                 |
+| Variable                | Required | Description                                                              |
+| ----------------------- | -------- | ------------------------------------------------------------------------ |
+| `DTRACK_API_KEY`        | Yes      | Dependency Track API key                                                 |
+| `DTRACK_API_URL`        | Yes      | Full API base URL (e.g., `https://dtrack.example.com/api`)               |
+| `DTRACK_PROJECT_ID`     | §        | Project UUID (alternative to using `COMPONENT_NAME`/`COMPONENT_VERSION`) |
+| `DTRACK_AUTO_CREATE`    | No       | Auto-create project if it doesn't exist (default: false)                 |
+| `DTRACK_PROJECT_TAGS`   | No       | Tags to add to the project (comma seperated)                             |
+| `DTRACK_PARENT_ID`      | No       | Id of the parent project                                                 |
+| `DTRACK_PARENT_NAME`    | No       | Name of the parent project                                               |
+| `DTRACK_PARENT_VERSION` | No       | Version of the parent project                                            |
+| `DTRACK_IS_LATEST`      | No       | Mark the uploaded BOM as the latest version (default: false)             |
 
 § Either `DTRACK_PROJECT_ID` **or** both `COMPONENT_NAME` and `COMPONENT_VERSION` are required
 
@@ -289,6 +294,10 @@ When uploading to Dependency Track (`UPLOAD_DESTINATIONS=dependency-track`), con
     DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}
     DTRACK_API_URL: https://dtrack.example.com/api
     DTRACK_AUTO_CREATE: true
+    DTRACK_IS_LATEST: true
+    DTRACK_PROJECT_TAGS: nightly,alpine
+    DTRACK_PARENT_NAME: parent-example
+    DTRACK_PARENT_VERSION: 1.0.0
     ENRICH: true
 ```
 
@@ -345,15 +354,15 @@ sbomify-action --token $SBOMIFY_TOKEN \
   --release "my-product:1.0.0"
 ```
 
-| Option | Required | Description |
-| --- | --- | --- |
-| `SBOM_INPUT` (positional) | Yes | Path to `.spdx.tar.zst` or `.tar.gz` archive |
-| `--token` (root option) | Yes | sbomify API token (pass before `yocto`, or set `TOKEN` env var) |
-| `--release` | Yes | Product release in `product_id:version` format |
-| `--augment/--no-augment` | No | Run augmentation per SBOM (default: off) |
-| `--enrich/--no-enrich` | No | Run enrichment per SBOM (default: off) |
-| `--dry-run` | No | Show what would happen without making API calls |
-| `--verbose` | No | Enable verbose logging |
+| Option                    | Required | Description                                                     |
+| ------------------------- | -------- | --------------------------------------------------------------- |
+| `SBOM_INPUT` (positional) | Yes      | Path to `.spdx.tar.zst` or `.tar.gz` archive                    |
+| `--token` (root option)   | Yes      | sbomify API token (pass before `yocto`, or set `TOKEN` env var) |
+| `--release`               | Yes      | Product release in `product_id:version` format                  |
+| `--augment/--no-augment`  | No       | Run augmentation per SBOM (default: off)                        |
+| `--enrich/--no-enrich`    | No       | Run enrichment per SBOM (default: off)                          |
+| `--dry-run`               | No       | Show what would happen without making API calls                 |
+| `--verbose`               | No       | Enable verbose logging                                          |
 
 **How it works:**
 
@@ -400,11 +409,9 @@ Create `sbomify.json` in your project root to provide augmentation metadata:
   "supplier": {
     "name": "My Company",
     "url": ["https://example.com"],
-    "contacts": [{"name": "Support", "email": "support@example.com"}]
+    "contacts": [{ "name": "Support", "email": "support@example.com" }]
   },
-  "authors": [
-    {"name": "John Doe", "email": "john@example.com"}
-  ],
+  "authors": [{ "name": "John Doe", "email": "john@example.com" }],
   "licenses": ["MIT"],
   "security_contact": "https://example.com/.well-known/security.txt",
   "release_date": "2024-06-15",
@@ -605,9 +612,12 @@ Operating system components (CycloneDX `type: operating-system`) are enriched wi
   "name": "debian",
   "version": "12.12",
   "properties": [
-    {"name": "cdx:lifecycle:milestone:generalAvailability", "value": "2023-06-10"},
-    {"name": "cdx:lifecycle:milestone:endOfSupport", "value": "2026-06-10"},
-    {"name": "cdx:lifecycle:milestone:endOfLife", "value": "2028-06-30"}
+    {
+      "name": "cdx:lifecycle:milestone:generalAvailability",
+      "value": "2023-06-10"
+    },
+    { "name": "cdx:lifecycle:milestone:endOfSupport", "value": "2026-06-10" },
+    { "name": "cdx:lifecycle:milestone:endOfLife", "value": "2028-06-30" }
   ]
 }
 ```
@@ -951,7 +961,7 @@ Generators are tried in priority order. Native tools (optimized for specific eco
 | 10       | **cyclonedx-py**    | Python only                                                                                                    | CycloneDX 1.0–1.7               |
 | 10       | **cargo-cyclonedx** | Rust only                                                                                                      | CycloneDX 1.4–1.6               |
 | 20       | **cdxgen**          | Python, JavaScript, **Java/Gradle**, Go, Rust, Ruby, Dart, C++, PHP, .NET, Swift, Elixir, Scala, Docker images | CycloneDX 1.4–1.7               |
-| ~~30~~   | ~~**Trivy**~~       | ~~Temporarily disabled due to security vulnerabilities~~                                                        | ~~CycloneDX 1.6, SPDX 2.3~~     |
+| ~~30~~   | ~~**Trivy**~~       | ~~Temporarily disabled due to security vulnerabilities~~                                                       | ~~CycloneDX 1.6, SPDX 2.3~~     |
 | 35       | **Syft**            | Python, JavaScript, Go, Rust, Ruby, Dart, C++, PHP, .NET, Swift, Elixir, Terraform, Docker images              | CycloneDX 1.2–1.6, SPDX 2.2–2.3 |
 
 #### How It Works
@@ -978,13 +988,13 @@ Generated SBOMs are validated against their JSON schemas before output.
 
 When installed via pip, sbomify-action requires external SBOM generators. The Docker image includes all tools pre-installed.
 
-| Tool             | Install Command                                                                                 | Notes                                                                                                                          |
-| ---------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| **cyclonedx-py** | `pip install cyclonedx-bom`                                                                     | Native Python generator; `cyclonedx-py` is the CLI command provided by the `cyclonedx-bom` package (installed as a dependency) |
-| **Syft**         | [Installation guide](https://github.com/anchore/syft#installation)                              | macOS: `brew install syft`                                                                                                     |
-| **cdxgen**       | `npm install -g @cyclonedx/cdxgen`                                                              | Requires Node.js/Bun                                                                                                           |
-| **crane**        | [Installation guide](https://github.com/google/go-containerregistry#installation)               | Required for Chainguard image detection; macOS: `brew install crane`                                                           |
-| **cosign**       | [Installation guide](https://github.com/sigstore/cosign#installation)                           | Required for Chainguard SBOM retrieval; macOS: `brew install cosign`                                                           |
+| Tool             | Install Command                                                                   | Notes                                                                                                                          |
+| ---------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| **cyclonedx-py** | `pip install cyclonedx-bom`                                                       | Native Python generator; `cyclonedx-py` is the CLI command provided by the `cyclonedx-bom` package (installed as a dependency) |
+| **Syft**         | [Installation guide](https://github.com/anchore/syft#installation)                | macOS: `brew install syft`                                                                                                     |
+| **cdxgen**       | `npm install -g @cyclonedx/cdxgen`                                                | Requires Node.js/Bun                                                                                                           |
+| **crane**        | [Installation guide](https://github.com/google/go-containerregistry#installation) | Required for Chainguard image detection; macOS: `brew install crane`                                                           |
+| **cosign**       | [Installation guide](https://github.com/sigstore/cosign#installation)             | Required for Chainguard SBOM retrieval; macOS: `brew install cosign`                                                           |
 
 **Minimum requirement**: At least one generator must be installed for SBOM generation. For Python projects, `cyclonedx-bom` (which provides the `cyclonedx-py` command) is installed as a dependency when you install sbomify-action via pip. For other ecosystems or Docker images, install `syft` or `cdxgen`.
 
@@ -1018,11 +1028,11 @@ After sbomify enrichment, the same component includes supplier, license, and ref
   "purl": "pkg:pypi/django@5.1",
   "publisher": "Django Software Foundation",
   "description": "A high-level Python web framework...",
-  "licenses": [{"expression": "BSD-3-Clause"}],
+  "licenses": [{ "expression": "BSD-3-Clause" }],
   "externalReferences": [
-    {"type": "website", "url": "https://www.djangoproject.com/"},
-    {"type": "vcs", "url": "https://github.com/django/django"},
-    {"type": "distribution", "url": "https://pypi.org/project/Django/"}
+    { "type": "website", "url": "https://www.djangoproject.com/" },
+    { "type": "vcs", "url": "https://github.com/django/django" },
+    { "type": "distribution", "url": "https://pypi.org/project/Django/" }
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ When uploading to Dependency Track (`UPLOAD_DESTINATIONS=dependency-track`), con
 | `DTRACK_API_URL`        | Yes      | Full API base URL (e.g., `https://dtrack.example.com/api`)               |
 | `DTRACK_PROJECT_ID`     | §        | Project UUID (alternative to using `COMPONENT_NAME`/`COMPONENT_VERSION`) |
 | `DTRACK_AUTO_CREATE`    | No       | Auto-create project if it doesn't exist (default: false)                 |
-| `DTRACK_PROJECT_TAGS`   | No       | Tags to add to the project (comma seperated)                             |
+| `DTRACK_PROJECT_TAGS`   | No       | Tags to add to the project (comma separated)                             |
 | `DTRACK_PARENT_ID`      | No       | Id of the parent project                                                 |
 | `DTRACK_PARENT_NAME`    | No       | Name of the parent project                                               |
 | `DTRACK_PARENT_VERSION` | No       | Version of the parent project                                            |

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Add business metadata without a sbomify account using a local config file:
     LOCK_FILE: requirements.txt
     OUTPUT_FILE: sbom.cdx.json
     UPLOAD: false
-    AUGMENT: true # Uses sbomify.json in project root
+    AUGMENT: true  # Uses sbomify.json in project root
     ENRICH: true
 ```
 
@@ -264,13 +264,13 @@ Setting `LOCK_FILE` (or `SBOM_FILE`) to `none` creates an empty SBOM and injects
 
 When uploading to Dependency Track (`UPLOAD_DESTINATIONS=dependency-track`), configure with `DTRACK_*` prefixed environment variables:
 
-| Variable                | Required | Description                                                              |
-| ----------------------- | -------- | ------------------------------------------------------------------------ |
-| `DTRACK_API_KEY`        | Yes      | Dependency Track API key                                                 |
-| `DTRACK_API_URL`        | Yes      | Full API base URL (e.g., `https://dtrack.example.com/api`)               |
-| `DTRACK_PROJECT_ID`     | §        | Project UUID (alternative to using `COMPONENT_NAME`/`COMPONENT_VERSION`) |
-| `DTRACK_AUTO_CREATE`    | No       | Auto-create project if it doesn't exist (default: false)                 |
-| `DTRACK_PROJECT_TAGS`   | No       | Tags to add to the project (comma separated)                             |
+| Variable             | Required | Description                                                              |
+| -------------------- | -------- | ------------------------------------------------------------------------ |
+| `DTRACK_API_KEY`     | Yes      | Dependency Track API key                                                 |
+| `DTRACK_API_URL`     | Yes      | Full API base URL (e.g., `https://dtrack.example.com/api`)               |
+| `DTRACK_PROJECT_ID`  | §        | Project UUID (alternative to using `COMPONENT_NAME`/`COMPONENT_VERSION`) |
+| `DTRACK_AUTO_CREATE` | No       | Auto-create project if it doesn't exist (default: false)                 |
+| `DTRACK_PROJECT_TAGS`   | No       | Tags to add to the project (comma seperated)                             |
 | `DTRACK_PARENT_ID`      | No       | Id of the parent project                                                 |
 | `DTRACK_PARENT_NAME`    | No       | Name of the parent project                                               |
 | `DTRACK_PARENT_VERSION` | No       | Version of the parent project                                            |
@@ -354,15 +354,15 @@ sbomify-action --token $SBOMIFY_TOKEN \
   --release "my-product:1.0.0"
 ```
 
-| Option                    | Required | Description                                                     |
-| ------------------------- | -------- | --------------------------------------------------------------- |
-| `SBOM_INPUT` (positional) | Yes      | Path to `.spdx.tar.zst` or `.tar.gz` archive                    |
-| `--token` (root option)   | Yes      | sbomify API token (pass before `yocto`, or set `TOKEN` env var) |
-| `--release`               | Yes      | Product release in `product_id:version` format                  |
-| `--augment/--no-augment`  | No       | Run augmentation per SBOM (default: off)                        |
-| `--enrich/--no-enrich`    | No       | Run enrichment per SBOM (default: off)                          |
-| `--dry-run`               | No       | Show what would happen without making API calls                 |
-| `--verbose`               | No       | Enable verbose logging                                          |
+| Option | Required | Description |
+| --- | --- | --- |
+| `SBOM_INPUT` (positional) | Yes | Path to `.spdx.tar.zst` or `.tar.gz` archive |
+| `--token` (root option) | Yes | sbomify API token (pass before `yocto`, or set `TOKEN` env var) |
+| `--release` | Yes | Product release in `product_id:version` format |
+| `--augment/--no-augment` | No | Run augmentation per SBOM (default: off) |
+| `--enrich/--no-enrich` | No | Run enrichment per SBOM (default: off) |
+| `--dry-run` | No | Show what would happen without making API calls |
+| `--verbose` | No | Enable verbose logging |
 
 **How it works:**
 
@@ -409,9 +409,11 @@ Create `sbomify.json` in your project root to provide augmentation metadata:
   "supplier": {
     "name": "My Company",
     "url": ["https://example.com"],
-    "contacts": [{ "name": "Support", "email": "support@example.com" }]
+    "contacts": [{"name": "Support", "email": "support@example.com"}]
   },
-  "authors": [{ "name": "John Doe", "email": "john@example.com" }],
+  "authors": [
+    {"name": "John Doe", "email": "john@example.com"}
+  ],
   "licenses": ["MIT"],
   "security_contact": "https://example.com/.well-known/security.txt",
   "release_date": "2024-06-15",
@@ -612,12 +614,9 @@ Operating system components (CycloneDX `type: operating-system`) are enriched wi
   "name": "debian",
   "version": "12.12",
   "properties": [
-    {
-      "name": "cdx:lifecycle:milestone:generalAvailability",
-      "value": "2023-06-10"
-    },
-    { "name": "cdx:lifecycle:milestone:endOfSupport", "value": "2026-06-10" },
-    { "name": "cdx:lifecycle:milestone:endOfLife", "value": "2028-06-30" }
+    {"name": "cdx:lifecycle:milestone:generalAvailability", "value": "2023-06-10"},
+    {"name": "cdx:lifecycle:milestone:endOfSupport", "value": "2026-06-10"},
+    {"name": "cdx:lifecycle:milestone:endOfLife", "value": "2028-06-30"}
   ]
 }
 ```
@@ -961,7 +960,7 @@ Generators are tried in priority order. Native tools (optimized for specific eco
 | 10       | **cyclonedx-py**    | Python only                                                                                                    | CycloneDX 1.0–1.7               |
 | 10       | **cargo-cyclonedx** | Rust only                                                                                                      | CycloneDX 1.4–1.6               |
 | 20       | **cdxgen**          | Python, JavaScript, **Java/Gradle**, Go, Rust, Ruby, Dart, C++, PHP, .NET, Swift, Elixir, Scala, Docker images | CycloneDX 1.4–1.7               |
-| ~~30~~   | ~~**Trivy**~~       | ~~Temporarily disabled due to security vulnerabilities~~                                                       | ~~CycloneDX 1.6, SPDX 2.3~~     |
+| ~~30~~   | ~~**Trivy**~~       | ~~Temporarily disabled due to security vulnerabilities~~                                                        | ~~CycloneDX 1.6, SPDX 2.3~~     |
 | 35       | **Syft**            | Python, JavaScript, Go, Rust, Ruby, Dart, C++, PHP, .NET, Swift, Elixir, Terraform, Docker images              | CycloneDX 1.2–1.6, SPDX 2.2–2.3 |
 
 #### How It Works
@@ -988,13 +987,13 @@ Generated SBOMs are validated against their JSON schemas before output.
 
 When installed via pip, sbomify-action requires external SBOM generators. The Docker image includes all tools pre-installed.
 
-| Tool             | Install Command                                                                   | Notes                                                                                                                          |
-| ---------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| **cyclonedx-py** | `pip install cyclonedx-bom`                                                       | Native Python generator; `cyclonedx-py` is the CLI command provided by the `cyclonedx-bom` package (installed as a dependency) |
-| **Syft**         | [Installation guide](https://github.com/anchore/syft#installation)                | macOS: `brew install syft`                                                                                                     |
-| **cdxgen**       | `npm install -g @cyclonedx/cdxgen`                                                | Requires Node.js/Bun                                                                                                           |
-| **crane**        | [Installation guide](https://github.com/google/go-containerregistry#installation) | Required for Chainguard image detection; macOS: `brew install crane`                                                           |
-| **cosign**       | [Installation guide](https://github.com/sigstore/cosign#installation)             | Required for Chainguard SBOM retrieval; macOS: `brew install cosign`                                                           |
+| Tool             | Install Command                                                                                 | Notes                                                                                                                          |
+| ---------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| **cyclonedx-py** | `pip install cyclonedx-bom`                                                                     | Native Python generator; `cyclonedx-py` is the CLI command provided by the `cyclonedx-bom` package (installed as a dependency) |
+| **Syft**         | [Installation guide](https://github.com/anchore/syft#installation)                              | macOS: `brew install syft`                                                                                                     |
+| **cdxgen**       | `npm install -g @cyclonedx/cdxgen`                                                              | Requires Node.js/Bun                                                                                                           |
+| **crane**        | [Installation guide](https://github.com/google/go-containerregistry#installation)               | Required for Chainguard image detection; macOS: `brew install crane`                                                           |
+| **cosign**       | [Installation guide](https://github.com/sigstore/cosign#installation)                           | Required for Chainguard SBOM retrieval; macOS: `brew install cosign`                                                           |
 
 **Minimum requirement**: At least one generator must be installed for SBOM generation. For Python projects, `cyclonedx-bom` (which provides the `cyclonedx-py` command) is installed as a dependency when you install sbomify-action via pip. For other ecosystems or Docker images, install `syft` or `cdxgen`.
 
@@ -1028,11 +1027,11 @@ After sbomify enrichment, the same component includes supplier, license, and ref
   "purl": "pkg:pypi/django@5.1",
   "publisher": "Django Software Foundation",
   "description": "A high-level Python web framework...",
-  "licenses": [{ "expression": "BSD-3-Clause" }],
+  "licenses": [{"expression": "BSD-3-Clause"}],
   "externalReferences": [
-    { "type": "website", "url": "https://www.djangoproject.com/" },
-    { "type": "vcs", "url": "https://github.com/django/django" },
-    { "type": "distribution", "url": "https://pypi.org/project/Django/" }
+    {"type": "website", "url": "https://www.djangoproject.com/"},
+    {"type": "vcs", "url": "https://github.com/django/django"},
+    {"type": "distribution", "url": "https://pypi.org/project/Django/"}
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -270,6 +270,11 @@ When uploading to Dependency Track (`UPLOAD_DESTINATIONS=dependency-track`), con
 | `DTRACK_API_URL`     | Yes      | Full API base URL (e.g., `https://dtrack.example.com/api`)               |
 | `DTRACK_PROJECT_ID`  | §        | Project UUID (alternative to using `COMPONENT_NAME`/`COMPONENT_VERSION`) |
 | `DTRACK_AUTO_CREATE` | No       | Auto-create project if it doesn't exist (default: false)                 |
+| `DTRACK_PROJECT_TAGS`   | No       | Tags to add to the project (comma seperated)                             |
+| `DTRACK_PARENT_ID`      | No       | Id of the parent project                                                 |
+| `DTRACK_PARENT_NAME`    | No       | Name of the parent project                                               |
+| `DTRACK_PARENT_VERSION` | No       | Version of the parent project                                            |
+| `DTRACK_IS_LATEST`      | No       | Mark the uploaded BOM as the latest version (default: false)             |
 
 § Either `DTRACK_PROJECT_ID` **or** both `COMPONENT_NAME` and `COMPONENT_VERSION` are required
 
@@ -289,6 +294,10 @@ When uploading to Dependency Track (`UPLOAD_DESTINATIONS=dependency-track`), con
     DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}
     DTRACK_API_URL: https://dtrack.example.com/api
     DTRACK_AUTO_CREATE: true
+    DTRACK_IS_LATEST: true
+    DTRACK_PROJECT_TAGS: nightly,alpine
+    DTRACK_PARENT_NAME: parent-example
+    DTRACK_PARENT_VERSION: 1.0.0
     ENRICH: true
 ```
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Add business metadata without a sbomify account using a local config file:
     LOCK_FILE: requirements.txt
     OUTPUT_FILE: sbom.cdx.json
     UPLOAD: false
-    AUGMENT: true  # Uses sbomify.json in project root
+    AUGMENT: true # Uses sbomify.json in project root
     ENRICH: true
 ```
 
@@ -264,12 +264,12 @@ Setting `LOCK_FILE` (or `SBOM_FILE`) to `none` creates an empty SBOM and injects
 
 When uploading to Dependency Track (`UPLOAD_DESTINATIONS=dependency-track`), configure with `DTRACK_*` prefixed environment variables:
 
-| Variable             | Required | Description                                                              |
-| -------------------- | -------- | ------------------------------------------------------------------------ |
-| `DTRACK_API_KEY`     | Yes      | Dependency Track API key                                                 |
-| `DTRACK_API_URL`     | Yes      | Full API base URL (e.g., `https://dtrack.example.com/api`)               |
-| `DTRACK_PROJECT_ID`  | §        | Project UUID (alternative to using `COMPONENT_NAME`/`COMPONENT_VERSION`) |
-| `DTRACK_AUTO_CREATE` | No       | Auto-create project if it doesn't exist (default: false)                 |
+| Variable                | Required | Description                                                              |
+| ----------------------- | -------- | ------------------------------------------------------------------------ |
+| `DTRACK_API_KEY`        | Yes      | Dependency Track API key                                                 |
+| `DTRACK_API_URL`        | Yes      | Full API base URL (e.g., `https://dtrack.example.com/api`)               |
+| `DTRACK_PROJECT_ID`     | §        | Project UUID (alternative to using `COMPONENT_NAME`/`COMPONENT_VERSION`) |
+| `DTRACK_AUTO_CREATE`    | No       | Auto-create project if it doesn't exist (default: false)                 |
 | `DTRACK_PROJECT_TAGS`   | No       | Tags to add to the project (comma seperated)                             |
 | `DTRACK_PARENT_ID`      | No       | Id of the parent project                                                 |
 | `DTRACK_PARENT_NAME`    | No       | Name of the parent project                                               |
@@ -354,15 +354,15 @@ sbomify-action --token $SBOMIFY_TOKEN \
   --release "my-product:1.0.0"
 ```
 
-| Option | Required | Description |
-| --- | --- | --- |
-| `SBOM_INPUT` (positional) | Yes | Path to `.spdx.tar.zst` or `.tar.gz` archive |
-| `--token` (root option) | Yes | sbomify API token (pass before `yocto`, or set `TOKEN` env var) |
-| `--release` | Yes | Product release in `product_id:version` format |
-| `--augment/--no-augment` | No | Run augmentation per SBOM (default: off) |
-| `--enrich/--no-enrich` | No | Run enrichment per SBOM (default: off) |
-| `--dry-run` | No | Show what would happen without making API calls |
-| `--verbose` | No | Enable verbose logging |
+| Option                    | Required | Description                                                     |
+| ------------------------- | -------- | --------------------------------------------------------------- |
+| `SBOM_INPUT` (positional) | Yes      | Path to `.spdx.tar.zst` or `.tar.gz` archive                    |
+| `--token` (root option)   | Yes      | sbomify API token (pass before `yocto`, or set `TOKEN` env var) |
+| `--release`               | Yes      | Product release in `product_id:version` format                  |
+| `--augment/--no-augment`  | No       | Run augmentation per SBOM (default: off)                        |
+| `--enrich/--no-enrich`    | No       | Run enrichment per SBOM (default: off)                          |
+| `--dry-run`               | No       | Show what would happen without making API calls                 |
+| `--verbose`               | No       | Enable verbose logging                                          |
 
 **How it works:**
 
@@ -409,11 +409,9 @@ Create `sbomify.json` in your project root to provide augmentation metadata:
   "supplier": {
     "name": "My Company",
     "url": ["https://example.com"],
-    "contacts": [{"name": "Support", "email": "support@example.com"}]
+    "contacts": [{ "name": "Support", "email": "support@example.com" }]
   },
-  "authors": [
-    {"name": "John Doe", "email": "john@example.com"}
-  ],
+  "authors": [{ "name": "John Doe", "email": "john@example.com" }],
   "licenses": ["MIT"],
   "security_contact": "https://example.com/.well-known/security.txt",
   "release_date": "2024-06-15",
@@ -614,9 +612,12 @@ Operating system components (CycloneDX `type: operating-system`) are enriched wi
   "name": "debian",
   "version": "12.12",
   "properties": [
-    {"name": "cdx:lifecycle:milestone:generalAvailability", "value": "2023-06-10"},
-    {"name": "cdx:lifecycle:milestone:endOfSupport", "value": "2026-06-10"},
-    {"name": "cdx:lifecycle:milestone:endOfLife", "value": "2028-06-30"}
+    {
+      "name": "cdx:lifecycle:milestone:generalAvailability",
+      "value": "2023-06-10"
+    },
+    { "name": "cdx:lifecycle:milestone:endOfSupport", "value": "2026-06-10" },
+    { "name": "cdx:lifecycle:milestone:endOfLife", "value": "2028-06-30" }
   ]
 }
 ```
@@ -960,7 +961,7 @@ Generators are tried in priority order. Native tools (optimized for specific eco
 | 10       | **cyclonedx-py**    | Python only                                                                                                    | CycloneDX 1.0–1.7               |
 | 10       | **cargo-cyclonedx** | Rust only                                                                                                      | CycloneDX 1.4–1.6               |
 | 20       | **cdxgen**          | Python, JavaScript, **Java/Gradle**, Go, Rust, Ruby, Dart, C++, PHP, .NET, Swift, Elixir, Scala, Docker images | CycloneDX 1.4–1.7               |
-| ~~30~~   | ~~**Trivy**~~       | ~~Temporarily disabled due to security vulnerabilities~~                                                        | ~~CycloneDX 1.6, SPDX 2.3~~     |
+| ~~30~~   | ~~**Trivy**~~       | ~~Temporarily disabled due to security vulnerabilities~~                                                       | ~~CycloneDX 1.6, SPDX 2.3~~     |
 | 35       | **Syft**            | Python, JavaScript, Go, Rust, Ruby, Dart, C++, PHP, .NET, Swift, Elixir, Terraform, Docker images              | CycloneDX 1.2–1.6, SPDX 2.2–2.3 |
 
 #### How It Works
@@ -987,13 +988,13 @@ Generated SBOMs are validated against their JSON schemas before output.
 
 When installed via pip, sbomify-action requires external SBOM generators. The Docker image includes all tools pre-installed.
 
-| Tool             | Install Command                                                                                 | Notes                                                                                                                          |
-| ---------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| **cyclonedx-py** | `pip install cyclonedx-bom`                                                                     | Native Python generator; `cyclonedx-py` is the CLI command provided by the `cyclonedx-bom` package (installed as a dependency) |
-| **Syft**         | [Installation guide](https://github.com/anchore/syft#installation)                              | macOS: `brew install syft`                                                                                                     |
-| **cdxgen**       | `npm install -g @cyclonedx/cdxgen`                                                              | Requires Node.js/Bun                                                                                                           |
-| **crane**        | [Installation guide](https://github.com/google/go-containerregistry#installation)               | Required for Chainguard image detection; macOS: `brew install crane`                                                           |
-| **cosign**       | [Installation guide](https://github.com/sigstore/cosign#installation)                           | Required for Chainguard SBOM retrieval; macOS: `brew install cosign`                                                           |
+| Tool             | Install Command                                                                   | Notes                                                                                                                          |
+| ---------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| **cyclonedx-py** | `pip install cyclonedx-bom`                                                       | Native Python generator; `cyclonedx-py` is the CLI command provided by the `cyclonedx-bom` package (installed as a dependency) |
+| **Syft**         | [Installation guide](https://github.com/anchore/syft#installation)                | macOS: `brew install syft`                                                                                                     |
+| **cdxgen**       | `npm install -g @cyclonedx/cdxgen`                                                | Requires Node.js/Bun                                                                                                           |
+| **crane**        | [Installation guide](https://github.com/google/go-containerregistry#installation) | Required for Chainguard image detection; macOS: `brew install crane`                                                           |
+| **cosign**       | [Installation guide](https://github.com/sigstore/cosign#installation)             | Required for Chainguard SBOM retrieval; macOS: `brew install cosign`                                                           |
 
 **Minimum requirement**: At least one generator must be installed for SBOM generation. For Python projects, `cyclonedx-bom` (which provides the `cyclonedx-py` command) is installed as a dependency when you install sbomify-action via pip. For other ecosystems or Docker images, install `syft` or `cdxgen`.
 
@@ -1027,11 +1028,11 @@ After sbomify enrichment, the same component includes supplier, license, and ref
   "purl": "pkg:pypi/django@5.1",
   "publisher": "Django Software Foundation",
   "description": "A high-level Python web framework...",
-  "licenses": [{"expression": "BSD-3-Clause"}],
+  "licenses": [{ "expression": "BSD-3-Clause" }],
   "externalReferences": [
-    {"type": "website", "url": "https://www.djangoproject.com/"},
-    {"type": "vcs", "url": "https://github.com/django/django"},
-    {"type": "distribution", "url": "https://pypi.org/project/Django/"}
+    { "type": "website", "url": "https://www.djangoproject.com/" },
+    { "type": "vcs", "url": "https://github.com/django/django" },
+    { "type": "distribution", "url": "https://pypi.org/project/Django/" }
   ]
 }
 ```

--- a/sbomify_action/_upload/destinations/dependency_track.py
+++ b/sbomify_action/_upload/destinations/dependency_track.py
@@ -62,7 +62,7 @@ class DependencyTrackConfig(DestinationConfig):
     api_url: str  # Full API base URL, we append /v1/bom
     project_id: Optional[str] = None
     auto_create: bool = False
-    project_tags: list[dict] | None = None
+    project_tags: list[str] | None = None
     parent_id: str = None
     parent_name: str = None
     parent_version: str = None

--- a/sbomify_action/_upload/destinations/dependency_track.py
+++ b/sbomify_action/_upload/destinations/dependency_track.py
@@ -78,12 +78,7 @@ class DependencyTrackConfig(DestinationConfig):
         if not api_key or not api_url:
             return None
 
-        # map list of tags to list[dict{name: tag}]
-        _project_tags = (
-            [{"name": t} for t in cls._get_env_list("PROJECT_TAGS")]
-            if cls._get_env("PROJECT_TAGS") is not None
-            else None
-        )
+        _project_tags = cls._get_env_list("PROJECT_TAGS") if cls._get_env("PROJECT_TAGS") is not None else None
 
         return cls(
             api_key=api_key,
@@ -226,14 +221,21 @@ class DependencyTrackDestination:
 
         # add project tags if set
         if self._config.project_tags is not None:
-            payload["projectTags"] = self._config.project_tags
+            payload["projectTags"] = [{"name": t} for t in self._config.project_tags]
 
-        # ensure parent settings are coherent
         if self._config.parent_id:
             payload["parentUUID"] = self._config.parent_id
         elif self._config.parent_name and self._config.parent_version:
             payload["parentName"] = self._config.parent_name
             payload["parentVersion"] = self._config.parent_version
+        # ensure parent settings are coherent
+        elif bool(self._config.parent_name) ^ bool(self._config.parent_version):
+            return UploadResult.failure_result(
+                destination_name=self.name,
+                error_message=(
+                    "Dependency Track parent project configuration requires either DTRACK_PARENT_ID or both DTRACK_PARENT_NAME and DTRACK_PARENT_VERSION"
+                ),
+            )
 
         # Execute the upload
         try:

--- a/sbomify_action/_upload/destinations/dependency_track.py
+++ b/sbomify_action/_upload/destinations/dependency_track.py
@@ -24,7 +24,7 @@ environment variables, not from DTRACK_* prefixed variables.
 import base64
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, Optional
 
 import requests
 
@@ -62,7 +62,7 @@ class DependencyTrackConfig(DestinationConfig):
     api_url: str  # Full API base URL, we append /v1/bom
     project_id: Optional[str] = None
     auto_create: bool = False
-    project_tags: List[dict] = None
+    project_tags: list[dict] | None = None
     parent_id: Optional[str] = None
     parent_name: Optional[str] = None
     parent_version: Optional[str] = None

--- a/sbomify_action/_upload/destinations/dependency_track.py
+++ b/sbomify_action/_upload/destinations/dependency_track.py
@@ -79,7 +79,11 @@ class DependencyTrackConfig(DestinationConfig):
             return None
 
         # map list of tags to list[dict{name: tag}]
-        _project_tags = [{"name": t} for t in cls._get_env_list("PROJECT_TAGS")]
+        _project_tags = (
+            [{"name": t} for t in cls._get_env_list("PROJECT_TAGS")]
+            if cls._get_env("PROJECT_TAGS") is not None
+            else None
+        )
 
         return cls(
             api_key=api_key,
@@ -92,7 +96,7 @@ class DependencyTrackConfig(DestinationConfig):
             parent_id=cls._get_env("PARENT_ID"),
             parent_name=cls._get_env("PARENT_NAME"),
             parent_version=cls._get_env("PARENT_VERSION"),
-            is_latest=cls._get_env_bool("IS_LATEST", default=False)
+            is_latest=cls._get_env_bool("IS_LATEST", default=False),
         )
 
     def is_configured(self) -> bool:
@@ -201,11 +205,7 @@ class DependencyTrackDestination:
         payload: Dict[str, Any] = {
             "bom": bom_base64,
             "autoCreate": self._config.auto_create,
-            "projectTags": [] if self._config.project_tags is None else self._config.project_tags,
-            "parentUUID": self._config.parent_id,
-            "parentName": self._config.parent_name,
-            "parentVersion": self._config.parent_version,
-            "isLatest": self._config.is_latest
+            "isLatest": self._config.is_latest,
         }
 
         # Add project identifier
@@ -223,6 +223,17 @@ class DependencyTrackDestination:
                     "Dependency Track requires either DTRACK_PROJECT_ID or both COMPONENT_NAME and COMPONENT_VERSION"
                 ),
             )
+
+        # add project tags if set
+        if self._config.project_tags is not None:
+            payload["projectTags"] = self._config.project_tags
+
+        # ensure parent settings are coherent
+        if self._config.parent_id:
+            payload["parentUUID"] = self._config.parent_id
+        elif self._config.parent_name and self._config.parent_version:
+            payload["parentName"] = self._config.parent_name
+            payload["parentVersion"] = self._config.parent_version
 
         # Execute the upload
         try:

--- a/sbomify_action/_upload/destinations/dependency_track.py
+++ b/sbomify_action/_upload/destinations/dependency_track.py
@@ -11,6 +11,11 @@ Configuration via environment variables (DTRACK_* prefix):
                     - https://proxy.example.com/dtrack/api (reverse proxy)
     DTRACK_PROJECT_ID: UUID of the project to upload to (optional if using name+version)
     DTRACK_AUTO_CREATE: Auto-create project if it doesn't exist (default: false)
+    DTRACK_PROJECT_TAGS: Tags to add to the project (comma seperated)
+    DTRACK_PARENT_ID: UUID of the parent project
+    DTRACK_PARENT_NAME: Name of the parent project
+    DTRACK_PARENT_VERSION: Version of the parent project
+    DTRACK_IS_LATEST: Mark the uploaded BOM as the latest version
 
 Note: Project name and version come from the global COMPONENT_NAME and COMPONENT_VERSION
 environment variables, not from DTRACK_* prefixed variables.
@@ -19,7 +24,7 @@ environment variables, not from DTRACK_* prefixed variables.
 import base64
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 import requests
 
@@ -57,6 +62,11 @@ class DependencyTrackConfig(DestinationConfig):
     api_url: str  # Full API base URL, we append /v1/bom
     project_id: Optional[str] = None
     auto_create: bool = False
+    project_tags: List[dict] = None
+    parent_id: Optional[str] = None
+    parent_name: Optional[str] = None
+    parent_version: Optional[str] = None
+    is_latest: bool = False
 
     @classmethod
     def from_env(cls) -> Optional["DependencyTrackConfig"]:
@@ -68,6 +78,11 @@ class DependencyTrackConfig(DestinationConfig):
         if not api_key or not api_url:
             return None
 
+        # map list of tags to list[dict{name: tag}]
+        _project_tags = list(map(
+            lambda t: {"name": t}, cls._get_env_list("PROJECT_TAGS")
+        ))
+
         return cls(
             api_key=api_key,
             api_url=api_url.rstrip(
@@ -75,6 +90,11 @@ class DependencyTrackConfig(DestinationConfig):
             ),  # Only strip trailing "/" so custom paths like /api or /dtrack/api are preserved
             project_id=cls._get_env("PROJECT_ID"),
             auto_create=cls._get_env_bool("AUTO_CREATE", default=False),
+            project_tags=_project_tags,
+            parent_id=cls._get_env("PARENT_ID"),
+            parent_name=cls._get_env("PARENT_NAME"),
+            parent_version=cls._get_env("PARENT_VERSION"),
+            is_latest=cls._get_env_bool("IS_LATEST", default=False)
         )
 
     def is_configured(self) -> bool:
@@ -103,6 +123,11 @@ class DependencyTrackDestination:
         DTRACK_API_URL: Base URL of Dependency Track (required)
         DTRACK_PROJECT_ID: UUID of the project (optional, alternative to name/version)
         DTRACK_AUTO_CREATE: Auto-create project (default: false)
+        DTRACK_PROJECT_TAGS: Tags to add to the project (optional, comma seperated)
+        DTRACK_PARENT_ID: UUID of the parent project (optional)
+        DTRACK_PARENT_NAME: Name of the parent project (optional)
+        DTRACK_PARENT_VERSION: Version of the parent project (optional)
+        DTRACK_IS_LATEST: Mark the uploaded BOM as the latest version (default: false)
     """
 
     def __init__(self, config: Optional[DependencyTrackConfig] = None):
@@ -178,6 +203,11 @@ class DependencyTrackDestination:
         payload: Dict[str, Any] = {
             "bom": bom_base64,
             "autoCreate": self._config.auto_create,
+            "projectTags": [] if self._config.project_tags is None else self._config.project_tags,
+            "parentUUID": self._config.parent_id,
+            "parentName": self._config.parent_name,
+            "parentVersion": self._config.parent_version,
+            "isLatest": self._config.is_latest
         }
 
         # Add project identifier

--- a/sbomify_action/_upload/destinations/dependency_track.py
+++ b/sbomify_action/_upload/destinations/dependency_track.py
@@ -79,9 +79,7 @@ class DependencyTrackConfig(DestinationConfig):
             return None
 
         # map list of tags to list[dict{name: tag}]
-        _project_tags = list(map(
-            lambda t: {"name": t}, cls._get_env_list("PROJECT_TAGS")
-        ))
+        _project_tags = [{"name": t} for t in cls._get_env_list("PROJECT_TAGS")]
 
         return cls(
             api_key=api_key,

--- a/sbomify_action/_upload/destinations/dependency_track.py
+++ b/sbomify_action/_upload/destinations/dependency_track.py
@@ -63,9 +63,9 @@ class DependencyTrackConfig(DestinationConfig):
     project_id: Optional[str] = None
     auto_create: bool = False
     project_tags: list[dict] | None = None
-    parent_id: Optional[str] = None
-    parent_name: Optional[str] = None
-    parent_version: Optional[str] = None
+    parent_id: str = None
+    parent_name: str = None
+    parent_version: str = None
     is_latest: bool = False
 
     @classmethod

--- a/sbomify_action/_upload/destinations/dependency_track.py
+++ b/sbomify_action/_upload/destinations/dependency_track.py
@@ -63,9 +63,9 @@ class DependencyTrackConfig(DestinationConfig):
     project_id: Optional[str] = None
     auto_create: bool = False
     project_tags: list[str] | None = None
-    parent_id: str = None
-    parent_name: str = None
-    parent_version: str = None
+    parent_id: str | None = None
+    parent_name: str | None = None
+    parent_version: str | None = None
     is_latest: bool = False
 
     @classmethod

--- a/sbomify_action/_upload/destinations/dependency_track.py
+++ b/sbomify_action/_upload/destinations/dependency_track.py
@@ -11,7 +11,7 @@ Configuration via environment variables (DTRACK_* prefix):
                     - https://proxy.example.com/dtrack/api (reverse proxy)
     DTRACK_PROJECT_ID: UUID of the project to upload to (optional if using name+version)
     DTRACK_AUTO_CREATE: Auto-create project if it doesn't exist (default: false)
-    DTRACK_PROJECT_TAGS: Tags to add to the project (comma seperated)
+    DTRACK_PROJECT_TAGS: Tags to add to the project (comma separated)
     DTRACK_PARENT_ID: UUID of the parent project
     DTRACK_PARENT_NAME: Name of the parent project
     DTRACK_PARENT_VERSION: Version of the parent project
@@ -120,7 +120,7 @@ class DependencyTrackDestination:
         DTRACK_API_URL: Base URL of Dependency Track (required)
         DTRACK_PROJECT_ID: UUID of the project (optional, alternative to name/version)
         DTRACK_AUTO_CREATE: Auto-create project (default: false)
-        DTRACK_PROJECT_TAGS: Tags to add to the project (optional, comma seperated)
+        DTRACK_PROJECT_TAGS: Tags to add to the project (optional, comma separated)
         DTRACK_PARENT_ID: UUID of the parent project (optional)
         DTRACK_PARENT_NAME: Name of the parent project (optional)
         DTRACK_PARENT_VERSION: Version of the parent project (optional)

--- a/sbomify_action/_upload/protocol.py
+++ b/sbomify_action/_upload/protocol.py
@@ -85,7 +85,7 @@ class DestinationConfig(ABC):
         return value.lower() in ("true", "yes", "1", "on")
 
     @classmethod
-    def _get_env_list(cls, key: str, default: list = None) -> list:
+    def _get_env_list(cls, key: str, default: list | None = None) -> list:
         """Get list environment variable with prefix."""
         value = cls._get_env(key)
         if value is None or value.strip() == "":

--- a/sbomify_action/_upload/protocol.py
+++ b/sbomify_action/_upload/protocol.py
@@ -84,6 +84,13 @@ class DestinationConfig(ABC):
             return default
         return value.lower() in ("true", "yes", "1", "on")
 
+    @classmethod
+    def _get_env_list(cls, key: str, default: list = None) -> list:
+        """Get list environment variable with prefix."""
+        value = cls._get_env(key)
+        if value is None or value.strip() == "":
+            return [] if default is None else default
+        return value.split(',')
 
 class Destination(Protocol):
     """

--- a/sbomify_action/_upload/protocol.py
+++ b/sbomify_action/_upload/protocol.py
@@ -85,7 +85,7 @@ class DestinationConfig(ABC):
         return value.lower() in ("true", "yes", "1", "on")
 
     @classmethod
-    def _get_env_list(cls, key: str, default: list | None = None) -> list:
+    def _get_env_list(cls, key: str, default: list[str] | None = None) -> list[str]:
         """Get list environment variable with prefix."""
         value = cls._get_env(key)
         if value is None or value.strip() == "":

--- a/sbomify_action/_upload/protocol.py
+++ b/sbomify_action/_upload/protocol.py
@@ -90,7 +90,8 @@ class DestinationConfig(ABC):
         value = cls._get_env(key)
         if value is None or value.strip() == "":
             return [] if default is None else default
-        return value.split(',')
+        return [t.strip() for t in value.split(",") if t.strip()]
+
 
 class Destination(Protocol):
     """

--- a/tests/test_upload_module.py
+++ b/tests/test_upload_module.py
@@ -942,7 +942,6 @@ class TestDependencyTrackDestination(unittest.TestCase):
             result = dest.upload(input)
 
             self.assertFalse(result.success)
-            print(result.error_message)
             self.assertIn("DTRACK_PARENT_ID", result.error_message)
             self.assertIn("DTRACK_PARENT_NAME", result.error_message)
             self.assertIn("DTRACK_PARENT_VERSION", result.error_message)

--- a/tests/test_upload_module.py
+++ b/tests/test_upload_module.py
@@ -493,6 +493,9 @@ class TestDependencyTrackConfig(unittest.TestCase):
                 "DTRACK_API_URL": "https://dtrack.example.com/api/",
                 "DTRACK_PROJECT_ID": "project-uuid",
                 "DTRACK_AUTO_CREATE": "true",
+                "DTRACK_PROJECT_TAGS": "alpine, nightly",
+                "DTRACK_PARENT_ID": "979bac33-4c62-4e62-a64b-cd6caa43d508",
+                "DTRACK_IS_LATEST": "true",
             },
         ):
             config = DependencyTrackConfig.from_env()
@@ -503,6 +506,9 @@ class TestDependencyTrackConfig(unittest.TestCase):
             self.assertEqual(config.api_url, "https://dtrack.example.com/api")
             self.assertEqual(config.project_id, "project-uuid")
             self.assertTrue(config.auto_create)
+            self.assertEqual(config.project_tags, ["alpine", "nightly"])
+            self.assertEqual(config.parent_id, "979bac33-4c62-4e62-a64b-cd6caa43d508")
+            self.assertTrue(config.is_latest)
 
     def test_from_env_preserves_custom_paths(self):
         """Test that custom API paths are preserved."""
@@ -557,6 +563,54 @@ class TestDependencyTrackConfig(unittest.TestCase):
         with patch.dict(os.environ, {}, clear=True):
             config = DependencyTrackConfig.from_env()
             self.assertIsNone(config)
+
+    def test_from_env_list_single(self):
+        """Test that a single tag is handled correctly"""
+        with patch.dict(
+            os.environ,
+            {
+                "DTRACK_API_KEY": "test-api-key",
+                "DTRACK_API_URL": "https://dtrack.example.com/api",
+                "DTRACK_PROJECT_TAGS": "alpine",
+            },
+            clear=True,
+        ):
+            config = DependencyTrackConfig.from_env()
+
+        self.assertIsNotNone(config)
+        self.assertEqual(config.project_tags, ["alpine"])
+
+    def test_from_env_list_trailing_comma(self):
+        """Test that tags with a trailing comma are handled correctly"""
+        with patch.dict(
+            os.environ,
+            {
+                "DTRACK_API_KEY": "test-api-key",
+                "DTRACK_API_URL": "https://dtrack.example.com/api",
+                "DTRACK_PROJECT_TAGS": "alpine, nightly,",
+            },
+            clear=True,
+        ):
+            config = DependencyTrackConfig.from_env()
+
+        self.assertIsNotNone(config)
+        self.assertEqual(config.project_tags, ["alpine", "nightly"])
+
+    def test_from_env_list_empty(self):
+        """Test that empty tags are handled correctly"""
+        with patch.dict(
+            os.environ,
+            {
+                "DTRACK_API_KEY": "test-api-key",
+                "DTRACK_API_URL": "https://dtrack.example.com/api",
+                "DTRACK_PROJECT_TAGS": "",
+            },
+            clear=True,
+        ):
+            config = DependencyTrackConfig.from_env()
+
+        self.assertIsNotNone(config)
+        self.assertEqual(config.project_tags, [])
 
     def test_is_configured_with_project_id(self):
         """Test is_configured with project_id."""
@@ -734,6 +788,166 @@ class TestDependencyTrackDestination(unittest.TestCase):
         self.assertFalse(result.success)
         self.assertIn("CycloneDX", result.error_message)
         self.assertIn("spdx", result.error_message)
+
+    @patch("sbomify_action._upload.destinations.dependency_track.requests.put")
+    def test_upload_success_with_parent_id(self, mock_put):
+        """Test successful upload with parent id"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"bomFormat": "CycloneDX", "specVersion": "1.6"}, f)
+            sbom_file = f.name
+
+        try:
+            mock_response = Mock()
+            mock_response.ok = True
+            mock_response.json.return_value = {"token": "upload-token-456"}
+            mock_put.return_value = mock_response
+
+            config = DependencyTrackConfig(
+                api_key="test-key",
+                api_url="https://dtrack.example.com/api",  # Full API base URL
+                auto_create=True,
+                parent_id="979bac33-4c62-4e62-a64b-cd6caa43d508",
+            )
+            dest = DependencyTrackDestination(config=config)
+            # Component name/version now come from UploadInput
+            input = UploadInput(
+                sbom_file=sbom_file,
+                sbom_format="cyclonedx",
+                component_name="my-project",
+                component_version="1.0.0",
+            )
+
+            result = dest.upload(input)
+
+            self.assertTrue(result.success)
+
+            # Verify payload contains projectName and projectVersion from UploadInput
+            call_args = mock_put.call_args
+            payload = call_args[1]["json"]
+            self.assertEqual(payload["projectName"], "my-project")
+            self.assertEqual(payload["projectVersion"], "1.0.0")
+            self.assertTrue(payload["autoCreate"])
+            self.assertEqual(payload["parentUUID"], "979bac33-4c62-4e62-a64b-cd6caa43d508")
+        finally:
+            Path(sbom_file).unlink()
+
+    @patch("sbomify_action._upload.destinations.dependency_track.requests.put")
+    def test_upload_success_with_parent_name_and_version(self, mock_put):
+        """Test successful upload with parent name and version"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"bomFormat": "CycloneDX", "specVersion": "1.6"}, f)
+            sbom_file = f.name
+
+        try:
+            mock_response = Mock()
+            mock_response.ok = True
+            mock_response.json.return_value = {"token": "upload-token-456"}
+            mock_put.return_value = mock_response
+
+            config = DependencyTrackConfig(
+                api_key="test-key",
+                api_url="https://dtrack.example.com/api",  # Full API base URL
+                auto_create=True,
+                parent_name="test-parent",
+                parent_version="1.0.0",
+            )
+            dest = DependencyTrackDestination(config=config)
+            # Component name/version now come from UploadInput
+            input = UploadInput(
+                sbom_file=sbom_file,
+                sbom_format="cyclonedx",
+                component_name="my-project",
+                component_version="1.0.0",
+            )
+
+            result = dest.upload(input)
+
+            self.assertTrue(result.success)
+
+            # Verify payload contains projectName and projectVersion from UploadInput
+            call_args = mock_put.call_args
+            payload = call_args[1]["json"]
+            self.assertEqual(payload["projectName"], "my-project")
+            self.assertEqual(payload["projectVersion"], "1.0.0")
+            self.assertTrue(payload["autoCreate"])
+            self.assertEqual(payload["parentName"], "test-parent")
+            self.assertEqual(payload["parentVersion"], "1.0.0")
+        finally:
+            Path(sbom_file).unlink()
+
+    @patch("sbomify_action._upload.destinations.dependency_track.requests.put")
+    def test_upload_success_with_project_tags(self, mock_put):
+        """Test successful upload with project tags"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"bomFormat": "CycloneDX", "specVersion": "1.6"}, f)
+            sbom_file = f.name
+
+        try:
+            mock_response = Mock()
+            mock_response.ok = True
+            mock_response.json.return_value = {"token": "upload-token-456"}
+            mock_put.return_value = mock_response
+
+            config = DependencyTrackConfig(
+                api_key="test-key",
+                api_url="https://dtrack.example.com/api",  # Full API base URL
+                auto_create=True,
+                project_tags=["alpine", "nightly"],
+            )
+            dest = DependencyTrackDestination(config=config)
+            # Component name/version now come from UploadInput
+            input = UploadInput(
+                sbom_file=sbom_file,
+                sbom_format="cyclonedx",
+                component_name="my-project",
+                component_version="1.0.0",
+            )
+
+            result = dest.upload(input)
+
+            self.assertTrue(result.success)
+
+            # Verify payload contains projectName and projectVersion from UploadInput
+            call_args = mock_put.call_args
+            payload = call_args[1]["json"]
+            self.assertEqual(payload["projectName"], "my-project")
+            self.assertEqual(payload["projectVersion"], "1.0.0")
+            self.assertTrue(payload["autoCreate"])
+            self.assertEqual(payload["projectTags"], [{"name": "alpine"}, {"name": "nightly"}])
+        finally:
+            Path(sbom_file).unlink()
+
+    def test_upload_partial_parent_config(self):
+        """Test failed upload with partial parent config"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"bomFormat": "CycloneDX", "specVersion": "1.6"}, f)
+            sbom_file = f.name
+
+        try:
+            config = DependencyTrackConfig(
+                api_key="test-key",
+                api_url="https://dtrack.example.com/api",  # Full API base URL
+                auto_create=True,
+                parent_name="test-parent",
+            )
+            dest = DependencyTrackDestination(config=config)
+
+            input = UploadInput(
+                sbom_file=sbom_file,
+                sbom_format="cyclonedx",
+                component_name="my-project",
+                component_version="1.0.0",
+            )
+
+            result = dest.upload(input)
+
+            self.assertFalse(result.success)
+            print(result.error_message)
+            self.assertIn("DTRACK_PARENT_ID", result.error_message)
+            self.assertIn("DTRACK_PARENT_NAME", result.error_message)
+            self.assertIn("DTRACK_PARENT_VERSION", result.error_message)
+        finally:
+            Path(sbom_file).unlink()
 
 
 class TestUploadOrchestrator(unittest.TestCase):


### PR DESCRIPTION
## Summary

1. Added new configuration options for uploads to dependency-track:

- `DTRACK_PROJECT_TAGS` - Tags to add to the project (comma seperated)
- `DTRACK_PARENT_ID` - Id of the parent project
- `DTRACK_PARENT_NAME` - Name of the parent project
- `DTRACK_PARENT_VERSION` - Version of the parent project
- `DTRACK_IS_LATEST` - Mark the uploaded BOM as the latest version (default: false)

2. New classmethod in `procol.py`: `_get_env_list`, which returns a comma seperated env option as a list.
3. Added the new options to README and formatted

closes: #212