### PR TITLE
Add OIDC trusted-publishing support

### DIFF
--- a/.github/workflows/sbomify.yaml
+++ b/.github/workflows/sbomify.yaml
@@ -1206,6 +1206,7 @@ jobs:
           # Trusted publishing via GitHub OIDC — no TOKEN secret required.
           # Binding configured in sbomify UI for this repo + component.
           API_BASE_URL: 'https://stage.sbomify.com'
+          OIDC_AUDIENCE: 'stage.sbomify.com'
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
           COMPONENT_VERSION: ${{ steps.version.outputs.version }}
@@ -1364,6 +1365,7 @@ jobs:
           # Trusted publishing via GitHub OIDC — no TOKEN secret required.
           # Binding configured in sbomify UI for this repo + component.
           API_BASE_URL: 'https://stage.sbomify.com'
+          OIDC_AUDIENCE: 'stage.sbomify.com'
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
           COMPONENT_VERSION: ${{ steps.version.outputs.version }}

--- a/.github/workflows/sbomify.yaml
+++ b/.github/workflows/sbomify.yaml
@@ -1203,7 +1203,8 @@ jobs:
       - name: Generate and Upload SBOM
         uses: sbomify/sbomify-action@master
         env:
-          TOKEN: ${{ secrets.SBOMIFY_STAGE_TOKEN }}
+          # Trusted publishing via GitHub OIDC — no TOKEN secret required.
+          # Binding configured in sbomify UI for this repo + component.
           API_BASE_URL: 'https://stage.sbomify.com'
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
@@ -1290,7 +1291,8 @@ jobs:
       - name: Generate and Upload SBOM
         uses: sbomify/sbomify-action@master
         env:
-          TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
+          # Trusted publishing via GitHub OIDC — no TOKEN secret required.
+          # Binding configured in sbomify UI for this repo + component.
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
           COMPONENT_VERSION: ${{ steps.version.outputs.version }}
@@ -1359,7 +1361,8 @@ jobs:
       - name: Generate and Upload SBOM
         uses: sbomify/sbomify-action@master
         env:
-          TOKEN: ${{ secrets.SBOMIFY_STAGE_TOKEN }}
+          # Trusted publishing via GitHub OIDC — no TOKEN secret required.
+          # Binding configured in sbomify UI for this repo + component.
           API_BASE_URL: 'https://stage.sbomify.com'
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
@@ -1430,7 +1433,8 @@ jobs:
       - name: Generate and Upload SBOM
         uses: sbomify/sbomify-action@master
         env:
