### PR TITLE
Handle DUPLICATE_NAME on component create (get-or-create)

### DIFF
--- a/sbomify_action/_yocto/api.py
+++ b/sbomify_action/_yocto/api.py
@@ -1,16 +1,72 @@
 """Component CRUD API calls for Yocto pipeline."""
 
+from typing import Iterator
+
 import requests
 
 from sbomify_action.exceptions import APIError, PlanLimitError
 from sbomify_action.http_client import get_default_headers
 from sbomify_action.logging_config import logger
 
+_PAGE_SIZE = 100
+_MAX_PAGES = 500  # Safety limit against runaway pagination
+
+
+def _iter_components(api_base_url: str, token: str, error_context: str) -> Iterator[dict]:
+    """Yield every component item from /api/v1/components, paginating as needed.
+
+    Raises APIError for any HTTP/transport/JSON-shape failure so callers see
+    the real cause instead of a misleading downstream error. Caller can
+    short-circuit by breaking out of the iteration.
+
+    Args:
+        api_base_url: Base URL for the sbomify API
+        token: API authentication token
+        error_context: Phrase used in error messages (e.g. "list components",
+            "look up component 'foo'")
+
+    Yields:
+        Each item dict from the paginated response.
+
+    Raises:
+        APIError: On network/timeout/HTTP error, or malformed/truncated response.
+    """
+    url = api_base_url + "/api/v1/components"
+    headers = get_default_headers(token)
+    page = 1
+
+    while page <= _MAX_PAGES:
+        try:
+            response = requests.get(url, headers=headers, params={"page": page, "page_size": _PAGE_SIZE}, timeout=60)
+        except requests.exceptions.ConnectionError:
+            raise APIError("Failed to connect to sbomify API")
+        except requests.exceptions.Timeout:
+            raise APIError("API request timed out")
+
+        if not response.ok:
+            raise APIError(f"Failed to {error_context}. [{response.status_code}]")
+
+        try:
+            data = response.json()
+        except (ValueError, requests.exceptions.JSONDecodeError):
+            raise APIError(f"Failed to {error_context}: invalid JSON response from API")
+
+        if not isinstance(data, dict):
+            raise APIError(f"Failed to {error_context}: unexpected response type ({type(data).__name__})")
+
+        yield from data.get("items", [])
+
+        if not data.get("next"):
+            return
+        page += 1
+
+    raise APIError(
+        f"Failed to {error_context}: pagination safety limit reached ({_MAX_PAGES} pages × {_PAGE_SIZE} items)"
+    )
+
 
 def list_components(api_base_url: str, token: str) -> dict[str, str]:
     """Fetch all components and return a name-to-id mapping.
-
-    Paginates through all results to build a complete cache.
 
     Args:
         api_base_url: Base URL for the sbomify API
@@ -22,48 +78,12 @@ def list_components(api_base_url: str, token: str) -> dict[str, str]:
     Raises:
         APIError: If API call fails
     """
-    url = api_base_url + "/api/v1/components"
-    headers = get_default_headers(token)
     components: dict[str, str] = {}
-    page = 1
-    max_pages = 500  # Safety limit against infinite pagination
-
-    while page <= max_pages:
-        try:
-            response = requests.get(url, headers=headers, params={"page": page, "page_size": 100}, timeout=60)
-        except requests.exceptions.ConnectionError:
-            raise APIError("Failed to connect to sbomify API")
-        except requests.exceptions.Timeout:
-            raise APIError("API request timed out")
-
-        if not response.ok:
-            raise APIError(f"Failed to list components. [{response.status_code}]")
-
-        try:
-            data = response.json()
-        except (ValueError, requests.exceptions.JSONDecodeError):
-            raise APIError("Failed to list components: invalid JSON response from API")
-
-        if not isinstance(data, dict):
-            raise APIError(f"Failed to list components: unexpected response type ({type(data).__name__})")
-
-        for item in data.get("items", []):
-            name = item.get("name")
-            comp_id = item.get("id")
-            if name and comp_id:
-                components[name] = str(comp_id)
-
-        # Paginate based on 'next' link, not empty items
-        if not data.get("next"):
-            break
-        page += 1
-
-    if page > max_pages and data.get("next"):
-        logger.warning(
-            f"Pagination safety limit reached ({max_pages} pages). "
-            f"Component cache may be incomplete ({len(components)} components fetched)."
-        )
-
+    for item in _iter_components(api_base_url, token, "list components"):
+        name = item.get("name")
+        comp_id = item.get("id")
+        if name and comp_id:
+            components[name] = str(comp_id)
     logger.info(f"Cached {len(components)} existing components")
     return components
 
