### PR TITLE
Skip --required-only for Go in cdxgen (fixes #231)

### DIFF
--- a/sbomify_action/_generation/generators/cdxgen.py
+++ b/sbomify_action/_generation/generators/cdxgen.py
@@ -172,8 +172,14 @@ class CdxgenFsGenerator:
 
         # Exclude dev dependencies and local workspace packages across all ecosystems
         # This filters out development-only dependencies, keeping only production dependencies
-        # For JavaScript, this also excludes local packages with path-based versions
-        cmd.append("--required-only")
+        # For JavaScript, this also excludes local packages with path-based versions.
+        #
+        # Skip for Go: cdxgen tags every `// indirect` line in go.mod as scope=optional,
+        # but under Go 1.17+ module-graph pruning the indirect block IS the build closure
+        # (those modules are compiled into the binary). --required-only would strip the
+        # entire transitive closure along with the h1: hashes from go.sum. See issue #231.
+        if ecosystem != "go":
+            cmd.append("--required-only")
 
         # Fail on error to ensure we catch issues early
         cmd.append("--fail-on-error")

--- a/tests/test_generation_plugin.py
+++ b/tests/test_generation_plugin.py
@@ -456,8 +456,8 @@ class TestCdxgenFsGenerator(unittest.TestCase):
     @patch("sbomify_action._generation.generators.cdxgen.ensure_java_maven_installed")
     @patch("sbomify_action._generation.generators.cdxgen.run_command")
     @patch("pathlib.Path.exists")
-    def test_generate_uses_required_only_flag_for_all_ecosystems(self, mock_exists, mock_run, mock_java_install):
-        """Test that --required-only flag is passed for all ecosystems to exclude dev dependencies."""
+    def test_generate_uses_required_only_flag_for_dev_aware_ecosystems(self, mock_exists, mock_run, mock_java_install):
+        """Test that --required-only flag is passed for ecosystems with a dev/prod distinction."""
         mock_run.return_value = MagicMock(returncode=0)
         mock_exists.return_value = True
 
@@ -478,6 +478,24 @@ class TestCdxgenFsGenerator(unittest.TestCase):
         self.generator.generate(java_input)
         cmd = mock_run.call_args[0][0]
         self.assertIn("--required-only", cmd)
+
+    @patch("sbomify_action._generation.generators.cdxgen.ensure_go_installed")
+    @patch("sbomify_action._generation.generators.cdxgen.run_command")
+    @patch("pathlib.Path.exists")
+    def test_generate_omits_required_only_for_go(self, mock_exists, mock_run, mock_go_install):
+        """Test that --required-only is NOT passed for Go (issue #231).
+
+        cdxgen marks every `// indirect` line in go.mod as scope=optional, but under
+        Go 1.17+ module-graph pruning the indirect block is the build closure — those
+        modules ship in the binary. --required-only would strip the transitive closure.
+        """
+        mock_run.return_value = MagicMock(returncode=0)
+        mock_exists.return_value = True
+
+        go_input = GenerationInput(lock_file="/path/to/go.mod", output_file="sbom.json")
+        self.generator.generate(go_input)
+        cmd = mock_run.call_args[0][0]
+        self.assertNotIn("--required-only", cmd)
 
     @patch("sbomify_action._generation.generators.cdxgen.run_command")
     @patch("pathlib.Path.exists")


### PR DESCRIPTION
## Summary

- Skip cdxgen's `--required-only` flag when the lockfile is `go.mod`.
- cdxgen marks every `// indirect` line in `go.mod` as `scope: optional`, but under Go 1.17+ module-graph pruning the indirect block **is** the build closure — those modules are compiled into the binary. `--required-only` was silently stripping the entire transitive closure (and the `h1:` hashes from `go.sum`) from every Go SBOM.
- Verified empirically with cdxgen 12.4.4 across Go, Python (uv), npm, and Rust — only Go is affected. Python and npm correctly tag dev deps and prod transitives stay. Rust doesn't set scope at all in this cdxgen version, making the flag a no-op there.

## Evidence

cdxgen's own source (`lib/helpers/utils.js:10898`) acknowledges the misuse:

> // This is misusing the scope attribute to represent direct vs indirect

Reporter's repro (`go.mod` with one direct + one indirect dep): 2 components → 1 after `--required-only`. A deeper closure (gRPC + cobra): 8 components → 2 after `--required-only`.

## Test plan

- [x] `uv run ruff check sbomify_action tests`
- [x] `uv run ruff format --check sbomify_action tests`
- [x] `uv run pytest` (2195 passed, 4 skipped)
- [x] New test `test_generate_omits_required_only_for_go` asserts the flag is NOT passed for `go.mod`
- [x] Existing test renamed to `test_generate_uses_required_only_flag_for_dev_aware_ecosystems` — still asserts the flag IS passed for JS/Python/Java

## Notes

The Docker/OCI generator (`cdxgen.py:289`) is unchanged. Source-code analysis suggests the Go `// indirect` heuristic only applies to `go.mod` parsing, not the binary-analysis path that `-t oci` triggers — but this was not empirically verified. Worth a follow-up if anyone reports Go binaries inside OCI images coming up short.

Fixes #231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)