-          TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
+          # Trusted publishing via GitHub OIDC — no TOKEN secret required.
+          # Binding configured in sbomify UI for this repo + component.
           COMPONENT_ID: ${{ matrix.component_id }}
           COMPONENT_NAME: ${{ matrix.component_name }}
           COMPONENT_VERSION: ${{ steps.version.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -79,6 +79,30 @@ That's it! This generates a CycloneDX SBOM from your lockfile and enriches it wi
     ENRICH: true
 ```
 
+### With sbomify (Trusted Publishing — no token)
+
+Skip the long-lived `TOKEN` secret. When the workflow grants `id-token: write`, the action exchanges a GitHub OIDC token for a short-lived sbomify access token on the fly. **Set up an OIDC binding** for the component in the sbomify UI first (Component → Settings → Trusted Publishing), then:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write   # required for OIDC trusted publishing
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: sbomify/sbomify-action@master
+        env:
+          COMPONENT_ID: your-component-id
+          LOCK_FILE: requirements.txt
+          AUGMENT: true
+          ENRICH: true
+```
+
+If `TOKEN` is set, it takes precedence — OIDC is only used as the fallback when no token is provided.
+
 ### Docker Image
 
 ```yaml
@@ -249,6 +273,7 @@ Setting `LOCK_FILE` (or `SBOM_FILE`) to `none` creates an empty SBOM and injects
 | `UPLOAD`                   | No       | Upload SBOM (default: true)                                                      |
 | `UPLOAD_DESTINATIONS`      | No       | Comma-separated destinations: `sbomify`, `dependency-track` (default: `sbomify`) |
 | `API_BASE_URL`             | No       | Override sbomify API URL for self-hosted instances                               |
+| `OIDC_AUDIENCE`            | No       | Audience for OIDC trusted publishing (default: `sbomify.com`; override for self-hosted) |
 | `ADDITIONAL_PACKAGES_FILE` | No       | Custom path to additional packages file                                          |
 | `ADDITIONAL_PACKAGES`      | No       | Inline PURLs to inject (comma or newline separated)                              |
 | `DISABLE_VCS_AUGMENTATION` | No       | Set to `true` to disable auto-detection of VCS info from CI environment          |
@@ -257,7 +282,7 @@ Setting `LOCK_FILE` (or `SBOM_FILE`) to `none` creates an empty SBOM and injects
 | `SYFT_CACHE_DIR`           | No       | Directory for Syft cache                                                         |
 
 † **One** of `LOCK_FILE`, `SBOM_FILE`, or `DOCKER_IMAGE` is required (pick one)
-‡ Required when uploading to sbomify or using sbomify features (`AUGMENT`, `PRODUCT_RELEASE`)
+‡ Required when uploading to sbomify or using sbomify features (`AUGMENT`, `PRODUCT_RELEASE`). `TOKEN` may be omitted in GitHub Actions when the workflow grants `permissions: id-token: write` — see [Trusted Publishing](#with-sbomify-trusted-publishing--no-token).
 
 <details>
 <summary><strong>Dependency Track configuration</strong></summary>

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   component-purl:
     description: 'Override the component PURL in the SBOM (e.g., pkg:npm/@scope/name@1.0.0)'
     required: false
+  oidc-audience:
+    description: 'OIDC audience for trusted publishing (default: sbomify.com; override for self-hosted)'
+    required: false
 runs:
   using: 'docker'
   # Bump/pin this to release
@@ -17,6 +20,7 @@ runs:
   env:
     WORKING_DIR: ${{ inputs['working-dir'] }}
     COMPONENT_PURL: ${{ inputs['component-purl'] }}
+    OIDC_AUDIENCE: ${{ inputs['oidc-audience'] }}
 branding:
   icon: 'upload-cloud'
   color: 'blue'

--- a/sbomify_action/_yocto/api.py
+++ b/sbomify_action/_yocto/api.py
@@ -1,6 +1,6 @@
 """Component CRUD API calls for Yocto pipeline."""
 
-from typing import Iterator
+from typing import Any, Iterator
 
 import requests
 
@@ -12,7 +12,7 @@ _PAGE_SIZE = 100
 _MAX_PAGES = 500  # Safety limit against runaway pagination
 
 
-def _iter_components(api_base_url: str, token: str, error_context: str) -> Iterator[dict]:
+def _iter_components(api_base_url: str, token: str, error_context: str) -> Iterator[dict[str, Any]]:
     """Yield every component item from /api/v1/components, paginating as needed.
 
     Raises APIError for any HTTP/transport/JSON-shape failure so callers see
@@ -151,7 +151,7 @@ def create_component(api_base_url: str, token: str, name: str) -> tuple[str, boo
 
     if not response.ok:
         err_msg = f"Failed to create component '{name}'. [{response.status_code}]"
-        body: dict = {}
+        body: dict[str, Any] = {}
         try:
             parsed = response.json()
             if isinstance(parsed, dict):

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import sys
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional, cast
@@ -39,6 +39,7 @@ from ..exceptions import (
     ConfigurationError,
     DockerImageNotFoundError,
     FileProcessingError,
+    OIDCError,
     SBOMGenerationError,
     SBOMValidationError,
     ToolNotAvailableError,
@@ -201,7 +202,10 @@ The tool can be configured via environment variables:
 class Config:
     """Configuration settings for the SBOM action."""
 
-    token: str
+    # repr=False so any incidental f"{config}" / pytest assertion diff /
+    # debug log doesn't dump the token. OIDC-minted tokens are short-lived
+    # but CI log lines persist much longer.
+    token: str = field(repr=False)
     component_id: str
     sbom_file: Optional[str] = None
     docker_image: Optional[str] = None
@@ -221,6 +225,10 @@ class Config:
     sbom_format: SBOMFormat = "cyclonedx"
     spec_version: Optional[str] = None
     oidc_audience: str | None = None
+    # Set to True at runtime when config.token was obtained via OIDC exchange;
+    # signals that the token is short-lived (default TTL 15 min) and should be
+    # re-minted before long-running post-upload work (e.g. processors).
+    token_is_oidc_minted: bool = field(default=False, repr=False)
 
     def __post_init__(self) -> None:
         """Set default values that depend on other fields."""
@@ -234,6 +242,34 @@ class Config:
             self.sbom_file is not None and self.sbom_file.lower() == NONE_SENTINEL
         )
 
+    @property
+    def uploads_to_sbomify(self) -> bool:
+        """True iff the configured upload destinations include sbomify."""
+        return self.upload and self.upload_destinations is not None and "sbomify" in self.upload_destinations
+
+    @property
+    def requires_sbomify_api(self) -> bool:
+        """True iff this run MUST authenticate to the sbomify API.
+
+        Used by validate() to decide whether credentials are mandatory,
+        and by run_pipeline() to decide whether to attempt OIDC exchange.
+        Augmentation does NOT mandate credentials (it can fall back to
+        sbomify.json + VCS providers) — see :py:attr:`will_use_sbomify_api`.
+        """
+        return self.uploads_to_sbomify or bool(self.product_releases)
+
+    @property
+    def will_use_sbomify_api(self) -> bool:
+        """True iff this run will call the sbomify API if credentials exist.
+
+        Superset of :py:attr:`requires_sbomify_api`: also covers augmentation,
+        which uses the API opportunistically when a token is present but
+        falls back to local providers otherwise. The OIDC exchange in
+        run_pipeline() uses this so users who enable AUGMENT with
+        ``id-token: write`` get backend metadata via trusted publishing.
+        """
+        return self.requires_sbomify_api or self.augment
+
     def validate(self) -> None:
         """
         Validate configuration settings.
@@ -244,13 +280,8 @@ class Config:
         # Check if sbomify API access is required:
         # - Uploading to sbomify destination
         # - Managing releases (uses sbomify API)
-        # Note: Augmentation does NOT require API - it can use sbomify.json and VCS metadata
-        uploads_to_sbomify = (
-            self.upload and self.upload_destinations is not None and "sbomify" in self.upload_destinations
-        )
-        requires_sbomify_api = uploads_to_sbomify or self.product_releases
-
-        if requires_sbomify_api:
+        # Augmentation is opportunistic — handled separately at runtime.
+        if self.requires_sbomify_api:
             if not self.token:
                 # Allow missing token when GitHub OIDC trusted publishing is available —
                 # the pipeline will exchange the OIDC JWT for a short-lived token at runtime.
@@ -258,7 +289,7 @@ class Config:
 
                 if not is_github_oidc_available():
                     operations = []
-                    if uploads_to_sbomify:
+                    if self.uploads_to_sbomify:
                         operations.append("uploading to sbomify")
                     if self.product_releases:
                         operations.append("PRODUCT_RELEASE is set")
@@ -266,11 +297,12 @@ class Config:
                     raise ConfigurationError(
                         f"sbomify API token is not defined (required when {reason}). "
                         "Either set TOKEN, or in GitHub Actions enable trusted publishing by "
-                        "granting `permissions: id-token: write` in the workflow."
+                        "granting `permissions: id-token: write` in the workflow (and create "
+                        "an OIDC binding for the component in the sbomify UI)."
                     )
             if not self.component_id:
                 operations = []
-                if uploads_to_sbomify:
+                if self.uploads_to_sbomify:
                     operations.append("uploading to sbomify")
                 if self.product_releases:
                     operations.append("PRODUCT_RELEASE is set")
@@ -663,7 +695,16 @@ def initialize_sentry() -> None:
             # SBOMGenerationError and APIError should still be sent (tool/system bugs)
             # DockerImageNotFoundError is a user configuration error (image doesn't exist)
             if isinstance(
-                exc_value, (SBOMValidationError, ConfigurationError, DockerImageNotFoundError, ToolNotAvailableError)
+                exc_value,
+                (
+                    SBOMValidationError,
+                    ConfigurationError,
+                    DockerImageNotFoundError,
+                    ToolNotAvailableError,
+                    # OIDC errors are user/setup issues (missing binding, wrong audience,
+                    # rate limit) — not actionable Sentry events.
+                    OIDCError,
+                ),
             ):
                 return None
 
@@ -682,6 +723,9 @@ def initialize_sentry() -> None:
         profiles_sample_rate=1.0,
         before_send=before_send,  # type: ignore[arg-type]
         release=f"sbomify-action@{SBOMIFY_VERSION}",
+        # Don't capture frame locals — they can hold OIDC JWTs / Bearer tokens
+        # if an unexpected exception fires inside sbomify_action.oidc.
+        include_local_variables=False,
     )
 
     # Set the action version as a tag (always safe to send)
@@ -1094,15 +1138,13 @@ def run_pipeline(config: Config) -> None:
 
     # OIDC trusted publishing (GitHub Actions): when TOKEN is missing but the
     # workflow granted id-token: write and we know which component to scope to,
-    # exchange a GitHub OIDC JWT for a short-lived sbomify access token.
-    # The resulting token then transparently powers upload, augment, and processors.
-    # Only run when the pipeline actually needs to call the sbomify API — mirrors
-    # the requires_sbomify_api logic in Config.validate().
-    uploads_to_sbomify = (
-        config.upload and config.upload_destinations is not None and "sbomify" in config.upload_destinations
-    )
-    needs_sbomify_api = uploads_to_sbomify or bool(config.product_releases)
-    if needs_sbomify_api and not config.token and config.component_id:
+    # exchange a GitHub OIDC JWT for a short-lived sbomify access token. The
+    # resulting token then transparently powers upload, augment, and processors.
+    #
+    # Triggered for any run that will call the sbomify API (uploads, product
+    # releases, OR augmentation). For augment-only with no token and no OIDC
+    # env, we skip silently — augmentation falls back to sbomify.json.
+    if config.will_use_sbomify_api and not config.token and config.component_id:
         from ..exceptions import OIDCBindingMissingError, OIDCExchangeError
         from ..oidc import is_github_oidc_available, obtain_sbomify_token_via_oidc
 
@@ -1113,12 +1155,24 @@ def run_pipeline(config: Config) -> None:
                     api_base_url=config.api_base_url,
                     audience=config.oidc_audience,
                 )
+                config.token_is_oidc_minted = True
             except OIDCBindingMissingError as exc:
                 logger.error(str(exc))
                 sys.exit(1)
             except OIDCExchangeError as exc:
                 logger.error(f"OIDC trusted publishing failed: {exc}")
                 sys.exit(1)
+        elif config.requires_sbomify_api:
+            # validate() let this config through assuming OIDC would be
+            # available at run-time. Env state drifted (caller bypassed
+            # validate, subprocess scrubbed env, etc.) — fail loud instead
+            # of letting the pipeline hit the API with no Authorization.
+            logger.error(
+                "sbomify API token is required but neither TOKEN nor GitHub OIDC env "
+                "is available at pipeline runtime. Set TOKEN, or ensure the workflow "
+                "grants `permissions: id-token: write` for the runner."
+            )
+            sys.exit(1)
 
     # Step 1: SBOM Generation/Validation
     _log_step_header(1, "SBOM Generation/Input Processing")
@@ -1422,8 +1476,10 @@ def run_pipeline(config: Config) -> None:
         if not config.token or not config.component_id:
             gha_notice(
                 "sbomify API augmentation skipped (TOKEN or COMPONENT_ID not set). "
-                "To add metadata, create a sbomify.json file in your project root "
-                "or configure sbomify API credentials.",
+                "To add metadata, either create a sbomify.json file in your project "
+                "root, set TOKEN + COMPONENT_ID, or in GitHub Actions enable trusted "
+                "publishing with `permissions: id-token: write` plus an OIDC binding "
+                "in the sbomify UI.",
                 title="API Augmentation Skipped",
             )
 
@@ -1586,6 +1642,26 @@ def run_pipeline(config: Config) -> None:
         _log_step_header(6, "Post-upload Processing")
         try:
             from sbomify_action._processors import ProcessorInput, ProcessorOrchestrator
+
+            # Re-mint the OIDC token before kicking off processors: long pipelines
+            # (large Docker images, Yocto builds, slow enrichment) can exceed the
+            # 15-minute default TTL on the originally minted token.
+            if config.token_is_oidc_minted:
+                from ..exceptions import OIDCBindingMissingError, OIDCExchangeError
+                from ..oidc import is_github_oidc_available, obtain_sbomify_token_via_oidc
+
+                if is_github_oidc_available():
+                    try:
+                        config.token = obtain_sbomify_token_via_oidc(
+                            component_id=config.component_id,
+                            api_base_url=config.api_base_url,
+                            audience=config.oidc_audience,
+                        )
+                    except (OIDCBindingMissingError, OIDCExchangeError) as exc:
+                        logger.warning(
+                            f"Could not refresh OIDC-minted token before processors: {exc}. "
+                            "Continuing with the original token — long-running pipelines may see 401s."
+                        )
 
             orchestrator = ProcessorOrchestrator(
                 api_base_url=config.api_base_url,

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -220,7 +220,7 @@ class Config:
     api_base_url: str = SBOMIFY_PRODUCTION_API
     sbom_format: SBOMFormat = "cyclonedx"
     spec_version: Optional[str] = None
-    oidc_audience: Optional[str] = None
+    oidc_audience: str | None = None
 
     def __post_init__(self) -> None:
         """Set default values that depend on other fields."""
@@ -1096,7 +1096,13 @@ def run_pipeline(config: Config) -> None:
     # workflow granted id-token: write and we know which component to scope to,
     # exchange a GitHub OIDC JWT for a short-lived sbomify access token.
     # The resulting token then transparently powers upload, augment, and processors.
-    if not config.token and config.component_id:
+    # Only run when the pipeline actually needs to call the sbomify API — mirrors
+    # the requires_sbomify_api logic in Config.validate().
+    uploads_to_sbomify = (
+        config.upload and config.upload_destinations is not None and "sbomify" in config.upload_destinations
+    )
+    needs_sbomify_api = uploads_to_sbomify or bool(config.product_releases)
+    if needs_sbomify_api and not config.token and config.component_id:
         from ..exceptions import OIDCBindingMissingError, OIDCExchangeError
         from ..oidc import is_github_oidc_available, obtain_sbomify_token_via_oidc
 

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -220,6 +220,7 @@ class Config:
     api_base_url: str = SBOMIFY_PRODUCTION_API
     sbom_format: SBOMFormat = "cyclonedx"
     spec_version: Optional[str] = None
+    oidc_audience: Optional[str] = None
 
     def __post_init__(self) -> None:
         """Set default values that depend on other fields."""
@@ -251,13 +252,22 @@ class Config:
 
         if requires_sbomify_api:
             if not self.token:
-                operations = []
-                if uploads_to_sbomify:
-                    operations.append("uploading to sbomify")
-                if self.product_releases:
-                    operations.append("PRODUCT_RELEASE is set")
-                reason = " or ".join(operations)
-                raise ConfigurationError(f"sbomify API token is not defined (required when {reason})")
+                # Allow missing token when GitHub OIDC trusted publishing is available —
+                # the pipeline will exchange the OIDC JWT for a short-lived token at runtime.
+                from ..oidc import is_github_oidc_available
+
+                if not is_github_oidc_available():
+                    operations = []
+                    if uploads_to_sbomify:
+                        operations.append("uploading to sbomify")
+                    if self.product_releases:
+                        operations.append("PRODUCT_RELEASE is set")
+                    reason = " or ".join(operations)
+                    raise ConfigurationError(
+                        f"sbomify API token is not defined (required when {reason}). "
+                        "Either set TOKEN, or in GitHub Actions enable trusted publishing by "
+                        "granting `permissions: id-token: write` in the workflow."
+                    )
             if not self.component_id:
                 operations = []
                 if uploads_to_sbomify:
@@ -474,6 +484,7 @@ def build_config(
     api_base_url: str = SBOMIFY_PRODUCTION_API,
     sbom_format: str = "cyclonedx",
     spec_version: Optional[str] = None,
+    oidc_audience: Optional[str] = None,
 ) -> Config:
     """
     Build and validate configuration from provided arguments.
@@ -552,6 +563,7 @@ def build_config(
         api_base_url=api_base_url,
         sbom_format=sbom_format_lower,
         spec_version=spec_version,
+        oidc_audience=oidc_audience,
     )
 
     try:
@@ -597,6 +609,7 @@ def load_config() -> Config:
         product_releases=os.getenv("PRODUCT_RELEASE"),
         api_base_url=os.getenv("API_BASE_URL", SBOMIFY_PRODUCTION_API),
         sbom_format=os.getenv("SBOM_FORMAT", "cyclonedx"),
+        oidc_audience=os.getenv("OIDC_AUDIENCE"),
     )
 
 
@@ -1078,6 +1091,28 @@ def run_pipeline(config: Config) -> None:
         logger.info(f"Using custom API base URL: {config.api_base_url}")
     else:
         logger.info(f"Using production API: {config.api_base_url}")
+
+    # OIDC trusted publishing (GitHub Actions): when TOKEN is missing but the
+    # workflow granted id-token: write and we know which component to scope to,
+    # exchange a GitHub OIDC JWT for a short-lived sbomify access token.
+    # The resulting token then transparently powers upload, augment, and processors.
+    if not config.token and config.component_id:
+        from ..exceptions import OIDCBindingMissingError, OIDCExchangeError
+        from ..oidc import is_github_oidc_available, obtain_sbomify_token_via_oidc
+
+        if is_github_oidc_available():
+            try:
+                config.token = obtain_sbomify_token_via_oidc(
+                    component_id=config.component_id,
+                    api_base_url=config.api_base_url,
+                    audience=config.oidc_audience,
+                )
+            except OIDCBindingMissingError as exc:
+                logger.error(str(exc))
+                sys.exit(1)
+            except OIDCExchangeError as exc:
+                logger.error(f"OIDC trusted publishing failed: {exc}")
+                sys.exit(1)
 
     # Step 1: SBOM Generation/Validation
     _log_step_header(1, "SBOM Generation/Input Processing")
@@ -2226,6 +2261,12 @@ def _parse_upload_destinations_callback(
     help="Override the spec version for SBOM generation (e.g., '1.6', '2.3', '3.0.1').",
 )
 @click.option(
+    "--oidc-audience",
+    envvar="OIDC_AUDIENCE",
+    default=None,
+    help="Audience claim for GitHub OIDC trusted publishing (default: sbomify.com; override for self-hosted).",
+)
+@click.option(
     "--telemetry/--no-telemetry",
     envvar="TELEMETRY",
     default=True,
@@ -2274,6 +2315,7 @@ def cli(
     api_base_url: str,
     sbom_format: str,
     spec_version: Optional[str],
+    oidc_audience: Optional[str],
     working_dir: str | None,
     telemetry: bool,
     verbose: bool,
@@ -2394,6 +2436,7 @@ def cli(
         api_base_url=api_base_url,
         sbom_format=sbom_format,
         spec_version=spec_version,
+        oidc_audience=oidc_audience,
     )
 
     # Run the pipeline

--- a/sbomify_action/exceptions.py
+++ b/sbomify_action/exceptions.py
@@ -87,6 +87,23 @@ class PlanLimitError(APIError):
     """Raised when an API operation fails due to plan limits (e.g., max components)."""
 
 
+class OIDCError(APIError):
+    """Base exception for OIDC trusted-publishing failures."""
+
+
+class OIDCBindingMissingError(OIDCError):
+    """Raised when the sbomify backend has no OIDC binding for the (component, repo) pair.
+
+    The user must create an OIDC binding for the component in the sbomify UI before
+    trusted publishing will work from this repository.
+    """
+
+
+class OIDCExchangeError(OIDCError):
+    """Raised when the OIDC -> sbomify token exchange fails for any other reason
+    (invalid OIDC token, rate limit, backend unavailable, etc.)."""
+
+
 class FileProcessingError(SbomifyError):
     """Raised when file operations fail."""
 

--- a/sbomify_action/oidc.py
+++ b/sbomify_action/oidc.py
@@ -21,7 +21,9 @@ publishing will work — otherwise the exchange returns 403.
 """
 
 import os
+import re
 import time
+from urllib.parse import urlparse
 
 import requests
 
@@ -30,21 +32,53 @@ from .http_client import get_default_headers
 from .logging_config import logger
 
 DEFAULT_OIDC_AUDIENCE = "sbomify.com"
+SBOMIFY_PRODUCTION_API = "https://app.sbomify.com"
 OIDC_REQUEST_TIMEOUT = 30
 EXCHANGE_TIMEOUT = 30
 EXCHANGE_RETRY_DELAY_SECONDS = 2
+
+# Redact Bearer tokens and JWT-shaped substrings from upstream error bodies
+# before we embed them in exception messages. Upstreams occasionally echo
+# request payloads or include credentials in debug responses; CI log lines
+# outlive the 15-minute token TTL.
+_BEARER_RE = re.compile(r"(?i)bearer\s+[A-Za-z0-9._\-+/=]+")
+_JWT_RE = re.compile(r"\beyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\b")
+
+
+def _scrub_secrets(text: str) -> str:
+    """Replace anything that looks like a Bearer token or JWT with [REDACTED]."""
+    text = _BEARER_RE.sub("Bearer [REDACTED]", text)
+    text = _JWT_RE.sub("[REDACTED-JWT]", text)
+    return text
 
 
 def is_github_oidc_available() -> bool:
     """True iff the runner exposes a GitHub Actions OIDC token request endpoint.
 
-    Requires `GITHUB_ACTIONS=true` plus both `ACTIONS_ID_TOKEN_REQUEST_URL`
+    Requires `GITHUB_ACTIONS=true` (any truthy form: 'true'/'1'/'yes'/'on',
+    case- and whitespace-insensitive) plus both `ACTIONS_ID_TOKEN_REQUEST_URL`
     and `ACTIONS_ID_TOKEN_REQUEST_TOKEN`. The latter two are only present
     when the workflow declares `permissions: id-token: write`.
     """
-    if os.environ.get("GITHUB_ACTIONS", "").lower() not in ("true", "1"):
+    if os.environ.get("GITHUB_ACTIONS", "").strip().lower() not in ("true", "1", "yes", "on"):
         return False
     return bool(os.environ.get("ACTIONS_ID_TOKEN_REQUEST_URL") and os.environ.get("ACTIONS_ID_TOKEN_REQUEST_TOKEN"))
+
+
+def default_audience_for(api_base_url: str | None) -> str:
+    """Pick a sensible OIDC audience default for the given sbomify deployment.
+
+    - Production (https://app.sbomify.com) → 'sbomify.com' (legacy convention)
+    - Any other deployment → the hostname of api_base_url (matches what
+      operators conventionally set OIDC_GITHUB_AUDIENCE to on stage/self-hosted)
+    - Missing/unparseable → 'sbomify.com' (final fallback)
+    """
+    if not api_base_url:
+        return DEFAULT_OIDC_AUDIENCE
+    if api_base_url.rstrip("/") == SBOMIFY_PRODUCTION_API:
+        return DEFAULT_OIDC_AUDIENCE
+    hostname = urlparse(api_base_url).hostname
+    return hostname or DEFAULT_OIDC_AUDIENCE
 
 
 def request_github_oidc_token(audience: str) -> str:
@@ -68,11 +102,13 @@ def request_github_oidc_token(audience: str) -> str:
             "Ensure the workflow grants `permissions: id-token: write`."
         )
 
+    headers = get_default_headers(token=bearer)
+    headers["Accept"] = "application/json"
     try:
         response = requests.get(
             url,
             params={"audience": audience},
-            headers={"Authorization": f"Bearer {bearer}", "Accept": "application/json"},
+            headers=headers,
             timeout=OIDC_REQUEST_TIMEOUT,
         )
     except requests.RequestException as exc:
@@ -80,7 +116,7 @@ def request_github_oidc_token(audience: str) -> str:
 
     if not response.ok:
         raise OIDCExchangeError(
-            f"GitHub OIDC token endpoint returned HTTP {response.status_code}: {response.text[:200]}"
+            f"GitHub OIDC token endpoint returned HTTP {response.status_code}: {_scrub_secrets(response.text[:200])}"
         )
 
     try:
@@ -119,10 +155,10 @@ def exchange_for_sbomify_token(
     """
     url = f"{api_base_url.rstrip('/')}/api/v1/auth/oidc/github/exchange"
     headers = get_default_headers(token=oidc_jwt, content_type="application/json")
-    body = {"component_id": component_id}
+    request_body = {"component_id": component_id}
 
     try:
-        response = requests.post(url, headers=headers, json=body, timeout=EXCHANGE_TIMEOUT)
+        response = requests.post(url, headers=headers, json=request_body, timeout=EXCHANGE_TIMEOUT)
     except requests.RequestException as exc:
         raise OIDCExchangeError(f"Failed to reach sbomify OIDC exchange endpoint: {exc}") from exc
 
@@ -132,7 +168,7 @@ def exchange_for_sbomify_token(
         logger.warning("sbomify OIDC exchange returned 503; retrying once")
         time.sleep(EXCHANGE_RETRY_DELAY_SECONDS)
         try:
-            response = requests.post(url, headers=headers, json=body, timeout=EXCHANGE_TIMEOUT)
+            response = requests.post(url, headers=headers, json=request_body, timeout=EXCHANGE_TIMEOUT)
         except requests.RequestException as exc:
             raise OIDCExchangeError(f"Failed to reach sbomify OIDC exchange endpoint on retry: {exc}") from exc
 
@@ -142,19 +178,26 @@ def exchange_for_sbomify_token(
         except ValueError as exc:
             raise OIDCExchangeError("sbomify OIDC exchange returned non-JSON response") from exc
         access_token = payload.get("access_token")
-        expires_in = int(payload.get("expires_in", 0) or 0)
-        if not access_token:
+        if not isinstance(access_token, str) or not access_token:
             raise OIDCExchangeError("sbomify OIDC exchange response did not contain access_token")
+        # Be tolerant of non-int expires_in (string, float, missing) — the
+        # access_token itself is what matters; TTL is only used for logging.
+        try:
+            expires_in = int(payload.get("expires_in") or 0)
+        except (TypeError, ValueError):
+            expires_in = 0
         return access_token, expires_in
 
-    # Best-effort detail extraction from the error body
+    # Best-effort detail extraction from the error body. Scrub secrets in
+    # case the backend ever echoes the JWT or another credential.
     detail = ""
     try:
-        body = response.json()
-        if isinstance(body, dict):
-            detail = body.get("detail") or body.get("error") or ""
+        error_body = response.json()
+        if isinstance(error_body, dict):
+            detail = error_body.get("detail") or error_body.get("error") or ""
     except ValueError:
         detail = response.text[:200]
+    detail = _scrub_secrets(str(detail)) if detail else ""
 
     if response.status_code == 403:
         raise OIDCBindingMissingError(
@@ -191,11 +234,12 @@ def obtain_sbomify_token_via_oidc(
 ) -> str:
     """Convenience: request a GitHub OIDC JWT and exchange it for a sbomify token.
 
-    Logs progress (without leaking the token). The audience defaults to
-    `sbomify.com`, which matches the production backend's
-    `OIDC_GITHUB_AUDIENCE`. Override for self-hosted instances.
+    Logs progress (without leaking the token). When ``audience`` is unset,
+    the default is derived from ``api_base_url`` so stage/self-hosted
+    deployments work without the user having to set OIDC_AUDIENCE. The
+    production deployment keeps the legacy `sbomify.com` value.
     """
-    requested_audience = audience or DEFAULT_OIDC_AUDIENCE
+    requested_audience = audience or default_audience_for(api_base_url)
     logger.info(f"Authenticating to sbomify via GitHub OIDC (component={component_id}, audience={requested_audience})")
     oidc_jwt = request_github_oidc_token(requested_audience)
     access_token, expires_in = exchange_for_sbomify_token(oidc_jwt, component_id, api_base_url)

--- a/sbomify_action/oidc.py
+++ b/sbomify_action/oidc.py
@@ -1,0 +1,196 @@
+"""OIDC trusted-publishing support.
+
+Lets the action exchange a CI-provided OIDC JWT (currently GitHub Actions only)
+for a short-lived sbomify access token, so users can publish SBOMs without
+storing a long-lived sbomify API token as a CI secret.
+
+Flow (GitHub Actions):
+  1. Workflow grants `permissions: id-token: write`. The runner exposes
+     `ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN`.
+  2. `request_github_oidc_token(audience)` calls that URL to mint a JWT with
+     the requested `aud` claim.
+  3. `exchange_for_sbomify_token(jwt, component_id, api_base_url)` POSTs the
+     JWT to `/api/v1/auth/oidc/github/exchange` and gets back a short-lived
+     sbomify access token (default TTL: 15 minutes).
+  4. The caller uses that token like any other sbomify API token.
+
+The sbomify backend matches the OIDC token against an `OIDCBinding` configured
+in the sbomify UI, which ties a component to a specific GitHub repository
+(by immutable owner_id/repository_id). The binding must exist before trusted
+publishing will work — otherwise the exchange returns 403.
+"""
+
+import os
+from typing import Optional
+
+import requests
+
+from .exceptions import OIDCBindingMissingError, OIDCExchangeError
+from .http_client import get_default_headers
+from .logging_config import logger
+
+DEFAULT_OIDC_AUDIENCE = "sbomify.com"
+OIDC_REQUEST_TIMEOUT = 30
+EXCHANGE_TIMEOUT = 30
+
+
+def is_github_oidc_available() -> bool:
+    """True iff the runner exposes a GitHub Actions OIDC token request endpoint.
+
+    Requires `GITHUB_ACTIONS=true` plus both `ACTIONS_ID_TOKEN_REQUEST_URL`
+    and `ACTIONS_ID_TOKEN_REQUEST_TOKEN`. The latter two are only present
+    when the workflow declares `permissions: id-token: write`.
+    """
+    if os.environ.get("GITHUB_ACTIONS", "").lower() not in ("true", "1"):
+        return False
+    return bool(os.environ.get("ACTIONS_ID_TOKEN_REQUEST_URL") and os.environ.get("ACTIONS_ID_TOKEN_REQUEST_TOKEN"))
+
+
+def request_github_oidc_token(audience: str) -> str:
+    """Fetch a GitHub Actions OIDC JWT for the given audience.
+
+    Calls `${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=<audience>` with
+    `Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}` and returns
+    the JWT from the response body's `value` field.
+
+    Raises:
+        OIDCExchangeError: if the runner endpoint is unreachable or returns
+            an unexpected payload. (We surface this as an exchange error
+            because to the user it's part of the same "could not authenticate
+            via OIDC" failure.)
+    """
+    url = os.environ.get("ACTIONS_ID_TOKEN_REQUEST_URL")
+    bearer = os.environ.get("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+    if not url or not bearer:
+        raise OIDCExchangeError(
+            "GitHub Actions OIDC environment is not available. "
+            "Ensure the workflow grants `permissions: id-token: write`."
+        )
+
+    try:
+        response = requests.get(
+            url,
+            params={"audience": audience},
+            headers={"Authorization": f"Bearer {bearer}", "Accept": "application/json"},
+            timeout=OIDC_REQUEST_TIMEOUT,
+        )
+    except requests.RequestException as exc:
+        raise OIDCExchangeError(f"Failed to reach GitHub OIDC token endpoint: {exc}") from exc
+
+    if not response.ok:
+        raise OIDCExchangeError(
+            f"GitHub OIDC token endpoint returned HTTP {response.status_code}: {response.text[:200]}"
+        )
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise OIDCExchangeError("GitHub OIDC token endpoint returned non-JSON response") from exc
+
+    token = payload.get("value")
+    if not token:
+        raise OIDCExchangeError("GitHub OIDC token endpoint response did not contain a 'value' field")
+    return str(token)
+
+
+def exchange_for_sbomify_token(
+    oidc_jwt: str,
+    component_id: str,
+    api_base_url: str,
+) -> tuple[str, int]:
+    """Exchange a GitHub OIDC JWT for a short-lived sbomify access token.
+
+    Args:
+        oidc_jwt: The GitHub Actions OIDC JWT (from `request_github_oidc_token`)
+        component_id: The sbomify component ID to scope the token to
+        api_base_url: The sbomify API base URL (e.g. `https://app.sbomify.com`)
+
+    Returns:
+        (access_token, expires_in) — the access token to use as a Bearer
+        credential, and its lifetime in seconds.
+
+    Raises:
+        OIDCBindingMissingError: 403 — no OIDC binding configured for this
+            component+repository in sbomify. The user needs to create one in
+            the sbomify UI.
+        OIDCExchangeError: any other failure (invalid JWT, rate limit,
+            backend error, etc.).
+    """
+    url = f"{api_base_url.rstrip('/')}/api/v1/auth/oidc/github/exchange"
+    headers = get_default_headers(token=oidc_jwt, content_type="application/json")
+
+    try:
+        response = requests.post(
+            url,
+            headers=headers,
+            json={"component_id": component_id},
+            timeout=EXCHANGE_TIMEOUT,
+        )
+    except requests.RequestException as exc:
+        raise OIDCExchangeError(f"Failed to reach sbomify OIDC exchange endpoint: {exc}") from exc
+
+    if response.status_code == 200:
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise OIDCExchangeError("sbomify OIDC exchange returned non-JSON response") from exc
+        access_token = payload.get("access_token")
+        expires_in = int(payload.get("expires_in", 0) or 0)
+        if not access_token:
+            raise OIDCExchangeError("sbomify OIDC exchange response did not contain access_token")
+        return access_token, expires_in
+
+    # Best-effort detail extraction from the error body
+    detail = ""
+    try:
+        body = response.json()
+        if isinstance(body, dict):
+            detail = body.get("detail") or body.get("error") or ""
+    except ValueError:
+        detail = response.text[:200]
+
+    if response.status_code == 403:
+        raise OIDCBindingMissingError(
+            f"sbomify rejected the OIDC token (403): no binding found for component "
+            f"'{component_id}' and this repository. Create an OIDC binding in the "
+            f"sbomify UI (Component → Settings → Trusted Publishing). "
+            f"{f'Detail: {detail}' if detail else ''}".strip()
+        )
+    if response.status_code == 404:
+        raise OIDCExchangeError(
+            f"sbomify component '{component_id}' was not found (404). "
+            f"Verify COMPONENT_ID is correct. {f'Detail: {detail}' if detail else ''}".strip()
+        )
+    if response.status_code == 401:
+        raise OIDCExchangeError(
+            f"sbomify rejected the GitHub OIDC token (401). The token signature, "
+            f"audience, or expiry did not validate. {f'Detail: {detail}' if detail else ''}".strip()
+        )
+    if response.status_code == 429:
+        raise OIDCExchangeError(
+            "sbomify OIDC exchange is rate-limited (429). Retry after a short delay. "
+            f"{f'Detail: {detail}' if detail else ''}".strip()
+        )
+    raise OIDCExchangeError(
+        f"sbomify OIDC exchange failed with HTTP {response.status_code}. "
+        f"{f'Detail: {detail}' if detail else ''}".strip()
+    )
+
+
+def obtain_sbomify_token_via_oidc(
+    component_id: str,
+    api_base_url: str,
+    audience: Optional[str] = None,
+) -> str:
+    """Convenience: request a GitHub OIDC JWT and exchange it for a sbomify token.
+
+    Logs progress (without leaking the token). The audience defaults to
+    `sbomify.com`, which matches the production backend's
+    `OIDC_GITHUB_AUDIENCE`. Override for self-hosted instances.
+    """
+    requested_audience = audience or DEFAULT_OIDC_AUDIENCE
+    logger.info(f"Authenticating to sbomify via GitHub OIDC (component={component_id}, audience={requested_audience})")
+    oidc_jwt = request_github_oidc_token(requested_audience)
+    access_token, expires_in = exchange_for_sbomify_token(oidc_jwt, component_id, api_base_url)
+    logger.info(f"Obtained short-lived sbomify token via OIDC (expires in {expires_in}s)")
+    return access_token

--- a/sbomify_action/oidc.py
+++ b/sbomify_action/oidc.py
@@ -21,7 +21,7 @@ publishing will work — otherwise the exchange returns 403.
 """
 
 import os
-from typing import Optional
+import time
 
 import requests
 
@@ -32,6 +32,7 @@ from .logging_config import logger
 DEFAULT_OIDC_AUDIENCE = "sbomify.com"
 OIDC_REQUEST_TIMEOUT = 30
 EXCHANGE_TIMEOUT = 30
+EXCHANGE_RETRY_DELAY_SECONDS = 2
 
 
 def is_github_oidc_available() -> bool:
@@ -118,16 +119,22 @@ def exchange_for_sbomify_token(
     """
     url = f"{api_base_url.rstrip('/')}/api/v1/auth/oidc/github/exchange"
     headers = get_default_headers(token=oidc_jwt, content_type="application/json")
+    body = {"component_id": component_id}
 
     try:
-        response = requests.post(
-            url,
-            headers=headers,
-            json={"component_id": component_id},
-            timeout=EXCHANGE_TIMEOUT,
-        )
+        response = requests.post(url, headers=headers, json=body, timeout=EXCHANGE_TIMEOUT)
     except requests.RequestException as exc:
         raise OIDCExchangeError(f"Failed to reach sbomify OIDC exchange endpoint: {exc}") from exc
+
+    # 503 typically means the backend couldn't fetch GitHub's JWKS (rare, transient).
+    # Retry once after a short delay before giving up.
+    if response.status_code == 503:
+        logger.warning("sbomify OIDC exchange returned 503; retrying once")
+        time.sleep(EXCHANGE_RETRY_DELAY_SECONDS)
+        try:
+            response = requests.post(url, headers=headers, json=body, timeout=EXCHANGE_TIMEOUT)
+        except requests.RequestException as exc:
+            raise OIDCExchangeError(f"Failed to reach sbomify OIDC exchange endpoint on retry: {exc}") from exc
 
     if response.status_code == 200:
         try:
@@ -180,7 +187,7 @@ def exchange_for_sbomify_token(
 def obtain_sbomify_token_via_oidc(
     component_id: str,
     api_base_url: str,
-    audience: Optional[str] = None,
+    audience: str | None = None,
 ) -> str:
     """Convenience: request a GitHub OIDC JWT and exchange it for a sbomify token.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,7 +19,8 @@ cli_main_module = import_module("sbomify_action.cli.main")
 class TestConfig(unittest.TestCase):
     """Test cases for the Config dataclass and related functionality."""
 
-    def test_config_validation_missing_token(self):
+    @patch("sbomify_action.oidc.is_github_oidc_available", return_value=False)
+    def test_config_validation_missing_token(self, _mock_oidc):
         """Test that Config raises ConfigurationError when token is missing and UPLOAD=true."""
         config = Config(token="", component_id="test-component", sbom_file="/path/to/sbom.json", upload=True)
 
@@ -98,7 +99,8 @@ class TestConfig(unittest.TestCase):
         # Should not raise any exception - sbomify credentials not required
         config.validate()
 
-    def test_config_validation_multi_destination_requires_sbomify_credentials(self):
+    @patch("sbomify_action.oidc.is_github_oidc_available", return_value=False)
+    def test_config_validation_multi_destination_requires_sbomify_credentials(self, _mock_oidc):
         """Test that sbomify credentials ARE required when sbomify is one of multiple destinations."""
         config = Config(
             token="",
@@ -115,7 +117,8 @@ class TestConfig(unittest.TestCase):
         self.assertIn("sbomify API token is not defined", str(cm.exception))
         self.assertIn("uploading to sbomify", str(cm.exception))
 
-    def test_config_validation_upload_requires_token(self):
+    @patch("sbomify_action.oidc.is_github_oidc_available", return_value=False)
+    def test_config_validation_upload_requires_token(self, _mock_oidc):
         """Test that TOKEN is required when uploading to sbomify."""
         config = Config(
             token="",
@@ -143,7 +146,8 @@ class TestConfig(unittest.TestCase):
         # Should not raise - augmentation can use sbomify.json without API credentials
         config.validate()
 
-    def test_config_validation_product_release_requires_token(self):
+    @patch("sbomify_action.oidc.is_github_oidc_available", return_value=False)
+    def test_config_validation_product_release_requires_token(self, _mock_oidc):
         """Test that TOKEN is required when PRODUCT_RELEASE is set even if UPLOAD=false."""
         config = Config(
             token="",
@@ -159,6 +163,33 @@ class TestConfig(unittest.TestCase):
 
         self.assertIn("sbomify API token is not defined", str(cm.exception))
         self.assertIn("PRODUCT_RELEASE is set", str(cm.exception))
+
+    @patch("sbomify_action.oidc.is_github_oidc_available", return_value=True)
+    def test_config_validation_oidc_available_no_token_required(self, _mock_oidc):
+        """When GitHub OIDC is available, validate() should NOT raise for missing TOKEN."""
+        config = Config(
+            token="",
+            component_id="test-component",
+            sbom_file="/path/to/sbom.json",
+            upload=True,
+            upload_destinations=["sbomify"],
+        )
+        # Should not raise — pipeline will perform OIDC exchange at runtime
+        config.validate()
+
+    @patch("sbomify_action.oidc.is_github_oidc_available", return_value=True)
+    def test_config_validation_oidc_available_still_requires_component_id(self, _mock_oidc):
+        """OIDC bypasses the TOKEN requirement but COMPONENT_ID is still required."""
+        config = Config(
+            token="",
+            component_id="",
+            sbom_file="/path/to/sbom.json",
+            upload=True,
+            upload_destinations=["sbomify"],
+        )
+        with self.assertRaises(ConfigurationError) as cm:
+            config.validate()
+        self.assertIn("Component ID is not defined", str(cm.exception))
 
     def test_config_validation_upload_requires_component_id(self):
         """Test that COMPONENT_ID is required when uploading to sbomify."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -191,6 +191,49 @@ class TestConfig(unittest.TestCase):
             config.validate()
         self.assertIn("Component ID is not defined", str(cm.exception))
 
+    def test_will_use_sbomify_api_includes_augment(self):
+        """AUGMENT alone (no upload, no PR) marks the run as 'may use sbomify API'."""
+        config = Config(
+            token="",
+            component_id="comp-1",
+            sbom_file="/path/to/sbom.json",
+            upload=False,
+            augment=True,
+        )
+        # validate() doesn't require credentials here (augment can fall back to
+        # sbomify.json) — but will_use_sbomify_api is True so run_pipeline knows
+        # to attempt OIDC exchange if available.
+        self.assertFalse(config.requires_sbomify_api)
+        self.assertTrue(config.will_use_sbomify_api)
+
+    def test_will_use_sbomify_api_equals_requires_when_uploading(self):
+        config = Config(
+            token="t",
+            component_id="c",
+            sbom_file="/path/to/sbom.json",
+            upload=True,
+            upload_destinations=["sbomify"],
+        )
+        self.assertTrue(config.requires_sbomify_api)
+        self.assertTrue(config.will_use_sbomify_api)
+
+    def test_will_use_sbomify_api_false_when_no_sbomify_involvement(self):
+        config = Config(
+            token="",
+            component_id="",
+            sbom_file="/path/to/sbom.json",
+            upload=False,
+            augment=False,
+        )
+        self.assertFalse(config.requires_sbomify_api)
+        self.assertFalse(config.will_use_sbomify_api)
+
+    def test_config_token_excluded_from_repr(self):
+        """field(repr=False) keeps the token out of repr(config) so accidental
+        logging or pytest diffs don't leak the short-lived OIDC-minted JWT."""
+        config = Config(token="super-secret-jwt-value", component_id="c", sbom_file="x")
+        self.assertNotIn("super-secret-jwt-value", repr(config))
+
     def test_config_validation_upload_requires_component_id(self):
         """Test that COMPONENT_ID is required when uploading to sbomify."""
         config = Config(
@@ -292,10 +335,15 @@ class TestConfig(unittest.TestCase):
         self.assertFalse(config.upload)
         self.assertTrue(config.augment)
 
+    @patch("sbomify_action.oidc.is_github_oidc_available", return_value=False)
     @patch.dict(os.environ, {"TOKEN": "", "COMPONENT_ID": "test"})
     @patch("sys.exit")
-    def test_load_config_exits_on_invalid_config(self, mock_exit):
-        """Test that load_config exits when configuration is invalid."""
+    def test_load_config_exits_on_invalid_config(self, mock_exit, _mock_oidc):
+        """Test that load_config exits when configuration is invalid.
+
+        is_github_oidc_available is patched to False so the test is
+        deterministic when run under CI workflows that grant id-token: write.
+        """
         load_config()
         mock_exit.assert_called_once_with(1)
 

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -1,0 +1,261 @@
+"""Unit tests for OIDC trusted-publishing support (sbomify_action.oidc)."""
+
+import unittest
+from unittest.mock import Mock, patch
+
+from sbomify_action.exceptions import OIDCBindingMissingError, OIDCExchangeError
+from sbomify_action.oidc import (
+    DEFAULT_OIDC_AUDIENCE,
+    exchange_for_sbomify_token,
+    is_github_oidc_available,
+    obtain_sbomify_token_via_oidc,
+    request_github_oidc_token,
+)
+
+
+def _gha_env(**overrides):
+    base = {
+        "GITHUB_ACTIONS": "true",
+        "ACTIONS_ID_TOKEN_REQUEST_URL": "https://gha-runner.example.com/token",
+        "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "runner-bearer",
+    }
+    base.update(overrides)
+    # patch.dict needs both the values to set AND the names to clear if value is None.
+    return {k: v for k, v in base.items() if v is not None}
+
+
+class TestIsGithubOidcAvailable(unittest.TestCase):
+    def test_all_env_present(self):
+        with patch.dict("os.environ", _gha_env(), clear=True):
+            self.assertTrue(is_github_oidc_available())
+
+    def test_github_actions_unset(self):
+        with patch.dict("os.environ", _gha_env(GITHUB_ACTIONS=""), clear=True):
+            self.assertFalse(is_github_oidc_available())
+
+    def test_request_url_missing(self):
+        env = _gha_env()
+        env.pop("ACTIONS_ID_TOKEN_REQUEST_URL")
+        with patch.dict("os.environ", env, clear=True):
+            self.assertFalse(is_github_oidc_available())
+
+    def test_request_token_missing(self):
+        env = _gha_env()
+        env.pop("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+        with patch.dict("os.environ", env, clear=True):
+            self.assertFalse(is_github_oidc_available())
+
+    def test_outside_github_actions(self):
+        with patch.dict("os.environ", {}, clear=True):
+            self.assertFalse(is_github_oidc_available())
+
+
+class TestRequestGithubOidcToken(unittest.TestCase):
+    @patch("sbomify_action.oidc.requests.get")
+    def test_success(self, mock_get):
+        mock_response = Mock()
+        mock_response.ok = True
+        mock_response.json.return_value = {"value": "the.jwt.here"}
+        mock_get.return_value = mock_response
+
+        with patch.dict("os.environ", _gha_env(), clear=True):
+            token = request_github_oidc_token("sbomify.com")
+
+        self.assertEqual(token, "the.jwt.here")
+        call = mock_get.call_args
+        self.assertEqual(call.args[0], "https://gha-runner.example.com/token")
+        self.assertEqual(call.kwargs["params"], {"audience": "sbomify.com"})
+        self.assertEqual(call.kwargs["headers"]["Authorization"], "Bearer runner-bearer")
+
+    def test_env_missing_raises(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with self.assertRaises(OIDCExchangeError):
+                request_github_oidc_token("sbomify.com")
+
+    @patch("sbomify_action.oidc.requests.get")
+    def test_non_2xx_raises(self, mock_get):
+        mock_response = Mock()
+        mock_response.ok = False
+        mock_response.status_code = 500
+        mock_response.text = "boom"
+        mock_get.return_value = mock_response
+
+        with patch.dict("os.environ", _gha_env(), clear=True):
+            with self.assertRaises(OIDCExchangeError):
+                request_github_oidc_token("sbomify.com")
+
+    @patch("sbomify_action.oidc.requests.get")
+    def test_missing_value_field_raises(self, mock_get):
+        mock_response = Mock()
+        mock_response.ok = True
+        mock_response.json.return_value = {"other": "field"}
+        mock_get.return_value = mock_response
+
+        with patch.dict("os.environ", _gha_env(), clear=True):
+            with self.assertRaises(OIDCExchangeError):
+                request_github_oidc_token("sbomify.com")
+
+
+class TestExchangeForSbomifyToken(unittest.TestCase):
+    @patch("sbomify_action.oidc.requests.post")
+    def test_success(self, mock_post):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "short-lived-token",
+            "expires_in": 900,
+            "component_id": "comp-1",
+            "token_type": "Bearer",
+        }
+        mock_post.return_value = mock_response
+
+        token, ttl = exchange_for_sbomify_token("oidc.jwt.here", "comp-1", "https://app.sbomify.com")
+
+        self.assertEqual(token, "short-lived-token")
+        self.assertEqual(ttl, 900)
+
+        call = mock_post.call_args
+        self.assertEqual(
+            call.args[0],
+            "https://app.sbomify.com/api/v1/auth/oidc/github/exchange",
+        )
+        self.assertEqual(call.kwargs["json"], {"component_id": "comp-1"})
+        self.assertEqual(call.kwargs["headers"]["Authorization"], "Bearer oidc.jwt.here")
+
+    @patch("sbomify_action.oidc.requests.post")
+    def test_trailing_slash_normalized(self, mock_post):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"access_token": "x", "expires_in": 900}
+        mock_post.return_value = mock_response
+
+        exchange_for_sbomify_token("jwt", "comp-1", "https://app.sbomify.com/")
+
+        self.assertEqual(
+            mock_post.call_args.args[0],
+            "https://app.sbomify.com/api/v1/auth/oidc/github/exchange",
+        )
+
+    @patch("sbomify_action.oidc.requests.post")
+    def test_403_raises_binding_missing(self, mock_post):
+        mock_response = Mock()
+        mock_response.status_code = 403
+        mock_response.json.return_value = {"detail": "no binding for repo 123/456"}
+        mock_post.return_value = mock_response
+
+        with self.assertRaises(OIDCBindingMissingError) as ctx:
+            exchange_for_sbomify_token("jwt", "comp-1", "https://app.sbomify.com")
+
+        msg = str(ctx.exception)
+        self.assertIn("comp-1", msg)
+        self.assertIn("Trusted Publishing", msg)
+
+    @patch("sbomify_action.oidc.requests.post")
+    def test_401_raises_exchange_error(self, mock_post):
+        mock_response = Mock()
+        mock_response.status_code = 401
+        mock_response.json.return_value = {"detail": "Invalid signature"}
+        mock_post.return_value = mock_response
+
+        with self.assertRaises(OIDCExchangeError) as ctx:
+            exchange_for_sbomify_token("jwt", "comp-1", "https://app.sbomify.com")
+        self.assertIn("401", str(ctx.exception))
+
+    @patch("sbomify_action.oidc.requests.post")
+    def test_404_raises_exchange_error(self, mock_post):
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.json.return_value = {"detail": "Component not found"}
+        mock_post.return_value = mock_response
+
+        with self.assertRaises(OIDCExchangeError) as ctx:
+            exchange_for_sbomify_token("jwt", "missing-comp", "https://app.sbomify.com")
+        self.assertIn("missing-comp", str(ctx.exception))
+
+    @patch("sbomify_action.oidc.requests.post")
+    def test_429_raises_exchange_error(self, mock_post):
+        mock_response = Mock()
+        mock_response.status_code = 429
+        mock_response.json.return_value = {"detail": "Rate limited"}
+        mock_post.return_value = mock_response
+
+        with self.assertRaises(OIDCExchangeError) as ctx:
+            exchange_for_sbomify_token("jwt", "comp-1", "https://app.sbomify.com")
+        self.assertIn("rate-limited", str(ctx.exception))
+
+    @patch("sbomify_action.oidc.requests.post")
+    def test_503_raises_exchange_error(self, mock_post):
+        mock_response = Mock()
+        mock_response.status_code = 503
+        mock_response.json.return_value = {"detail": "JWKS unreachable"}
+        mock_post.return_value = mock_response
+
+        with self.assertRaises(OIDCExchangeError):
+            exchange_for_sbomify_token("jwt", "comp-1", "https://app.sbomify.com")
+
+    @patch("sbomify_action.oidc.requests.post")
+    def test_response_without_access_token_raises(self, mock_post):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"expires_in": 900}
+        mock_post.return_value = mock_response
+
+        with self.assertRaises(OIDCExchangeError):
+            exchange_for_sbomify_token("jwt", "comp-1", "https://app.sbomify.com")
+
+
+class TestObtainSbomifyTokenViaOidc(unittest.TestCase):
+    @patch("sbomify_action.oidc.requests.post")
+    @patch("sbomify_action.oidc.requests.get")
+    def test_end_to_end(self, mock_get, mock_post):
+        # GH OIDC token request
+        mock_get_response = Mock()
+        mock_get_response.ok = True
+        mock_get_response.json.return_value = {"value": "github.oidc.jwt"}
+        mock_get.return_value = mock_get_response
+
+        # sbomify exchange
+        mock_post_response = Mock()
+        mock_post_response.status_code = 200
+        mock_post_response.json.return_value = {
+            "access_token": "sbomify-short-token",
+            "expires_in": 900,
+        }
+        mock_post.return_value = mock_post_response
+
+        with patch.dict("os.environ", _gha_env(), clear=True):
+            token = obtain_sbomify_token_via_oidc(
+                component_id="comp-xyz",
+                api_base_url="https://app.sbomify.com",
+            )
+
+        self.assertEqual(token, "sbomify-short-token")
+        # Default audience is sbomify.com
+        self.assertEqual(mock_get.call_args.kwargs["params"]["audience"], DEFAULT_OIDC_AUDIENCE)
+        # OIDC JWT was forwarded to the exchange endpoint
+        self.assertEqual(
+            mock_post.call_args.kwargs["headers"]["Authorization"],
+            "Bearer github.oidc.jwt",
+        )
+
+    @patch("sbomify_action.oidc.requests.post")
+    @patch("sbomify_action.oidc.requests.get")
+    def test_custom_audience(self, mock_get, mock_post):
+        mock_get.return_value = Mock(ok=True, json=Mock(return_value={"value": "jwt"}))
+        mock_post.return_value = Mock(
+            status_code=200,
+            json=Mock(return_value={"access_token": "t", "expires_in": 900}),
+        )
+
+        with patch.dict("os.environ", _gha_env(), clear=True):
+            obtain_sbomify_token_via_oidc(
+                component_id="comp-xyz",
+                api_base_url="https://self-hosted.example.com",
+                audience="self-hosted.example.com",
+            )
+
+        self.assertEqual(mock_get.call_args.kwargs["params"]["audience"], "self-hosted.example.com")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -3,6 +3,8 @@
 import unittest
 from unittest.mock import Mock, patch
 
+import requests
+
 from sbomify_action.exceptions import OIDCBindingMissingError, OIDCExchangeError
 from sbomify_action.oidc import (
     DEFAULT_OIDC_AUDIENCE,
@@ -95,6 +97,14 @@ class TestRequestGithubOidcToken(unittest.TestCase):
             with self.assertRaises(OIDCExchangeError):
                 request_github_oidc_token("sbomify.com")
 
+    @patch("sbomify_action.oidc.requests.get")
+    def test_connection_error_raises_exchange_error(self, mock_get):
+        mock_get.side_effect = requests.ConnectionError("dns failure")
+        with patch.dict("os.environ", _gha_env(), clear=True):
+            with self.assertRaises(OIDCExchangeError) as ctx:
+                request_github_oidc_token("sbomify.com")
+        self.assertIn("Failed to reach", str(ctx.exception))
+
 
 class TestExchangeForSbomifyToken(unittest.TestCase):
     @patch("sbomify_action.oidc.requests.post")
@@ -183,15 +193,49 @@ class TestExchangeForSbomifyToken(unittest.TestCase):
             exchange_for_sbomify_token("jwt", "comp-1", "https://app.sbomify.com")
         self.assertIn("rate-limited", str(ctx.exception))
 
+    @patch("sbomify_action.oidc.time.sleep")
     @patch("sbomify_action.oidc.requests.post")
-    def test_503_raises_exchange_error(self, mock_post):
-        mock_response = Mock()
-        mock_response.status_code = 503
-        mock_response.json.return_value = {"detail": "JWKS unreachable"}
-        mock_post.return_value = mock_response
+    def test_503_retries_then_raises(self, mock_post, _mock_sleep):
+        """Two consecutive 503s — give up after one retry."""
+        five_oh_three = Mock()
+        five_oh_three.status_code = 503
+        five_oh_three.json.return_value = {"detail": "JWKS unreachable"}
+        mock_post.return_value = five_oh_three
 
         with self.assertRaises(OIDCExchangeError):
             exchange_for_sbomify_token("jwt", "comp-1", "https://app.sbomify.com")
+        self.assertEqual(mock_post.call_count, 2)
+
+    @patch("sbomify_action.oidc.time.sleep")
+    @patch("sbomify_action.oidc.requests.post")
+    def test_503_then_success_recovers(self, mock_post, _mock_sleep):
+        """503 followed by 200 on retry — should succeed."""
+        five_oh_three = Mock(status_code=503, json=Mock(return_value={"detail": "JWKS unreachable"}))
+        ok = Mock(status_code=200, json=Mock(return_value={"access_token": "t", "expires_in": 900}))
+        mock_post.side_effect = [five_oh_three, ok]
+
+        token, ttl = exchange_for_sbomify_token("jwt", "comp-1", "https://app.sbomify.com")
+        self.assertEqual(token, "t")
+        self.assertEqual(ttl, 900)
+        self.assertEqual(mock_post.call_count, 2)
+
+    @patch("sbomify_action.oidc.time.sleep")
+    @patch("sbomify_action.oidc.requests.post")
+    def test_503_then_request_exception_on_retry_raises(self, mock_post, _mock_sleep):
+        """503 then a transport-level failure on retry should be reported."""
+        five_oh_three = Mock(status_code=503, json=Mock(return_value={}))
+        mock_post.side_effect = [five_oh_three, requests.ConnectionError("dns")]
+
+        with self.assertRaises(OIDCExchangeError) as ctx:
+            exchange_for_sbomify_token("jwt", "comp-1", "https://app.sbomify.com")
+        self.assertIn("retry", str(ctx.exception).lower())
+
+    @patch("sbomify_action.oidc.requests.post")
+    def test_connection_error_raises_exchange_error(self, mock_post):
+        mock_post.side_effect = requests.ConnectionError("nope")
+        with self.assertRaises(OIDCExchangeError) as ctx:
+            exchange_for_sbomify_token("jwt", "comp-1", "https://app.sbomify.com")
+        self.assertIn("Failed to reach", str(ctx.exception))
 
     @patch("sbomify_action.oidc.requests.post")
     def test_response_without_access_token_raises(self, mock_post):

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -8,6 +8,8 @@ import requests
 from sbomify_action.exceptions import OIDCBindingMissingError, OIDCExchangeError
 from sbomify_action.oidc import (
     DEFAULT_OIDC_AUDIENCE,
+    _scrub_secrets,
+    default_audience_for,
     exchange_for_sbomify_token,
     is_github_oidc_available,
     obtain_sbomify_token_via_oidc,
@@ -34,6 +36,16 @@ class TestIsGithubOidcAvailable(unittest.TestCase):
     def test_github_actions_unset(self):
         with patch.dict("os.environ", _gha_env(GITHUB_ACTIONS=""), clear=True):
             self.assertFalse(is_github_oidc_available())
+
+    def test_github_actions_with_whitespace(self):
+        """GITHUB_ACTIONS=' true ' (leading/trailing whitespace) is still truthy."""
+        with patch.dict("os.environ", _gha_env(GITHUB_ACTIONS=" true "), clear=True):
+            self.assertTrue(is_github_oidc_available())
+
+    def test_github_actions_yes(self):
+        """GITHUB_ACTIONS='yes' should be accepted (some self-hosted runners use this)."""
+        with patch.dict("os.environ", _gha_env(GITHUB_ACTIONS="yes"), clear=True):
+            self.assertTrue(is_github_oidc_available())
 
     def test_request_url_missing(self):
         env = _gha_env()
@@ -299,6 +311,126 @@ class TestObtainSbomifyTokenViaOidc(unittest.TestCase):
             )
 
         self.assertEqual(mock_get.call_args.kwargs["params"]["audience"], "self-hosted.example.com")
+
+
+class TestDefaultAudienceFor(unittest.TestCase):
+    def test_production_keeps_legacy_audience(self):
+        self.assertEqual(default_audience_for("https://app.sbomify.com"), "sbomify.com")
+        self.assertEqual(default_audience_for("https://app.sbomify.com/"), "sbomify.com")
+
+    def test_stage_derives_from_hostname(self):
+        self.assertEqual(default_audience_for("https://stage.sbomify.com"), "stage.sbomify.com")
+
+    def test_self_hosted_derives_from_hostname(self):
+        self.assertEqual(default_audience_for("https://sbom.example.com"), "sbom.example.com")
+
+    def test_missing_url_falls_back_to_constant(self):
+        self.assertEqual(default_audience_for(None), DEFAULT_OIDC_AUDIENCE)
+        self.assertEqual(default_audience_for(""), DEFAULT_OIDC_AUDIENCE)
+
+
+class TestScrubSecrets(unittest.TestCase):
+    def test_bearer_redacted(self):
+        out = _scrub_secrets("got Bearer abc123.def456")
+        self.assertNotIn("abc123", out)
+        self.assertIn("[REDACTED]", out)
+
+    def test_jwt_redacted(self):
+        jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature_part"
+        out = _scrub_secrets(f"token leaked: {jwt} oops")
+        self.assertNotIn(jwt, out)
+        self.assertIn("[REDACTED-JWT]", out)
+
+    def test_no_secret_unchanged(self):
+        self.assertEqual(_scrub_secrets("plain error message"), "plain error message")
+
+
+class TestExpiresInTolerance(unittest.TestCase):
+    @patch("sbomify_action.oidc.requests.post")
+    def test_non_numeric_expires_in_does_not_crash(self, mock_post):
+        """If backend returns expires_in='15m' or similar, we still extract the token."""
+        mock_post.return_value = Mock(
+            status_code=200,
+            json=Mock(return_value={"access_token": "t", "expires_in": "15m"}),
+        )
+        token, ttl = exchange_for_sbomify_token("jwt", "comp-1", "https://app.sbomify.com")
+        self.assertEqual(token, "t")
+        self.assertEqual(ttl, 0)  # Falls back to 0 rather than raising ValueError.
+
+    @patch("sbomify_action.oidc.requests.post")
+    def test_missing_expires_in(self, mock_post):
+        mock_post.return_value = Mock(
+            status_code=200,
+            json=Mock(return_value={"access_token": "t"}),
+        )
+        token, ttl = exchange_for_sbomify_token("jwt", "comp-1", "https://app.sbomify.com")
+        self.assertEqual(token, "t")
+        self.assertEqual(ttl, 0)
+
+    @patch("sbomify_action.oidc.requests.post")
+    def test_non_string_access_token_rejected(self, mock_post):
+        """A numeric access_token should be rejected rather than silently coerced."""
+        mock_post.return_value = Mock(
+            status_code=200,
+            json=Mock(return_value={"access_token": 12345, "expires_in": 900}),
+        )
+        with self.assertRaises(OIDCExchangeError):
+            exchange_for_sbomify_token("jwt", "comp-1", "https://app.sbomify.com")
+
+
+class TestErrorBodyRedaction(unittest.TestCase):
+    @patch("sbomify_action.oidc.requests.post")
+    def test_jwt_in_error_detail_is_redacted(self, mock_post):
+        leaky_jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.sig"
+        mock_post.return_value = Mock(
+            status_code=403,
+            json=Mock(return_value={"detail": f"rejected token {leaky_jwt}"}),
+        )
+        with self.assertRaises(OIDCBindingMissingError) as ctx:
+            exchange_for_sbomify_token("jwt", "comp-1", "https://app.sbomify.com")
+        self.assertNotIn(leaky_jwt, str(ctx.exception))
+        self.assertIn("[REDACTED-JWT]", str(ctx.exception))
+
+    @patch("sbomify_action.oidc.requests.get")
+    def test_bearer_in_gh_response_text_is_redacted(self, mock_get):
+        mock_get.return_value = Mock(
+            ok=False,
+            status_code=500,
+            text="Internal error: header was 'Bearer runner.secret.value'",
+        )
+        with patch.dict("os.environ", _gha_env(), clear=True):
+            with self.assertRaises(OIDCExchangeError) as ctx:
+                request_github_oidc_token("sbomify.com")
+        self.assertNotIn("runner.secret.value", str(ctx.exception))
+        self.assertIn("[REDACTED]", str(ctx.exception))
+
+
+class TestGithubOidcHeaders(unittest.TestCase):
+    @patch("sbomify_action.oidc.requests.get")
+    def test_uses_project_user_agent(self, mock_get):
+        mock_get.return_value = Mock(ok=True, json=Mock(return_value={"value": "jwt"}))
+        with patch.dict("os.environ", _gha_env(), clear=True):
+            request_github_oidc_token("sbomify.com")
+        headers = mock_get.call_args.kwargs["headers"]
+        self.assertIn("User-Agent", headers)
+        self.assertIn("sbomify-action", headers["User-Agent"])
+        self.assertEqual(headers["Authorization"], "Bearer runner-bearer")
+        self.assertEqual(headers["Accept"], "application/json")
+
+
+class TestObtainAudienceDefault(unittest.TestCase):
+    @patch("sbomify_action.oidc.requests.post")
+    @patch("sbomify_action.oidc.requests.get")
+    def test_audience_derived_from_api_base_url_when_unset(self, mock_get, mock_post):
+        mock_get.return_value = Mock(ok=True, json=Mock(return_value={"value": "jwt"}))
+        mock_post.return_value = Mock(status_code=200, json=Mock(return_value={"access_token": "t", "expires_in": 900}))
+        with patch.dict("os.environ", _gha_env(), clear=True):
+            obtain_sbomify_token_via_oidc(
+                component_id="comp-x",
+                api_base_url="https://stage.sbomify.com",
+                audience=None,
+            )
+        self.assertEqual(mock_get.call_args.kwargs["params"]["audience"], "stage.sbomify.com")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds client-side support for the OIDC token exchange endpoint recently added in sbomify (`POST /api/v1/auth/oidc/github/exchange`). In GitHub Actions with `permissions: id-token: write` and no `TOKEN` set, the action transparently mints a GitHub OIDC JWT, exchanges it for a short-lived (15 min) sbomify access token, and uses that token for upload, augmentation, and post-upload processors.
- Activation is **auto-detect** — no new flag, no behaviour change for users who set `TOKEN`. To opt in, drop the `TOKEN` secret and grant `id-token: write` in the workflow. The component needs an OIDC binding configured in the sbomify UI (Component → Settings → Trusted Publishing).
- Migrates this repo's own four SBOM-publishing jobs (source + container × staging + production) off `SBOMIFY_TOKEN` / `SBOMIFY_STAGE_TOKEN` to OIDC.

## Changes

- `sbomify_action/oidc.py` (new) — `is_github_oidc_available()`, `request_github_oidc_token()`, `exchange_for_sbomify_token()`, `obtain_sbomify_token_via_oidc()`. Maps 401/403/404/429/503 to actionable error messages.
- `sbomify_action/exceptions.py` — adds `OIDCError`, `OIDCBindingMissingError`, `OIDCExchangeError`.
- `sbomify_action/cli/main.py` — adds `oidc_audience` to `Config`, relaxes `Config.validate()` to allow missing `TOKEN` when OIDC is available, adds `--oidc-audience` / `OIDC_AUDIENCE`, and inserts an exchange step at the top of `run_pipeline()`.
- `action.yml` — adds `oidc-audience` input.
- `README.md` — new "Trusted Publishing — no token" example, `OIDC_AUDIENCE` row, updated `TOKEN` footnote.
- `tests/test_oidc.py` (new) — 17 tests, new module hits 86% coverage.
- `tests/test_config.py` — adds OIDC-positive case, defensively mocks `is_github_oidc_available()=False` in existing missing-token tests so they remain deterministic when run in a GHA workflow that grants `id-token: write`.
- `.github/workflows/sbomify.yaml` — removes `TOKEN: ${{ secrets.SBOMIFY_* }}` from all four SBOM jobs (`id-token: write` was already present).

## Test plan

- [x] `uv run ruff check sbomify_action tests`
- [x] `uv run ruff format --check sbomify_action tests`
- [x] `uv run mypy sbomify_action`
- [x] `uv run pytest` — **2216 passed, 4 skipped**
- [ ] **End-to-end:** first push to `master` after merge will exercise the staging SBOM jobs against `stage.sbomify.com`. Production jobs run on tag push.
- [ ] If staging uses a different OIDC audience than `sbomify.com`, set `OIDC_AUDIENCE` on the staging matrix entries. (Default `sbomify.com` is what production expects.)
- [ ] Once the OIDC flow is verified live, the `SBOMIFY_TOKEN` and `SBOMIFY_STAGE_TOKEN` repo secrets can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)