@@ -83,46 +103,17 @@ def get_component_id_by_name(api_base_url: str, token: str, name: str) -> str | 
         name: Component name to look up
 
     Returns:
-        Component ID if found, None otherwise
+        Component ID if found, None if walked all pages without a match.
 
     Raises:
-        APIError: If API call fails (network/timeout/non-404 HTTP error)
+        APIError: On network/HTTP/JSON failure (callers see the real cause
+            rather than a misleading "could not be found" error).
     """
-    url = api_base_url + "/api/v1/components"
-    headers = get_default_headers(token)
-    page = 1
-    max_pages = 500  # Safety limit against runaway pagination
-
-    while page <= max_pages:
-        try:
-            response = requests.get(url, headers=headers, params={"page": page, "page_size": 100}, timeout=60)
-        except requests.exceptions.ConnectionError:
-            raise APIError("Failed to connect to sbomify API")
-        except requests.exceptions.Timeout:
-            raise APIError("API request timed out")
-
-        if response.status_code == 404:
-            return None
-        if not response.ok:
-            raise APIError(f"Failed to look up component '{name}'. [{response.status_code}]")
-
-        try:
-            data = response.json()
-        except (ValueError, requests.exceptions.JSONDecodeError):
-            return None
-        if not isinstance(data, dict):
-            return None
-
-        for item in data.get("items", []):
-            if item.get("name") == name:
-                comp_id = item.get("id")
-                if comp_id is not None:
-                    return str(comp_id)
-
-        if not data.get("next"):
-            return None
-        page += 1
-
+    for item in _iter_components(api_base_url, token, f"look up component '{name}'"):
+        if item.get("name") == name:
+            comp_id = item.get("id")
+            if comp_id is not None:
+                return str(comp_id)
     return None
 
 
@@ -160,26 +151,29 @@ def create_component(api_base_url: str, token: str, name: str) -> tuple[str, boo
 
     if not response.ok:
         err_msg = f"Failed to create component '{name}'. [{response.status_code}]"
-        detail = ""
-        error_code = ""
+        body: dict = {}
         try:
-            body = response.json()
-            if isinstance(body, dict):
-                detail = body.get("detail", "") or ""
-                error_code = body.get("error_code", "") or ""
-            if detail:
-                err_msg += f" - {detail}"
+            parsed = response.json()
+            if isinstance(parsed, dict):
+                body = parsed
         except ValueError:
             pass
+        detail = body.get("detail") or ""
+        error_code = body.get("error_code") or ""
+        if detail:
+            err_msg += f" - {detail}"
 
-        if response.status_code == 400 and error_code == "DUPLICATE_NAME":
+        # Recover from DUPLICATE_NAME (stale cache or concurrent create).
+        # Accept both 400 and 409: 409 is REST-canonical for conflicts and
+        # matches the DUPLICATE_ARTIFACT shape in _upload/destinations/sbomify.py.
+        if response.status_code in (400, 409) and error_code == "DUPLICATE_NAME":
             logger.info(f"Component '{name}' already exists, retrieving existing component ID")
             existing_id = get_component_id_by_name(api_base_url, token, name)
-            if existing_id:
+            if existing_id is not None:
                 return existing_id, False
             raise APIError(f"Component '{name}' reported as duplicate by API but could not be found via lookup")
 
-        if response.status_code == 403 and "maximum" in detail.lower():
+        if response.status_code == 403 and isinstance(detail, str) and "maximum" in detail.lower():
             raise PlanLimitError(err_msg)
 
         raise APIError(err_msg)

--- a/sbomify_action/_yocto/api.py
+++ b/sbomify_action/_yocto/api.py
@@ -68,8 +68,72 @@ def list_components(api_base_url: str, token: str) -> dict[str, str]:
     return components
 
 
-def create_component(api_base_url: str, token: str, name: str) -> str:
+def get_component_id_by_name(api_base_url: str, token: str, name: str) -> str | None:
+    """Look up a component ID by exact name match.
+
+    Used to recover from DUPLICATE_NAME errors when the local cache is stale
+    (e.g. another concurrent run created the component, or it predates our
+    initial snapshot). The /api/v1/components endpoint doesn't support
+    server-side name filtering, so this paginates until the name is found
+    (short-circuits on first match).
+
+    Args:
+        api_base_url: Base URL for the sbomify API
+        token: API authentication token
+        name: Component name to look up
+
+    Returns:
+        Component ID if found, None otherwise
+
+    Raises:
+        APIError: If API call fails (network/timeout/non-404 HTTP error)
+    """
+    url = api_base_url + "/api/v1/components"
+    headers = get_default_headers(token)
+    page = 1
+    max_pages = 500  # Safety limit against runaway pagination
+
+    while page <= max_pages:
+        try:
+            response = requests.get(url, headers=headers, params={"page": page, "page_size": 100}, timeout=60)
+        except requests.exceptions.ConnectionError:
+            raise APIError("Failed to connect to sbomify API")
+        except requests.exceptions.Timeout:
+            raise APIError("API request timed out")
+
+        if response.status_code == 404:
+            return None
+        if not response.ok:
+            raise APIError(f"Failed to look up component '{name}'. [{response.status_code}]")
+
+        try:
+            data = response.json()
+        except (ValueError, requests.exceptions.JSONDecodeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+
+        for item in data.get("items", []):
+            if item.get("name") == name:
+                comp_id = item.get("id")
+                if comp_id is not None:
+                    return str(comp_id)
+
+        if not data.get("next"):
+            return None
+        page += 1
+
+    return None
+
+
+def create_component(api_base_url: str, token: str, name: str) -> tuple[str, bool]:
     """Create a new component.
+
+    If a component with the same name already exists (DUPLICATE_NAME error
+    from sbomify API), the existing component's ID is returned with
+    ``was_created=False`` instead of failing — get-or-create semantics.
+    This guards against stale caches and concurrent runs racing on the
+    same name.
 
     Args:
         api_base_url: Base URL for the sbomify API
@@ -77,7 +141,8 @@ def create_component(api_base_url: str, token: str, name: str) -> str:
         name: Component name
 
     Returns:
-        Component ID
+        Tuple of (component_id, was_created). ``was_created`` is False when
+        an existing component was recovered via DUPLICATE_NAME.
 
     Raises:
         APIError: If API call fails
@@ -96,12 +161,23 @@ def create_component(api_base_url: str, token: str, name: str) -> str:
     if not response.ok:
         err_msg = f"Failed to create component '{name}'. [{response.status_code}]"
         detail = ""
+        error_code = ""
         try:
-            detail = response.json().get("detail", "")
+            body = response.json()
+            if isinstance(body, dict):
+                detail = body.get("detail", "") or ""
+                error_code = body.get("error_code", "") or ""
             if detail:
                 err_msg += f" - {detail}"
         except ValueError:
             pass
+
+        if response.status_code == 400 and error_code == "DUPLICATE_NAME":
+            logger.info(f"Component '{name}' already exists, retrieving existing component ID")
+            existing_id = get_component_id_by_name(api_base_url, token, name)
+            if existing_id:
+                return existing_id, False
+            raise APIError(f"Component '{name}' reported as duplicate by API but could not be found via lookup")
 
         if response.status_code == 403 and "maximum" in detail.lower():
             raise PlanLimitError(err_msg)
@@ -115,7 +191,7 @@ def create_component(api_base_url: str, token: str, name: str) -> str:
     comp_id = data.get("id")
     if comp_id is None:
         raise APIError(f"Invalid response when creating component '{name}': no id returned")
-    return str(comp_id)
+    return str(comp_id), True
 
 
 def patch_component_visibility(api_base_url: str, token: str, component_id: str, visibility: str) -> None:
@@ -165,7 +241,10 @@ def get_or_create_component(api_base_url: str, token: str, name: str, cache: dic
     if name in cache:
         return cache[name], False
 
-    comp_id = create_component(api_base_url, token, name)
+    comp_id, was_created = create_component(api_base_url, token, name)
     cache[name] = comp_id
-    logger.info(f"Created component '{name}' -> {comp_id}")
-    return comp_id, True
+    if was_created:
+        logger.info(f"Created component '{name}' -> {comp_id}")
+    else:
+        logger.info(f"Recovered existing component '{name}' -> {comp_id}")
+    return comp_id, was_created

--- a/tests/test_yocto_api.py
+++ b/tests/test_yocto_api.py
@@ -6,6 +6,7 @@ import pytest
 
 from sbomify_action._yocto.api import (
     create_component,
+    get_component_id_by_name,
     get_or_create_component,
     list_components,
     patch_component_visibility,
@@ -111,22 +112,72 @@ class TestCreateComponent:
         mock_resp.json.return_value = {"id": "new-comp-1", "name": "busybox"}
         mock_post.return_value = mock_resp
 
-        result = create_component(API_BASE, TOKEN, "busybox")
-        assert result == "new-comp-1"
+        comp_id, was_created = create_component(API_BASE, TOKEN, "busybox")
+        assert comp_id == "new-comp-1"
+        assert was_created is True
 
         # Verify correct payload
         call_kwargs = mock_post.call_args
         assert call_kwargs.kwargs["json"] == {"name": "busybox", "component_type": "sbom"}
 
     @patch("sbomify_action._yocto.api.requests.post")
-    def test_failure(self, mock_post):
+    def test_generic_400_raises(self, mock_post):
+        # 400 without DUPLICATE_NAME error_code still raises
         mock_resp = MagicMock()
         mock_resp.ok = False
         mock_resp.status_code = 400
-        mock_resp.json.return_value = {"detail": "Duplicate name"}
+        mock_resp.json.return_value = {"detail": "Validation error", "error_code": "INVALID_DATA"}
         mock_post.return_value = mock_resp
 
         with pytest.raises(APIError, match="Failed to create component"):
+            create_component(API_BASE, TOKEN, "busybox")
+
+    @patch("sbomify_action._yocto.api.requests.get")
+    @patch("sbomify_action._yocto.api.requests.post")
+    def test_duplicate_name_recovers_existing_id(self, mock_post, mock_get):
+        # POST returns 400 with DUPLICATE_NAME error_code
+        post_resp = MagicMock()
+        post_resp.ok = False
+        post_resp.status_code = 400
+        post_resp.json.return_value = {
+            "detail": "A component with this name already exists in this team",
+            "error_code": "DUPLICATE_NAME",
+        }
+        mock_post.return_value = post_resp
+
+        # Lookup finds the existing component
+        get_resp = MagicMock()
+        get_resp.ok = True
+        get_resp.status_code = 200
+        get_resp.json.return_value = {
+            "items": [{"id": "existing-id", "name": "busybox"}],
+            "next": None,
+        }
+        mock_get.return_value = get_resp
+
+        comp_id, was_created = create_component(API_BASE, TOKEN, "busybox")
+        assert comp_id == "existing-id"
+        assert was_created is False  # signals recovered, not newly created
+
+    @patch("sbomify_action._yocto.api.requests.get")
+    @patch("sbomify_action._yocto.api.requests.post")
+    def test_duplicate_name_but_lookup_misses_raises(self, mock_post, mock_get):
+        post_resp = MagicMock()
+        post_resp.ok = False
+        post_resp.status_code = 400
+        post_resp.json.return_value = {
+            "detail": "duplicate",
+            "error_code": "DUPLICATE_NAME",
+        }
+        mock_post.return_value = post_resp
+
+        get_resp = MagicMock()
+        get_resp.ok = True
+        get_resp.status_code = 200
+        get_resp.json.return_value = {"items": [], "next": None}
+        mock_get.return_value = get_resp
+
+        with pytest.raises(APIError, match="reported as duplicate"):
             create_component(API_BASE, TOKEN, "busybox")
 
     @patch("sbomify_action._yocto.api.requests.post")
@@ -161,6 +212,69 @@ class TestCreateComponent:
 
         with pytest.raises(APIError, match="no id returned"):
             create_component(API_BASE, TOKEN, "busybox")
+
+
+class TestGetComponentIdByName:
+    @patch("sbomify_action._yocto.api.requests.get")
+    def test_finds_on_first_page(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "items": [
+                {"id": "c1", "name": "other"},
+                {"id": "c2", "name": "busybox"},
+            ],
+            "next": None,
+        }
+        mock_get.return_value = mock_resp
+
+        assert get_component_id_by_name(API_BASE, TOKEN, "busybox") == "c2"
+
+    @patch("sbomify_action._yocto.api.requests.get")
+    def test_paginates_until_found(self, mock_get):
+        page1 = MagicMock()
+        page1.ok = True
+        page1.status_code = 200
+        page1.json.return_value = {"items": [{"id": "c1", "name": "other"}], "next": "page2"}
+        page2 = MagicMock()
+        page2.ok = True
+        page2.status_code = 200
+        page2.json.return_value = {"items": [{"id": "c2", "name": "busybox"}], "next": "page3"}
+        mock_get.side_effect = [page1, page2]
+
+        assert get_component_id_by_name(API_BASE, TOKEN, "busybox") == "c2"
+        # Stops at page 2 — does not fetch page 3
+        assert mock_get.call_count == 2
+
+    @patch("sbomify_action._yocto.api.requests.get")
+    def test_not_found(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"items": [], "next": None}
+        mock_get.return_value = mock_resp
+
+        assert get_component_id_by_name(API_BASE, TOKEN, "busybox") is None
+
+    @patch("sbomify_action._yocto.api.requests.get")
+    def test_404_returns_none(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.ok = False
+        mock_resp.status_code = 404
+        mock_get.return_value = mock_resp
+
+        assert get_component_id_by_name(API_BASE, TOKEN, "busybox") is None
+
+    @patch("sbomify_action._yocto.api.requests.get")
+    def test_500_raises(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.ok = False
+        mock_resp.status_code = 500
+        mock_get.return_value = mock_resp
+
+        with pytest.raises(APIError, match="Failed to look up component"):
+            get_component_id_by_name(API_BASE, TOKEN, "busybox")
 
 
 class TestPatchComponentVisibility:
@@ -214,13 +328,25 @@ class TestGetOrCreateComponent:
 
     @patch("sbomify_action._yocto.api.create_component")
     def test_cache_miss_creates(self, mock_create):
-        mock_create.return_value = "new-id"
+        mock_create.return_value = ("new-id", True)
         cache: dict[str, str] = {}
 
         comp_id, was_created = get_or_create_component(API_BASE, TOKEN, "busybox", cache)
         assert comp_id == "new-id"
         assert was_created is True
         assert cache["busybox"] == "new-id"  # cache updated
+
+    @patch("sbomify_action._yocto.api.create_component")
+    def test_cache_miss_recovers_existing(self, mock_create):
+        # Stale cache: API reports DUPLICATE_NAME, create_component recovers
+        # the existing ID and signals was_created=False
+        mock_create.return_value = ("existing-id", False)
+        cache: dict[str, str] = {}
+
+        comp_id, was_created = get_or_create_component(API_BASE, TOKEN, "busybox", cache)
+        assert comp_id == "existing-id"
+        assert was_created is False
+        assert cache["busybox"] == "existing-id"
 
     @patch("sbomify_action._yocto.api.create_component")
     def test_create_failure_propagates(self, mock_create):

--- a/tests/test_yocto_api.py
+++ b/tests/test_yocto_api.py
@@ -121,12 +121,25 @@ class TestCreateComponent:
         assert call_kwargs.kwargs["json"] == {"name": "busybox", "component_type": "sbom"}
 
     @patch("sbomify_action._yocto.api.requests.post")
-    def test_generic_400_raises(self, mock_post):
-        # 400 without DUPLICATE_NAME error_code still raises
+    def test_400_with_invalid_data_raises(self, mock_post):
+        # 400 with error_code != DUPLICATE_NAME still raises (no recovery)
         mock_resp = MagicMock()
         mock_resp.ok = False
         mock_resp.status_code = 400
         mock_resp.json.return_value = {"detail": "Validation error", "error_code": "INVALID_DATA"}
+        mock_post.return_value = mock_resp
+
+        with pytest.raises(APIError, match="Failed to create component"):
+            create_component(API_BASE, TOKEN, "busybox")
+
+    @patch("sbomify_action._yocto.api.requests.post")
+    def test_400_without_error_code_raises(self, mock_post):
+        # Regression pin: a 400 whose body OMITS error_code (older API
+        # version, proxy stripping fields, etc.) must NOT trigger recovery.
+        mock_resp = MagicMock()
+        mock_resp.ok = False
+        mock_resp.status_code = 400
+        mock_resp.json.return_value = {"detail": "Duplicate name"}
         mock_post.return_value = mock_resp
 
         with pytest.raises(APIError, match="Failed to create component"):
@@ -158,6 +171,33 @@ class TestCreateComponent:
         comp_id, was_created = create_component(API_BASE, TOKEN, "busybox")
         assert comp_id == "existing-id"
         assert was_created is False  # signals recovered, not newly created
+
+    @patch("sbomify_action._yocto.api.requests.get")
+    @patch("sbomify_action._yocto.api.requests.post")
+    def test_409_duplicate_name_recovers_existing_id(self, mock_post, mock_get):
+        # Future-proofing: API may migrate to REST-canonical 409 Conflict
+        # (matching the DUPLICATE_ARTIFACT shape) while preserving error_code.
+        post_resp = MagicMock()
+        post_resp.ok = False
+        post_resp.status_code = 409
+        post_resp.json.return_value = {
+            "detail": "A component with this name already exists in this team",
+            "error_code": "DUPLICATE_NAME",
+        }
+        mock_post.return_value = post_resp
+
+        get_resp = MagicMock()
+        get_resp.ok = True
+        get_resp.status_code = 200
+        get_resp.json.return_value = {
+            "items": [{"id": "existing-id", "name": "busybox"}],
+            "next": None,
+        }
+        mock_get.return_value = get_resp
+
+        comp_id, was_created = create_component(API_BASE, TOKEN, "busybox")
+        assert comp_id == "existing-id"
+        assert was_created is False
 
     @patch("sbomify_action._yocto.api.requests.get")
     @patch("sbomify_action._yocto.api.requests.post")
@@ -258,13 +298,17 @@ class TestGetComponentIdByName:
         assert get_component_id_by_name(API_BASE, TOKEN, "busybox") is None
 
     @patch("sbomify_action._yocto.api.requests.get")
-    def test_404_returns_none(self, mock_get):
+    def test_404_raises(self, mock_get):
+        # 404 on a collection endpoint signals misconfiguration (wrong base URL,
+        # endpoint removed), not "no such component" — surface the real cause
+        # rather than mask it as "could not be found via lookup".
         mock_resp = MagicMock()
         mock_resp.ok = False
         mock_resp.status_code = 404
         mock_get.return_value = mock_resp
 
-        assert get_component_id_by_name(API_BASE, TOKEN, "busybox") is None
+        with pytest.raises(APIError, match="Failed to look up component"):
+            get_component_id_by_name(API_BASE, TOKEN, "busybox")
 
     @patch("sbomify_action._yocto.api.requests.get")
     def test_500_raises(self, mock_get):
@@ -274,6 +318,31 @@ class TestGetComponentIdByName:
         mock_get.return_value = mock_resp
 
         with pytest.raises(APIError, match="Failed to look up component"):
+            get_component_id_by_name(API_BASE, TOKEN, "busybox")
+
+    @patch("sbomify_action._yocto.api.requests.get")
+    def test_invalid_json_raises(self, mock_get):
+        # Matches list_components behavior — don't silently swallow malformed
+        # JSON as "not found", because that produces a misleading downstream
+        # error in create_component's recovery path.
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.status_code = 200
+        mock_resp.json.side_effect = ValueError("Expecting value")
+        mock_get.return_value = mock_resp
+
+        with pytest.raises(APIError, match="invalid JSON"):
+            get_component_id_by_name(API_BASE, TOKEN, "busybox")
+
+    @patch("sbomify_action._yocto.api.requests.get")
+    def test_non_dict_response_raises(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = ["not", "a", "dict"]
+        mock_get.return_value = mock_resp
+
+        with pytest.raises(APIError, match="unexpected response type"):
             get_component_id_by_name(API_BASE, TOKEN, "busybox")
 
 


### PR DESCRIPTION
## Summary

Align with [sbomify/sbomify#983](https://github.com/sbomify/sbomify/pull/983), which changes the sbomify API to return `error_code: DUPLICATE_NAME` (was `INVALID_DATA`) on POST `/api/v1/components` name collisions. That PR's description explicitly names this action's wizard as the client that needs the distinct code.

- `create_component()` now treats `400 + error_code=DUPLICATE_NAME` as get-or-create: it looks up the existing component by name and returns its id instead of raising. Closes the stale-cache / concurrent-create race that `get_or_create_component`'s startup snapshot couldn't cover.
- Return signature changed to `tuple[str, bool]` (`id`, `was_created`). The pipeline's `components_created` counter and `patch_component_visibility` side-effect now only fire on real creates, not recoveries.
- New `get_component_id_by_name()` helper. The `/api/v1/components` endpoint has no server-side name filter (confirmed against `sbomify/apps/core/apis.py:1571`), so the lookup paginates and short-circuits on the first match.

## Test plan

- [x] `uv run pytest` — 2203 passed, 4 skipped
- [x] `uv run ruff check sbomify_action tests` — clean
- [x] `uv run ruff format --check sbomify_action tests` — clean
- [x] New unit tests cover: DUPLICATE_NAME recovers existing id, DUPLICATE_NAME but lookup misses raises, generic 400 still raises, and the new lookup helper (single page hit, paginated short-circuit, not-found, 404, 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)