### PR TITLE
fix(wizard): component_type 422, existing sbomify.json, edge-case hardening + review fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,9 @@ repos:
           - types-PyYAML
           - types-toml
           - click
+          # The wizard subpackage subclasses Textual's App/Screen/widgets.
+          # Without Textual in the hook's isolated env, mypy treats those base
+          # classes as ``Any`` and emits spurious "Class cannot subclass value
+          # of type Any" / "Returning Any" errors. Pinned to the project floor
+          # so the hook's types match the runtime.
+          - textual>=0.85.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
           # The wizard subpackage subclasses Textual's App/Screen/widgets.
           # Without Textual in the hook's isolated env, mypy treats those base
           # classes as ``Any`` and emits spurious "Class cannot subclass value
-          # of type Any" / "Returning Any" errors. Pinned to the project floor
-          # so the hook's types match the runtime.
-          - textual>=0.85.0
+          # of type Any" / "Returning Any" errors. Pinned to the version in
+          # uv.lock so the hook's type view is reproducible and matches the
+          # runtime; bump together with the textual dep in pyproject/uv.lock.
+          - textual==8.2.7

--- a/sbomify_action/_enrichment/metadata.py
+++ b/sbomify_action/_enrichment/metadata.py
@@ -179,4 +179,5 @@ class NormalizedMetadata:
             or self.hashes
             or self.cle_eos
             or self.cle_eol
+            or self.cle_release_date
         )

--- a/sbomify_action/_generation/chainguard.py
+++ b/sbomify_action/_generation/chainguard.py
@@ -218,6 +218,11 @@ def _detect_chainguard_from_provenance(docker_image: str) -> ChainguardBaseImage
     for entry in index.get("manifests", []):
         annotations = entry.get("annotations", {})
         if annotations.get("vnd.docker.reference.type") == "attestation-manifest":
+            # ``.get`` (not ``[...]``) guards an off-spec entry that matches the
+            # annotation but omits ``digest``; ``if att_digest: break`` then keeps
+            # scanning for a later attestation entry that has one rather than
+            # aborting — same continue-on-missing semantics as
+            # ``_resolve_platform_digest`` above.
             att_digest = entry.get("digest")
             if att_digest:
                 break

--- a/sbomify_action/_generation/chainguard.py
+++ b/sbomify_action/_generation/chainguard.py
@@ -111,7 +111,9 @@ def _resolve_platform_digest(image_ref: str) -> str | None:
         for entry in manifest.get("manifests", []):
             p = entry.get("platform", {})
             if p.get("os") == os_name and p.get("architecture") == arch:
-                return str(entry["digest"])
+                digest = entry.get("digest")
+                if digest:
+                    return str(digest)
         logger.debug(f"No matching platform {current_platform} in manifest list for {image_ref}")
         return None
 
@@ -216,8 +218,9 @@ def _detect_chainguard_from_provenance(docker_image: str) -> ChainguardBaseImage
     for entry in index.get("manifests", []):
         annotations = entry.get("annotations", {})
         if annotations.get("vnd.docker.reference.type") == "attestation-manifest":
-            att_digest = entry["digest"]
-            break
+            att_digest = entry.get("digest")
+            if att_digest:
+                break
 
     if not att_digest:
         logger.debug(f"No attestation manifest found for {docker_image}")
@@ -237,8 +240,9 @@ def _detect_chainguard_from_provenance(docker_image: str) -> ChainguardBaseImage
     for layer in att_manifest.get("layers", []):
         annotations = layer.get("annotations", {})
         if annotations.get("in-toto.io/predicate-type") == "https://slsa.dev/provenance/v1":
-            provenance_digest = layer["digest"]
-            break
+            provenance_digest = layer.get("digest")
+            if provenance_digest:
+                break
 
     if not provenance_digest:
         logger.debug(f"No SLSA provenance layer found in attestation for {docker_image}")

--- a/sbomify_action/_generation/generators/cdxgen.py
+++ b/sbomify_action/_generation/generators/cdxgen.py
@@ -190,8 +190,13 @@ class CdxgenFsGenerator:
         logger.info(f"Running cdxgen for {input.lock_file_name} (CycloneDX {version}, type={cdxgen_type or 'auto'})")
 
         try:
-            # run_command raises SBOMGenerationError on failure (uses check=True)
-            run_command(cmd, "cdxgen", timeout=DEFAULT_TIMEOUT, cwd=str(lock_file_directory))
+            # run_command raises SBOMGenerationError on failure (uses check=True).
+            # log_errors=False: cdxgen is a priority-20 fallback that routinely
+            # fails for ecosystems it doesn't handle (eg a Python uv.lock, where
+            # cyclonedx-py/syft take over). Its failure is benign on the happy
+            # path, so log it at DEBUG rather than spamming ERROR; the
+            # orchestrator surfaces a real ERROR only if every generator fails.
+            run_command(cmd, "cdxgen", timeout=DEFAULT_TIMEOUT, cwd=str(lock_file_directory), log_errors=False)
 
             # Verify output file was created
             if not Path(output_file_abs).exists():
@@ -300,8 +305,12 @@ class CdxgenImageGenerator:
         logger.info(f"Running cdxgen for {input.docker_image} (CycloneDX {version})")
 
         try:
-            # run_command raises SBOMGenerationError on failure (uses check=True)
-            run_command(cmd, "cdxgen", timeout=DEFAULT_TIMEOUT, docker_image=input.docker_image)
+            # run_command raises SBOMGenerationError on failure (uses check=True).
+            # log_errors=False: cdxgen image scanning is a priority-20 fallback
+            # ahead of syft; a benign failure here shouldn't spam ERROR when syft
+            # can still succeed. (Docker-image-not-found is handled separately and
+            # still logs at WARNING.)
+            run_command(cmd, "cdxgen", timeout=DEFAULT_TIMEOUT, docker_image=input.docker_image, log_errors=False)
 
             # Verify output file was created
             if not Path(input.output_file).exists():

--- a/sbomify_action/_generation/generators/cyclonedx_cargo.py
+++ b/sbomify_action/_generation/generators/cyclonedx_cargo.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from sbomify_action.exceptions import SBOMGenerationError
 from sbomify_action.logging_config import logger
+from sbomify_action.tool_checks import check_tool_available
 
 from ..protocol import (
     CARGO_CYCLONEDX_DEFAULT,
@@ -23,6 +24,13 @@ from ..protocol import (
 )
 from ..result import GenerationResult
 from ..utils import run_command
+
+# Check tool availability once at module load (mirrors cyclonedx_py / syft).
+# Without this guard, supports() would claim a Cargo.lock and then fail at
+# generate() time when cargo-cyclonedx isn't installed (eg pip installs that
+# don't bundle it) — a spurious ERROR + wasted attempt before the orchestrator
+# falls through to a generic generator.
+_CARGO_CYCLONEDX_AVAILABLE, _CARGO_CYCLONEDX_PATH = check_tool_available("cargo-cyclonedx")
 
 
 class CycloneDXCargoGenerator:
@@ -69,6 +77,10 @@ class CycloneDXCargoGenerator:
         Supports Cargo.lock files when requesting CycloneDX format.
         Does not support Docker images or SPDX format.
         """
+        # Check if cargo-cyclonedx is installed
+        if not _CARGO_CYCLONEDX_AVAILABLE:
+            return False
+
         # Only supports lock files, not Docker images
         if not input.is_lock_file:
             return False

--- a/sbomify_action/_generation/utils.py
+++ b/sbomify_action/_generation/utils.py
@@ -163,16 +163,17 @@ def log_command_error(command_name: str, stderr: str, stdout: str, level: str = 
         command_name: The name of the command that failed
         stderr: The stderr output from the command
         stdout: The stdout output from the command (some tools output errors here)
-        level: Log level to use ("error" or "warning"). Default is "error".
+        level: Log level to use ("error", "warning", or "debug"). Default is
+            "error". "debug" is used for failures inside a generator priority
+            chain where a later generator is expected to succeed, so the
+            failure is benign noise on the happy path.
     """
     # Prefer stderr, fall back to stdout (some tools like cdxgen output errors to stdout)
     output = stderr or stdout
     if output:
         message = f"[{command_name}] error: {output.strip()}"
-        if level == "warning":
-            logger.warning(message)
-        else:
-            logger.error(message)
+        log_fn = {"debug": logger.debug, "warning": logger.warning}.get(level, logger.error)
+        log_fn(message)
 
 
 # Patterns that indicate a Docker image was not found in the registry
@@ -295,6 +296,7 @@ def run_command(
     capture_output: bool = True,
     cwd: str | None = None,
     docker_image: str | None = None,
+    log_errors: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     """
     Run a command and handle common error cases.
@@ -308,6 +310,15 @@ def run_command(
         capture_output: Whether to capture stdout/stderr
         cwd: Working directory for the command (optional)
         docker_image: Docker image being scanned (optional, for better error messages)
+        log_errors: When True (default), a non-zero exit logs at ERROR. Set
+            False for a generator that runs inside the priority chain and is
+            expected to fail gracefully when a higher-priority or fallback
+            generator can still succeed (e.g. cdxgen on a Python lockfile,
+            where cyclonedx-py/syft take over) — its failure is then logged
+            at DEBUG so it doesn't spam ERROR on the happy path. The
+            ``SBOMGenerationError`` is still raised either way; the
+            orchestrator surfaces the real ERROR only if *every* generator
+            in the chain fails.
 
     Returns:
         CompletedProcess result
@@ -370,9 +381,18 @@ def run_command(
                 returncode=e.returncode,
             )
 
-        # Other errors are logged at ERROR level (potential bugs or system issues)
-        logger.error(f"{command_name} command failed with error: {e}")
-        log_command_error(command_name, stderr, stdout)
+        # Other errors normally log at ERROR (potential bugs or system issues).
+        # When the caller is a priority-chain generator that fails gracefully
+        # (log_errors=False), drop to DEBUG so an expected fallback doesn't
+        # spam red ERROR lines on the happy path — the SBOMGenerationError is
+        # still raised, and the orchestrator logs ERROR only if all generators
+        # fail.
+        if log_errors:
+            logger.error(f"{command_name} command failed with error: {e}")
+            log_command_error(command_name, stderr, stdout)
+        else:
+            logger.debug(f"{command_name} command failed (trying next generator): {e}")
+            log_command_error(command_name, stderr, stdout, level="debug")
 
         # Include error summary in the exception message for better diagnostics
         error_summary = extract_error_summary(stderr or stdout)

--- a/sbomify_action/_generation/utils.py
+++ b/sbomify_action/_generation/utils.py
@@ -310,7 +310,8 @@ def run_command(
         capture_output: Whether to capture stdout/stderr
         cwd: Working directory for the command (optional)
         docker_image: Docker image being scanned (optional, for better error messages)
-        log_errors: When True (default), a non-zero exit logs at ERROR. Set
+        log_errors: When True (default), a failure (non-zero exit, timeout, or
+            missing binary) logs at ERROR. Set
             False for a generator that runs inside the priority chain and is
             expected to fail gracefully when a higher-priority or fallback
             generator can still succeed (e.g. cdxgen on a Python lockfile,
@@ -408,10 +409,15 @@ def run_command(
         )
     except subprocess.TimeoutExpired:
         elapsed = int(time.time() - start_time)
-        logger.error(f"{command_name} command timed out after {elapsed}s (limit: {timeout}s)")
+        # Honour log_errors here too: a cdxgen timeout on, say, a Python
+        # lockfile is the same benign priority-chain fallback as a non-zero
+        # exit — it shouldn't spam red ERROR when a later generator succeeds.
+        timeout_msg = f"{command_name} command timed out after {elapsed}s (limit: {timeout}s)"
+        logger.error(timeout_msg) if log_errors else logger.debug(timeout_msg)
         raise SBOMGenerationError(f"{command_name} command timed out")
     except FileNotFoundError:
-        logger.error(f"{command_name} command not found")
+        not_found_msg = f"{command_name} command not found"
+        logger.error(not_found_msg) if log_errors else logger.debug(not_found_msg)
         raise SBOMGenerationError(f"{command_name} command not found - is it installed?")
     finally:
         # Stop the progress thread

--- a/sbomify_action/_upload/destinations/dependency_track.py
+++ b/sbomify_action/_upload/destinations/dependency_track.py
@@ -214,6 +214,15 @@ class DependencyTrackDestination:
                 destination_name=self.name,
                 error_message="SBOM upload to Dependency Track timed out",
             )
+        except requests.exceptions.RequestException as e:
+            # Any other transport-layer failure (SSLError, ProxyError,
+            # TooManyRedirects, …). Return a clean failure result rather than
+            # letting it propagate and crash the upload step — the upload
+            # destination contract is to report failures, not raise.
+            return UploadResult.failure_result(
+                destination_name=self.name,
+                error_message=f"SBOM upload to Dependency Track failed: {e}",
+            )
 
         # Handle response
         if not response.ok:

--- a/sbomify_action/_upload/destinations/sbomify.py
+++ b/sbomify_action/_upload/destinations/sbomify.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from sbomify_action.exceptions import APIError, AuthError
 from sbomify_action.logging_config import logger
-from sbomify_action.sbomify_api import SbomifyApiClient
+from sbomify_action.sbomify_api import SbomifyApiClient, clean_validation_error
 
 from ..protocol import UploadInput
 from ..result import UploadResult
@@ -174,7 +174,14 @@ class SbomifyDestination:
                 response_json = response.json()
                 error_code = response_json.get("error_code")
                 if "detail" in response_json:
-                    err_msg += f" - {response_json['detail']}"
+                    # Collapse pydantic 422 list-detail into readable text so a
+                    # raw Python dict repr never reaches the user (mirrors the
+                    # SbomifyApiClient error path). Use the module-level helper,
+                    # not SbomifyApiClient's, so it survives tests that mock the
+                    # client class wholesale.
+                    cleaned = clean_validation_error(response_json["detail"])
+                    if cleaned:
+                        err_msg += f" - {cleaned}"
 
                 # Handle duplicate SBOM error with specific message
                 if response.status_code == 409 and error_code == "DUPLICATE_ARTIFACT":

--- a/sbomify_action/_yocto/api.py
+++ b/sbomify_action/_yocto/api.py
@@ -41,12 +41,12 @@ def get_component_id_by_name(api_base_url: str, token: str, name: str) -> str | 
 def create_component(api_base_url: str, token: str, name: str) -> tuple[str, bool]:
     """Create a new component (or recover an existing one on DUPLICATE_NAME).
 
-    Yocto components are SBOM-typed (``component_type='sbom'``) by historical
-    convention — the pre-consolidation Yocto code hard-coded this string on
-    every payload. Anything else mis-categorises the component in the sbomify
-    dashboard, so we pass it explicitly instead of letting the client default.
+    Yocto components are BOM-typed (``component_type='bom'``). The backend
+    ComponentType enum is ``{bom, document}`` — there is no "sbom" value
+    (passing it 422s), so we pass ``"bom"`` explicitly rather than relying
+    on a client default.
     """
-    return _client(api_base_url, token).create_component(name, component_type="sbom")
+    return _client(api_base_url, token).create_component(name, component_type="bom")
 
 
 def patch_component_visibility(api_base_url: str, token: str, component_id: str, visibility: str) -> None:
@@ -57,7 +57,7 @@ def patch_component_visibility(api_base_url: str, token: str, component_id: str,
 def get_or_create_component(api_base_url: str, token: str, name: str, cache: dict[str, str]) -> tuple[str, bool]:
     """Look the name up in ``cache``; on miss, create the component (and update cache).
 
-    Passes ``component_type='sbom'`` so newly-created Yocto components match
-    the historical type (see ``create_component`` above).
+    Passes ``component_type='bom'`` so newly-created Yocto components get
+    the correct backend type (see ``create_component`` above).
     """
-    return _client(api_base_url, token).get_or_create_component(name, cache, component_type="sbom")
+    return _client(api_base_url, token).get_or_create_component(name, cache, component_type="bom")

--- a/sbomify_action/cli/wizard/apply.py
+++ b/sbomify_action/cli/wizard/apply.py
@@ -71,10 +71,10 @@ def apply_plan(state: WizardState, opts: WizardOptions, *, log: LogFn = _noop) -
             log("info", f"Reused existing component {planned.name} ({comp_id})")
             continue
 
-        # Pass component_type='sbom' explicitly — the wizard onboards code-
-        # repo SBOMs, matching the legacy default that the consolidated
-        # client no longer carries.
-        comp_id, was_created = api.get_or_create_component(planned.name, create_cache, component_type="sbom")
+        # Pass component_type='bom' explicitly — the wizard onboards
+        # code-repo SBOMs, which are BOM-typed components on the backend
+        # (the ComponentType enum is {bom, document}; there is no "sbom").
+        comp_id, was_created = api.get_or_create_component(planned.name, create_cache, component_type="bom")
         component_ids[str(planned.lockfile.rel_path)] = comp_id
         state.component_ids[planned.lockfile.rel_path] = comp_id
         if not was_created:
@@ -139,15 +139,29 @@ def apply_plan(state: WizardState, opts: WizardOptions, *, log: LogFn = _noop) -
             json_path = opts.repo_root / "sbomify.json"
             try:
                 write_sbomify_json(json_path, plan.sbomify_json_data)
-            except SbomifyJsonOwnershipError as e:
-                log("error", str(e))
-                raise
+            except SbomifyJsonOwnershipError:
+                # A hand-authored sbomify.json already lives here (no wizard
+                # sentinel). Don't clobber it — but don't dead-end the whole
+                # apply over it either. The action's json_config provider reads
+                # whatever sbomify.json exists at run time, so the existing file
+                # is already doing its job; skip the write and keep going so the
+                # workflow + components still get created. The user can delete
+                # the file (or add the '__sbomify_wizard__' key) to hand it over
+                # to the wizard on a later run.
+                log(
+                    "warning",
+                    f"{json_path} already exists and wasn't created by the wizard — "
+                    "keeping it as-is (the action reads it at run time). Skipping the "
+                    "write. Delete it or add the '__sbomify_wizard__' key to let the "
+                    "wizard manage it.",
+                )
             except OSError as e:
                 log("error", f"Could not write {json_path}: {e}")
                 raise
-            state.written_files.append(json_path)
-            state.applied.append(f"wrote {json_path}")
-            log("success", f"Wrote {json_path}")
+            else:
+                state.written_files.append(json_path)
+                state.applied.append(f"wrote {json_path}")
+                log("success", f"Wrote {json_path}")
 
     # 6. Emit the workflow file. Last step so an API failure above never
     # leaves a broken .yml on disk that points at non-existent components.

--- a/sbomify_action/cli/wizard/apply.py
+++ b/sbomify_action/cli/wizard/apply.py
@@ -151,9 +151,10 @@ def apply_plan(state: WizardState, opts: WizardOptions, *, log: LogFn = _noop) -
                 log(
                     "warning",
                     f"{json_path} already exists and wasn't created by the wizard — "
-                    "keeping it as-is (the action reads it at run time). Skipping the "
-                    "write. Delete it or add the '__sbomify_wizard__' key to let the "
-                    "wizard manage it.",
+                    "keeping it as-is (the action reads it at run time). Any values you "
+                    "entered in the wizard were NOT written to it. To let the wizard "
+                    "manage this file, delete it (or add the '__sbomify_wizard__' key) "
+                    "and re-run.",
                 )
             except OSError as e:
                 log("error", f"Could not write {json_path}: {e}")
@@ -179,6 +180,12 @@ def apply_plan(state: WizardState, opts: WizardOptions, *, log: LogFn = _noop) -
     try:
         write_workflow(target, rendered)
     except WorkflowOwnershipError as e:
+        # Unlike the sbomify.json ownership conflict above (which we soften to
+        # a warning and skip), a hand-authored workflow IS fatal: sboms.yml is
+        # wizard-owned CI infrastructure with no value if half-written, and
+        # there's no run-time fallback that reads "whatever is there". Failing
+        # loud forces the user to resolve the conflict rather than silently
+        # shipping a workflow that doesn't match the plan.
         log("error", str(e))
         raise
     state.written_files.append(target)

--- a/sbomify_action/cli/wizard/apply.py
+++ b/sbomify_action/cli/wizard/apply.py
@@ -12,6 +12,7 @@ workflow on disk.
 
 from __future__ import annotations
 
+import json
 from typing import Any, Callable, Literal
 
 from sbomify_action.cli.wizard import ci_emitter
@@ -38,8 +39,10 @@ def apply_plan(state: WizardState, opts: WizardOptions, *, log: LogFn = _noop) -
     """Execute every staged mutation in ``state.plan``.
 
     Idempotent where possible (component create uses get-or-create
-    semantics; attach is a set-union; workflow write backs up to .bak)
-    and fail-fast otherwise. Populates ``state.applied``,
+    semantics; attach is a set-union; the workflow write is sentinel-guarded
+    — overwrites a wizard-owned file, refuses a hand-authored one, and writes
+    no ``.bak`` since git holds the prior version) and fail-fast otherwise.
+    Populates ``state.applied``,
     ``state.created_product_id``, ``state.component_ids``, and
     ``state.written_files`` as side effects so the done screen can show
     what happened.
@@ -155,6 +158,14 @@ def apply_plan(state: WizardState, opts: WizardOptions, *, log: LogFn = _noop) -
                     "entered in the wizard were NOT written to it. To let the wizard "
                     "manage this file, delete it (or add the '__sbomify_wizard__' key) "
                     "and re-run.",
+                )
+                # Surface the unwritten payload so the user can copy it into the
+                # file by hand instead of re-running the whole wizard to
+                # reproduce what they typed.
+                log(
+                    "info",
+                    "Values you entered (copy into sbomify.json manually if wanted):\n"
+                    + json.dumps(plan.sbomify_json_data, indent=2, sort_keys=True),
                 )
             except OSError as e:
                 log("error", f"Could not write {json_path}: {e}")

--- a/sbomify_action/cli/wizard/existing.py
+++ b/sbomify_action/cli/wizard/existing.py
@@ -8,8 +8,9 @@ YAML parsing, no grep over arbitrary workflow files, no inference of
 intent from ``on:`` triggers.
 
 If the file exists with the sentinel → the apply phase will overwrite
-it (after .bak backup). If it exists *without* the sentinel → the
-apply phase will refuse with a clear error.
+it in place (git tracks the previous version; the wizard deliberately
+writes no ``.bak`` — see ``io.py``). If it exists *without* the
+sentinel → the apply phase will refuse with a clear error.
 """
 
 from __future__ import annotations

--- a/sbomify_action/cli/wizard/repo_facts.py
+++ b/sbomify_action/cli/wizard/repo_facts.py
@@ -47,6 +47,11 @@ def gather_repo_facts(repo_root: Path) -> RepoFacts:
     if not suggested_repo_name:
         suggested_repo_name = repo_root.name
 
+    # Detect an existing repo-root sbomify.json so the wizard can pre-fill
+    # the json_config form from it and avoid dead-ending on the ownership
+    # check at apply time.
+    has_sbomify_json = (repo_root / "sbomify.json").is_file()
+
     return RepoFacts(
         repo_root=repo_root,
         is_git=is_git,
@@ -57,6 +62,7 @@ def gather_repo_facts(repo_root: Path) -> RepoFacts:
         has_release_tags=has_release_tags,
         owner_repo_slug=owner_repo_slug,
         visibility=visibility,
+        has_sbomify_json=has_sbomify_json,
     )
 
 

--- a/sbomify_action/cli/wizard/screens/authenticate.py
+++ b/sbomify_action/cli/wizard/screens/authenticate.py
@@ -20,13 +20,16 @@ from sbomify_action.sbomify_api import SbomifyApiClient
 def _pick_default_workspace_key(workspaces: list[dict[str, object]]) -> str | None:
     """Return the ``key`` of the workspace the wizard should bind to.
 
-    The backend scopes ``list_products`` / ``list_components`` to the
-    token's bound team (scoped tokens) or the authenticating user's
-    *default* workspace (PATs). Mirror that by reading the
+    ``GET /api/v1/workspaces/`` returns every workspace the underlying
+    *user* belongs to, regardless of the token's scope (the backend does
+    not filter that endpoint by token-bound team today). But
+    ``list_products`` / ``list_components`` ARE scoped — to the token's
+    bound team for scoped tokens, or the authenticating user's *default*
+    workspace for PATs. Mirror that scoping by reading the
     ``is_default_team`` flag on the current user's membership entry —
-    that's the same signal the backend uses. When no entry is marked
-    default (or the response omits the membership block), fall back
-    to the first usable key.
+    the same signal the backend uses for the component listing. When no
+    entry is marked default (or the response omits the membership block),
+    fall back to the first usable key.
     """
     fallback: str | None = None
     for ws in workspaces:
@@ -141,18 +144,18 @@ class AuthenticateScreen(WizardScreen):
         # Resolve the workspace key up front. The contact-profiles
         # endpoint is nested under ``/api/v1/workspaces/{team_key}/``
         # and there's no "current workspace" alias — we have to know
-        # the key explicitly. ``list_workspaces`` returns one or more
-        # entries: a scoped token returns the one workspace it's bound
-        # to; a personal-access token returns every workspace the
-        # user belongs to.
+        # the key explicitly. ``list_workspaces`` returns every workspace
+        # the underlying USER belongs to, regardless of token scope (the
+        # backend doesn't filter that endpoint by token-bound team), so a
+        # multi-workspace user gets multiple entries even with a token
+        # scoped to one team.
         #
-        # For multi-workspace tokens we MUST pick the workspace where
-        # list_products / list_components are actually scoped — those
-        # endpoints have no team_key parameter and resolve via the
-        # token's bound team (scoped) or the user's default workspace
-        # (PAT). Picking the wrong workspace silently binds profiles
-        # to components that live elsewhere — the exact failure mode
-        # apply.py's profile-binding step exists to avoid.
+        # We MUST pick the workspace where list_products / list_components
+        # are actually scoped — those endpoints have no team_key parameter
+        # and resolve via the token's bound team (scoped) or the user's
+        # default workspace (PAT). Picking the wrong workspace silently
+        # binds profiles to components that live elsewhere — the exact
+        # failure mode apply.py's profile-binding step exists to avoid.
         #
         # Strategy: prefer the workspace whose membership entry has
         # ``is_default_team=True`` for the current user (the same
@@ -175,8 +178,8 @@ class AuthenticateScreen(WizardScreen):
                 "(unknown)",
             )
             logger.warning(
-                "Token spans %d workspaces; the wizard will use %r (key=%s) — the "
-                "user's default workspace. If you intended to onboard a different "
+                "You belong to %d workspaces; the wizard will use %r (key=%s) — your "
+                "default workspace. If you intended to onboard a different "
                 "workspace, change the default in the sbomify UI and re-run.",
                 len(workspaces),
                 picked_name,

--- a/sbomify_action/cli/wizard/screens/configure_sbomify_json.py
+++ b/sbomify_action/cli/wizard/screens/configure_sbomify_json.py
@@ -19,12 +19,15 @@ alongside the code it describes.
 
 from __future__ import annotations
 
+import json
+
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.css.query import NoMatches
 from textual.widgets import Button, Input, RadioButton, RadioSet, Static
 
+from sbomify_action.cli.wizard.io import WIZARD_JSON_SENTINEL_KEY
 from sbomify_action.cli.wizard.screens._base import WizardScreen
 
 # CycloneDX-defined lifecycle phases. The action's existing
@@ -322,10 +325,6 @@ class ConfigureSbomifyJsonScreen(WizardScreen):
         keys the form doesn't render (eg ``licenses``) are ignored here but
         preserved on disk because apply leaves a non-wizard file untouched.
         """
-        import json
-
-        from sbomify_action.cli.wizard.io import WIZARD_JSON_SENTINEL_KEY
-
         json_path = self.wizard.state.facts.repo_root / "sbomify.json"
         try:
             with json_path.open("r", encoding="utf-8") as f:

--- a/sbomify_action/cli/wizard/screens/configure_sbomify_json.py
+++ b/sbomify_action/cli/wizard/screens/configure_sbomify_json.py
@@ -148,9 +148,13 @@ class ConfigureSbomifyJsonScreen(WizardScreen):
             yield Button("Save  ▸", id="save", variant="primary")
 
     def on_mount(self) -> None:
-        # Pre-populate from any previously-saved data so the user can
-        # come back and edit.
-        prior = self.wizard.state.plan.sbomify_json_data or {}
+        # Pre-populate from previously-saved plan data so the user can come
+        # back and edit. If the plan has nothing yet but the repo already
+        # ships a sbomify.json, seed the form from that on-disk file so the
+        # user edits their existing metadata instead of re-typing it.
+        prior = self.wizard.state.plan.sbomify_json_data
+        if not prior and self.wizard.state.facts.has_sbomify_json:
+            prior = self._load_from_disk()
         if prior:
             self._populate_from(prior)
         self.query_one("#sup-name", Input).focus()
@@ -307,3 +311,27 @@ class ConfigureSbomifyJsonScreen(WizardScreen):
             value = data.get(key)
             if isinstance(value, str):
                 self.query_one(f"#{input_id}", Input).value = value
+
+    def _load_from_disk(self) -> dict[str, object] | None:
+        """Read an existing repo-root ``sbomify.json`` to seed the form.
+
+        Returns the parsed JSON object with the wizard sentinel key removed
+        (it's bookkeeping the form shouldn't surface), or ``None`` if the
+        file is absent, unreadable, malformed, or not a JSON object. Purely
+        a convenience — any failure just leaves the form blank, and unknown
+        keys the form doesn't render (eg ``licenses``) are ignored here but
+        preserved on disk because apply leaves a non-wizard file untouched.
+        """
+        import json
+
+        from sbomify_action.cli.wizard.io import WIZARD_JSON_SENTINEL_KEY
+
+        json_path = self.wizard.state.facts.repo_root / "sbomify.json"
+        try:
+            with json_path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, ValueError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        return {k: v for k, v in data.items() if k != WIZARD_JSON_SENTINEL_KEY}

--- a/sbomify_action/cli/wizard/state.py
+++ b/sbomify_action/cli/wizard/state.py
@@ -100,6 +100,12 @@ class RepoFacts:
     falls back to ``unknown``. Used to gate the attestation warning
     on the configure screen and surface the visibility line on the
     welcome screen."""
+    has_sbomify_json: bool = False
+    """True iff a ``sbomify.json`` already exists in the repo root at
+    wizard start. When set, the Configure (sbomify.json) screen pre-fills
+    its form from the existing file instead of opening blank, and the
+    apply phase treats a hand-authored (non-wizard) file as the source of
+    truth rather than dead-ending on the ownership check."""
 
 
 @dataclass

--- a/sbomify_action/sbomify_api.py
+++ b/sbomify_action/sbomify_api.py
@@ -58,7 +58,7 @@ def clean_validation_error(detail: Any) -> str | None:
                 msg = item.get("msg") or item.get("detail") or ""
                 loc = item.get("loc")
                 field = None
-                if isinstance(loc, (list, tuple)) and loc:
+                if isinstance(loc, list | tuple) and loc:
                     # ``loc`` is a path like ['body', 'payload', '<field>'];
                     # the trailing element is the field the user cares about.
                     field = str(loc[-1])

--- a/sbomify_action/sbomify_api.py
+++ b/sbomify_action/sbomify_api.py
@@ -25,6 +25,52 @@ DEFAULT_TIMEOUT = 60
 DEFAULT_PAGE_SIZE = 100
 MAX_PAGES = 500  # Safety limit against runaway pagination.
 
+# Component types the sbomify backend accepts (mirrors
+# ``core.schemas.ComponentType``: BOM="bom", DOCUMENT="document"). There is
+# NO "sbom" value — passing one trips a server-side 422. We validate
+# client-side so a wrong literal fails fast with a clear message at the
+# call site instead of an opaque enum-validation dump from the API.
+VALID_COMPONENT_TYPES = frozenset({"bom", "document"})
+
+
+def clean_validation_error(detail: Any) -> str | None:
+    """Render an API error ``detail`` into human-readable text.
+
+    django-ninja / pydantic 422 responses put a *list* of per-field error
+    dicts (``{type, loc, msg, ctx}``) in ``detail``. Stringifying that list
+    dumps raw Python reprs — eg ``[{'type': 'enum', 'loc': ['body', 'payload',
+    'component_type'], 'msg': "Input should be 'document' or 'bom'", ...}]`` —
+    at the user. Collapse it to ``<field>: <msg>`` lines instead. A plain-string
+    detail (the common case) passes through unchanged; ``None`` stays ``None``
+    so callers can treat "no detail" as falsy.
+
+    Module-level (not just a client method) so other code paths that handle raw
+    API responses — eg the upload destination, which never goes through
+    ``SbomifyApiClient`` — can reuse it without depending on the class (and
+    without breaking when tests mock the class wholesale).
+    """
+    if detail is None:
+        return None
+    if isinstance(detail, list):
+        parts: list[str] = []
+        for item in detail:
+            if isinstance(item, dict):
+                msg = item.get("msg") or item.get("detail") or ""
+                loc = item.get("loc")
+                field = None
+                if isinstance(loc, (list, tuple)) and loc:
+                    # ``loc`` is a path like ['body', 'payload', '<field>'];
+                    # the trailing element is the field the user cares about.
+                    field = str(loc[-1])
+                if field and msg:
+                    parts.append(f"{field}: {msg}")
+                elif msg:
+                    parts.append(str(msg))
+            elif item:
+                parts.append(str(item))
+        return "; ".join(parts) if parts else None
+    return str(detail)
+
 
 class SbomifyApiClient:
     """Thin wrapper around the sbomify REST API.
@@ -100,10 +146,18 @@ class SbomifyApiClient:
         message = f"{prefix} [{response.status_code}]"
         body = SbomifyApiClient._safe_json_dict(response)
         if body is not None:
-            detail = body.get("detail")
+            detail = SbomifyApiClient._clean_validation_error(body.get("detail"))
             if detail:
                 message += f" - {detail}"
         return message
+
+    @staticmethod
+    def _clean_validation_error(detail: Any) -> str | None:
+        """Backwards-compatible alias for the module-level
+        :func:`clean_validation_error`. Kept so existing call sites and tests
+        that reference ``SbomifyApiClient._clean_validation_error`` keep working.
+        """
+        return clean_validation_error(detail)
 
     @staticmethod
     def _safe_json_dict(response: requests.Response) -> dict[str, Any] | None:
@@ -252,7 +306,16 @@ class SbomifyApiClient:
         ``DUPLICATE_NAME`` (status 400 or 409) by looking the existing
         component up by name. Raises ``PlanLimitError`` when the team has
         hit their component-count limit.
+
+        Raises ``ValueError`` if ``component_type`` isn't a value the
+        backend accepts — a hardcoded-literal mistake (the only way a bad
+        type reaches here) should fail loud at the call site / in CI, not
+        ship and surface as an opaque 422 at runtime.
         """
+        if component_type not in VALID_COMPONENT_TYPES:
+            raise ValueError(
+                f"Invalid component_type {component_type!r}; expected one of {sorted(VALID_COMPONENT_TYPES)}."
+            )
         response = self._request(
             "POST",
             "/api/v1/components",
@@ -269,7 +332,15 @@ class SbomifyApiClient:
             return str(comp_id), True
 
         body = self._safe_json_dict(response) or {}
-        detail = body.get("detail") or ""
+        # ``raw_detail`` drives plan-limit detection; ``detail`` (cleaned) is for
+        # the human-facing message only. Keep them separate: the backend's
+        # plan-limit 403 sends a plain string ("maximum components reached"),
+        # whereas a pydantic 422 sends a list. Matching "maximum" against the
+        # *cleaned* string would misfire on a list-detail whose collapsed text
+        # happens to contain "maximum" (eg "name: ...maximum length 255"),
+        # raising PlanLimitError for a plain validation error.
+        raw_detail = body.get("detail")
+        detail = self._clean_validation_error(raw_detail) or ""
         error_code = body.get("error_code") or ""
         err_msg = f"Failed to create component '{name}'. [{response.status_code}]"
         if detail:
@@ -282,7 +353,7 @@ class SbomifyApiClient:
                 return existing_id, False
             raise APIError(f"Component '{name}' reported as duplicate by API but could not be found via lookup")
 
-        if response.status_code == 403 and isinstance(detail, str) and "maximum" in detail.lower():
+        if response.status_code == 403 and isinstance(raw_detail, str) and "maximum" in raw_detail.lower():
             raise PlanLimitError(err_msg)
         raise APIError(err_msg)
 

--- a/tests/test_chainguard.py
+++ b/tests/test_chainguard.py
@@ -10,6 +10,7 @@ from sbomify_action._generation.chainguard import (
     ChainguardBaseImage,
     _extract_repo,
     _parse_purl_docker_uri,
+    _resolve_platform_digest,
     convert_spdx_to_cyclonedx,
     detect_chainguard_image,
     fetch_chainguard_sbom,
@@ -306,6 +307,34 @@ class TestDetectDirectChainguard:
     def test_crane_not_available(self, mock_which):
         result = detect_chainguard_image("cgr.dev/chainguard/python:latest")
         assert result is None
+
+    @patch("sbomify_action._generation.chainguard._run_crane")
+    def test_resolve_platform_digest_tolerates_missing_digest(self, mock_crane):
+        """A manifest-list entry that matches the platform but lacks a 'digest'
+        key must NOT raise KeyError — _resolve_platform_digest returns None and
+        the caller treats it as 'no resolvable digest'. (OCI mandates digest;
+        this guards against a malformed/non-spec registry response.) Both
+        common linux platforms are present and digest-less so the test is
+        deterministic regardless of the runner's architecture."""
+        manifest_list_no_digest = json.dumps(
+            {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.image.index.v1+json",
+                "manifests": [
+                    {
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "platform": {"architecture": "amd64", "os": "linux"},
+                    },
+                    {
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "platform": {"architecture": "arm64", "os": "linux"},
+                    },
+                ],
+            }
+        )
+        mock_crane.return_value = manifest_list_no_digest
+        # Must not raise; returns None because no matching entry carries a digest.
+        assert _resolve_platform_digest("cgr.dev/chainguard/python:latest") is None
 
 
 class TestDetectFromProvenance:

--- a/tests/test_chainguard.py
+++ b/tests/test_chainguard.py
@@ -8,6 +8,7 @@ import pytest
 
 from sbomify_action._generation.chainguard import (
     ChainguardBaseImage,
+    _detect_chainguard_from_provenance,
     _extract_repo,
     _parse_purl_docker_uri,
     _resolve_platform_digest,
@@ -441,6 +442,29 @@ class TestDetectFromProvenance:
 
         result = detect_chainguard_image("oldimage:latest")
         assert result is None
+
+    @patch("sbomify_action._generation.chainguard._run_crane")
+    def test_tolerates_attestation_entry_missing_digest(self, mock_crane):
+        """An image-index attestation entry that matches the annotation but lacks
+        a 'digest' key must NOT raise KeyError — _detect_chainguard_from_provenance
+        returns None. Mirrors the _resolve_platform_digest hardening for the
+        provenance code path (off-spec/malformed registry responses)."""
+        index_no_digest = json.dumps(
+            {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.image.index.v1+json",
+                "manifests": [
+                    {
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "annotations": {"vnd.docker.reference.type": "attestation-manifest"},
+                        # no "digest" key — must not KeyError
+                    },
+                ],
+            }
+        )
+        mock_crane.return_value = index_no_digest
+
+        assert _detect_chainguard_from_provenance("nginx:latest") is None
 
 
 class TestFetchChainguardSbom:

--- a/tests/test_cyclonedx_cargo_generator.py
+++ b/tests/test_cyclonedx_cargo_generator.py
@@ -19,8 +19,16 @@ from sbomify_action._generation.protocol import (
 )
 
 
+@patch("sbomify_action._generation.generators.cyclonedx_cargo._CARGO_CYCLONEDX_AVAILABLE", True)
 class TestCycloneDXCargoGenerator(unittest.TestCase):
-    """Tests for CycloneDXCargoGenerator."""
+    """Tests for CycloneDXCargoGenerator.
+
+    The class-level patch forces ``_CARGO_CYCLONEDX_AVAILABLE=True`` so the
+    ``supports()`` tests exercise the lock-file/format/version logic regardless
+    of whether cargo-cyclonedx happens to be installed in the test env (it
+    usually isn't — it's a Rust tool). Mirrors the pattern used for the
+    syft/cyclonedx-py generators in test_generation_plugin.py.
+    """
 
     def setUp(self):
         """Set up test fixtures."""
@@ -147,8 +155,14 @@ class TestCycloneDXCargoGenerator(unittest.TestCase):
         self.assertIn("Unsupported CycloneDX version", result.error_message)
 
 
+@patch("sbomify_action._generation.generators.cyclonedx_cargo._CARGO_CYCLONEDX_AVAILABLE", True)
 class TestCycloneDXCargoGeneratorPriority(unittest.TestCase):
-    """Tests for CycloneDXCargoGenerator priority in registry."""
+    """Tests for CycloneDXCargoGenerator priority in registry.
+
+    Forces ``_CARGO_CYCLONEDX_AVAILABLE=True`` so ``get_generators_for`` (which
+    filters on ``supports()``) includes the cargo generator regardless of
+    whether the Rust tool is installed in the test env.
+    """
 
     def test_cargo_generator_is_registered(self):
         """Test that CycloneDXCargoGenerator is in default registry."""
@@ -202,6 +216,28 @@ class TestCycloneDXCargoGeneratorPriority(unittest.TestCase):
         self.assertEqual(generators[0].name, "cyclonedx-cargo")
         self.assertEqual(generators[1].name, "cdxgen-fs")
         self.assertEqual(generators[2].name, "trivy-fs")
+
+
+class TestCycloneDXCargoToolAvailability(unittest.TestCase):
+    """Availability-guard regression tests (kept out of the class-patched
+    classes so the False case isn't masked by a class-level True patch)."""
+
+    @patch("sbomify_action._generation.generators.cyclonedx_cargo._CARGO_CYCLONEDX_AVAILABLE", False)
+    def test_does_not_support_when_tool_missing(self):
+        """When cargo-cyclonedx isn't installed, supports() must return False so
+        the orchestrator falls through to a generic generator instead of
+        picking cargo-cyclonedx and failing at generate() time with a spurious
+        ERROR. Mirrors the cyclonedx-py / syft availability guards."""
+        generator = CycloneDXCargoGenerator()
+        gen_input = GenerationInput(lock_file="/path/to/Cargo.lock", output_format="cyclonedx")
+        self.assertFalse(generator.supports(gen_input))
+
+    @patch("sbomify_action._generation.generators.cyclonedx_cargo._CARGO_CYCLONEDX_AVAILABLE", True)
+    def test_supports_when_tool_available(self):
+        """Sanity: with the tool available, the Cargo.lock is supported."""
+        generator = CycloneDXCargoGenerator()
+        gen_input = GenerationInput(lock_file="/path/to/Cargo.lock", output_format="cyclonedx")
+        self.assertTrue(generator.supports(gen_input))
 
 
 class TestCycloneDXCargoGeneratorCommandLine(unittest.TestCase):

--- a/tests/test_enrichment_module.py
+++ b/tests/test_enrichment_module.py
@@ -110,6 +110,13 @@ class TestNormalizedMetadata:
         metadata = NormalizedMetadata(supplier="Test Org")
         assert metadata.has_data() is True
 
+    def test_has_data_with_cle_release_date(self):
+        """has_data must count cle_release_date — a source returning only a
+        release date (and nothing else) carries meaningful data and must not
+        be discarded as empty."""
+        metadata = NormalizedMetadata(cle_release_date="2024-01-15")
+        assert metadata.has_data() is True
+
     def test_has_data_empty(self):
         """Test has_data returns False when no data is present."""
         metadata = NormalizedMetadata()

--- a/tests/test_generation_plugin.py
+++ b/tests/test_generation_plugin.py
@@ -1,5 +1,6 @@
 """Tests for the SBOM generation plugin architecture."""
 
+import subprocess
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -22,6 +23,40 @@ from sbomify_action._generation.generators import (
     TrivyImageGenerator,
 )
 from sbomify_action.exceptions import SBOMGenerationError, ToolNotAvailableError
+
+
+class TestRunCommandErrorLogging(unittest.TestCase):
+    """run_command's ``log_errors`` flag controls the severity of a failed
+    subprocess. A priority-chain fallback that fails gracefully (eg cdxgen on
+    a Python lockfile, where cyclonedx-py/syft take over) passes
+    ``log_errors=False`` so it logs at DEBUG instead of spamming red ERROR
+    lines on the happy path — while still raising ``SBOMGenerationError`` so
+    the orchestrator can try the next generator."""
+
+    @patch("sbomify_action._generation.utils.subprocess.run")
+    def test_log_errors_false_logs_debug_not_error(self, mock_run: MagicMock) -> None:
+        from sbomify_action._generation import utils
+
+        mock_run.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd=["cdxgen", "."], stderr="yargs-parser node version error", output=""
+        )
+        with patch.object(utils, "logger") as mock_logger:
+            with self.assertRaises(SBOMGenerationError):
+                utils.run_command(["cdxgen", "."], "cdxgen", log_errors=False)
+            # The failure must NOT reach ERROR (neither the summary line nor
+            # log_command_error's body, both of which route through utils.logger).
+            mock_logger.error.assert_not_called()
+            self.assertTrue(mock_logger.debug.called, "expected the failure to be logged at DEBUG")
+
+    @patch("sbomify_action._generation.utils.subprocess.run")
+    def test_log_errors_true_still_logs_error(self, mock_run: MagicMock) -> None:
+        from sbomify_action._generation import utils
+
+        mock_run.side_effect = subprocess.CalledProcessError(returncode=1, cmd=["syft", "."], stderr="boom", output="")
+        with patch.object(utils, "logger") as mock_logger:
+            with self.assertRaises(SBOMGenerationError):
+                utils.run_command(["syft", "."], "syft", log_errors=True)
+            mock_logger.error.assert_called()
 
 
 class TestFormatVersion(unittest.TestCase):

--- a/tests/test_sbomify_api.py
+++ b/tests/test_sbomify_api.py
@@ -217,9 +217,19 @@ def test_get_component_id_by_name_returns_none_when_missing() -> None:
 
 def test_create_component_success() -> None:
     client, _ = _client_with([_FakeResponse(201, {"id": "new-id", "name": "foo"})])
-    comp_id, was_created = client.create_component("foo", component_type="sbom")
+    comp_id, was_created = client.create_component("foo", component_type="bom")
     assert comp_id == "new-id"
     assert was_created is True
+
+
+def test_create_component_rejects_invalid_type_without_request() -> None:
+    """A component_type the backend doesn't accept (e.g. the old "sbom"
+    literal) must fail fast client-side with a clear ValueError, never
+    reaching the network to come back as an opaque 422."""
+    client, session = _client_with([])
+    with pytest.raises(ValueError, match="Invalid component_type 'sbom'"):
+        client.create_component("foo", component_type="sbom")
+    session.request.assert_not_called()
 
 
 def test_create_component_recovers_from_duplicate_name() -> None:
@@ -232,7 +242,7 @@ def test_create_component_recovers_from_duplicate_name() -> None:
             ),
         ]
     )
-    comp_id, was_created = client.create_component("foo", component_type="sbom")
+    comp_id, was_created = client.create_component("foo", component_type="bom")
     assert comp_id == "existing-id"
     assert was_created is False
 
@@ -240,13 +250,89 @@ def test_create_component_recovers_from_duplicate_name() -> None:
 def test_create_component_plan_limit() -> None:
     client, _ = _client_with([_FakeResponse(403, {"detail": "maximum components reached"})])
     with pytest.raises(PlanLimitError):
-        client.create_component("foo", component_type="sbom")
+        client.create_component("foo", component_type="bom")
+
+
+def test_create_component_403_validation_list_is_not_plan_limit() -> None:
+    """A 403 whose detail is a pydantic *list* (not the plain plan-limit
+    string) must raise APIError — even when the collapsed message contains
+    the word 'maximum' (eg a max-length validation error). Plan-limit
+    detection keys off the raw string detail, not the cleaned text, so this
+    can't be misclassified as a PlanLimitError."""
+    client, _ = _client_with(
+        [
+            _FakeResponse(
+                403,
+                {
+                    "detail": [
+                        {
+                            "type": "string_too_long",
+                            "loc": ["body", "payload", "name"],
+                            "msg": "String should have at most 255 characters (maximum length)",
+                        }
+                    ]
+                },
+            )
+        ]
+    )
+    with pytest.raises(APIError) as exc:
+        client.create_component("foo", component_type="bom")
+    assert not isinstance(exc.value, PlanLimitError)
+    # The readable message is still surfaced.
+    assert "name:" in str(exc.value)
+
+
+def test_clean_validation_error_collapses_pydantic_list() -> None:
+    """A pydantic/django-ninja 422 'detail' (list of per-field error dicts)
+    collapses to readable '<field>: <msg>' text instead of a raw repr dump."""
+    detail = [
+        {
+            "type": "enum",
+            "loc": ["body", "payload", "component_type"],
+            "msg": "Input should be 'document' or 'bom'",
+            "ctx": {"expected": "'document' or 'bom'"},
+        }
+    ]
+    cleaned = SbomifyApiClient._clean_validation_error(detail)
+    assert cleaned == "component_type: Input should be 'document' or 'bom'"
+
+
+def test_clean_validation_error_passthrough_and_none() -> None:
+    assert SbomifyApiClient._clean_validation_error("plain message") == "plain message"
+    assert SbomifyApiClient._clean_validation_error(None) is None
+    assert SbomifyApiClient._clean_validation_error([]) is None
+
+
+def test_create_component_422_renders_clean_detail() -> None:
+    """An unexpected 422 (non-DUPLICATE_NAME) surfaces readable text in the
+    raised APIError — not a raw Python dict repr."""
+    client, _ = _client_with(
+        [
+            _FakeResponse(
+                422,
+                {
+                    "detail": [
+                        {
+                            "type": "enum",
+                            "loc": ["body", "payload", "component_type"],
+                            "msg": "Input should be 'document' or 'bom'",
+                        }
+                    ]
+                },
+            )
+        ]
+    )
+    with pytest.raises(APIError) as exc:
+        client.create_component("foo", component_type="bom")
+    message = str(exc.value)
+    assert "component_type: Input should be 'document' or 'bom'" in message
+    assert "{'type'" not in message  # no raw dict repr leaked to the user
 
 
 def test_get_or_create_component_uses_cache() -> None:
     client, session = _client_with([])
     cache = {"foo": "cached-id"}
-    comp_id, created = client.get_or_create_component("foo", cache, component_type="sbom")
+    comp_id, created = client.get_or_create_component("foo", cache, component_type="bom")
     assert comp_id == "cached-id"
     assert created is False
     session.request.assert_not_called()

--- a/tests/test_upload_module.py
+++ b/tests/test_upload_module.py
@@ -1009,6 +1009,35 @@ class TestDependencyTrackErrors(unittest.TestCase):
             Path(sbom_file).unlink()
 
     @patch("sbomify_action._upload.destinations.dependency_track.requests.put")
+    def test_upload_other_request_exception_returns_failure(self, mock_put):
+        """A non-ConnectionError/Timeout transport failure (eg SSLError) must
+        return a clean UploadResult.failure_result, not propagate and crash
+        the upload step."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"bomFormat": "CycloneDX", "specVersion": "1.6"}, f)
+            sbom_file = f.name
+
+        try:
+            import requests
+
+            mock_put.side_effect = requests.exceptions.SSLError("certificate verify failed")
+
+            config = DependencyTrackConfig(
+                api_key="test-key",
+                api_url="https://dtrack.example.com/api",
+                project_id="project-uuid",
+            )
+            dest = DependencyTrackDestination(config=config)
+            input = UploadInput(sbom_file=sbom_file, sbom_format="cyclonedx")
+
+            result = dest.upload(input)  # must not raise
+
+            self.assertFalse(result.success)
+            self.assertIn("failed", result.error_message.lower())
+        finally:
+            Path(sbom_file).unlink()
+
+    @patch("sbomify_action._upload.destinations.dependency_track.requests.put")
     def test_upload_timeout_error(self, mock_put):
         """Test upload with timeout error."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:

--- a/tests/test_wizard_state.py
+++ b/tests/test_wizard_state.py
@@ -386,3 +386,42 @@ def test_apply_writes_sbomify_json_when_absent(tmp_path: Path) -> None:
     written = json.loads((tmp_path / "sbomify.json").read_text(encoding="utf-8"))
     assert written["supplier"] == {"name": "Acme"}
     assert WIZARD_JSON_SENTINEL_KEY in written  # wizard stamped it for future ownership
+
+
+def test_apply_creates_component_with_bom_type(tmp_path: Path) -> None:
+    """apply_plan must create components with component_type='bom' (the backend
+    enum is {bom, document}; the old 'sbom' 422'd). Pins the apply.py call-site
+    directly — the other component-type tests cover the client + yocto facade,
+    not this path."""
+    facts = RepoFacts(
+        repo_root=tmp_path,
+        is_git=True,
+        remote_url="git@github.com:acme/widget.git",
+        suggested_repo_name="widget",
+        default_branch="main",
+        current_branch="main",
+        has_release_tags=False,
+        owner_repo_slug="acme/widget",
+    )
+    state = WizardState(facts=facts)
+    api = MagicMock()
+    api.get_or_create_component.return_value = ("comp-id-1", True)
+    state.api = api
+    state.workspace = WorkspaceSnapshot()
+    lockfile = DiscoveredLockfile(
+        path=tmp_path / "uv.lock", rel_path=Path("uv.lock"), ecosystem="python", suggested_name="widget"
+    )
+    state.plan = Plan(create_components=[PlannedComponent(lockfile=lockfile, name="widget")], augmentation="skip")
+
+    opts = WizardOptions(
+        token=None,
+        api_base_url="https://api.test",
+        repo_root=tmp_path,
+        output_dir=tmp_path / ".github" / "workflows",
+        dry_run=False,
+    )
+
+    apply_plan(state, opts)
+
+    api.get_or_create_component.assert_called_once()
+    assert api.get_or_create_component.call_args.kwargs.get("component_type") == "bom"

--- a/tests/test_wizard_state.py
+++ b/tests/test_wizard_state.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
+from sbomify_action.cli.wizard.apply import apply_plan
 from sbomify_action.cli.wizard.io import (
     WIZARD_HEADER_SENTINEL,
     WIZARD_JSON_SENTINEL_KEY,
@@ -17,6 +20,7 @@ from sbomify_action.cli.wizard.io import (
     write_workflow,
 )
 from sbomify_action.cli.wizard.options import WizardOptions
+from sbomify_action.cli.wizard.repo_facts import gather_repo_facts
 from sbomify_action.cli.wizard.state import (
     DiscoveredLockfile,
     Plan,
@@ -282,3 +286,103 @@ def test_sbomify_json_has_wizard_sentinel_helpers(tmp_path: Path) -> None:
     with_sentinel = tmp_path / "sent.json"
     with_sentinel.write_text('{"' + WIZARD_JSON_SENTINEL_KEY + '": {}}', encoding="utf-8")
     assert sbomify_json_has_wizard_sentinel(with_sentinel) is True
+
+
+# ----------------------------------------------------------------------
+# P1: existing sbomify.json detection + non-dead-ending apply
+
+
+def test_gather_repo_facts_detects_existing_sbomify_json(tmp_path: Path) -> None:
+    """has_sbomify_json reflects whether a repo-root sbomify.json exists."""
+    assert gather_repo_facts(tmp_path).has_sbomify_json is False
+
+    (tmp_path / "sbomify.json").write_text('{"supplier": {"name": "Acme"}}', encoding="utf-8")
+    assert gather_repo_facts(tmp_path).has_sbomify_json is True
+
+
+def test_repo_facts_has_sbomify_json_defaults_false(tmp_path: Path) -> None:
+    """The dataclass default keeps existing construct sites working."""
+    assert _facts(tmp_path).has_sbomify_json is False
+
+
+def test_apply_keeps_handauthored_sbomify_json_and_still_writes_workflow(tmp_path: Path) -> None:
+    """A pre-existing non-wizard sbomify.json must NOT dead-end apply.
+
+    Before the fix, apply raised on the ownership check and never wrote the
+    workflow. Now it keeps the user's file untouched (the action reads it at
+    run time), logs a warning, and proceeds to write the workflow + create
+    components.
+    """
+    # Hand-authored sbomify.json with a field the wizard form doesn't surface
+    # (``licenses``) — proving we never clobber/strip it.
+    handauthored = {"supplier": {"name": "Lithium Project"}, "licenses": ["MIT"]}
+    json_path = tmp_path / "sbomify.json"
+    json_path.write_text(json.dumps(handauthored), encoding="utf-8")
+
+    facts = RepoFacts(
+        repo_root=tmp_path,
+        is_git=True,
+        remote_url="git@github.com:acme/widget.git",
+        suggested_repo_name="widget",
+        default_branch="main",
+        current_branch="main",
+        has_release_tags=False,
+        owner_repo_slug="acme/widget",
+        has_sbomify_json=True,
+    )
+    state = WizardState(facts=facts)
+    state.api = MagicMock()  # not exercised: no product, no components
+    state.workspace = WorkspaceSnapshot()
+    state.plan = Plan(augmentation="json_config", sbomify_json_data={"supplier": {"name": "edited"}})
+
+    opts = WizardOptions(
+        token=None,
+        api_base_url="https://api.test",
+        repo_root=tmp_path,
+        output_dir=tmp_path / ".github" / "workflows",
+        dry_run=False,
+    )
+
+    logs: list[tuple[str, str]] = []
+    apply_plan(state, opts, log=lambda kind, msg: logs.append((kind, msg)))
+
+    # The hand-authored file is byte-for-byte preserved (no sentinel injected,
+    # licenses intact).
+    assert json.loads(json_path.read_text(encoding="utf-8")) == handauthored
+    # A warning was surfaced, not a fatal error.
+    assert any(kind == "warning" and "wizard" in msg.lower() for kind, msg in logs)
+    # The workflow still got written — apply did not dead-end.
+    assert (tmp_path / ".github" / "workflows" / "sboms.yml").is_file()
+
+
+def test_apply_writes_sbomify_json_when_absent(tmp_path: Path) -> None:
+    """With no pre-existing file, apply writes a wizard-stamped sbomify.json."""
+    facts = RepoFacts(
+        repo_root=tmp_path,
+        is_git=True,
+        remote_url="git@github.com:acme/widget.git",
+        suggested_repo_name="widget",
+        default_branch="main",
+        current_branch="main",
+        has_release_tags=False,
+        owner_repo_slug="acme/widget",
+        has_sbomify_json=False,
+    )
+    state = WizardState(facts=facts)
+    state.api = MagicMock()
+    state.workspace = WorkspaceSnapshot()
+    state.plan = Plan(augmentation="json_config", sbomify_json_data={"supplier": {"name": "Acme"}})
+
+    opts = WizardOptions(
+        token=None,
+        api_base_url="https://api.test",
+        repo_root=tmp_path,
+        output_dir=tmp_path / ".github" / "workflows",
+        dry_run=False,
+    )
+
+    apply_plan(state, opts)
+
+    written = json.loads((tmp_path / "sbomify.json").read_text(encoding="utf-8"))
+    assert written["supplier"] == {"name": "Acme"}
+    assert WIZARD_JSON_SENTINEL_KEY in written  # wizard stamped it for future ownership

--- a/tests/test_wizard_textual.py
+++ b/tests/test_wizard_textual.py
@@ -123,6 +123,31 @@ async def test_configure_sbomify_json_prefills_from_existing_file(
         assert pressed is not None and pressed.id == "phase-build"
 
 
+async def test_configure_sbomify_json_tolerates_unreadable_existing_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """P1 robustness: a malformed / non-object sbomify.json must NOT crash the
+    Configure form — _load_from_disk returns None and the form opens blank."""
+    from textual.widgets import Input
+
+    from sbomify_action.cli.wizard.screens.configure_sbomify_json import ConfigureSbomifyJsonScreen
+
+    for bad_content in ("this is not json", "[1, 2, 3]"):  # malformed, then a JSON array (non-dict)
+        _stub_discovery(monkeypatch, [])
+        (tmp_path / "sbomify.json").write_text(bad_content, encoding="utf-8")
+
+        app = WizardApp(_opts(tmp_path))
+        async with app.run_test(size=(120, 60)) as pilot:
+            assert app.state.facts.has_sbomify_json is True  # the (bad) file exists
+            await app.push_screen(ConfigureSbomifyJsonScreen())
+            await pilot.pause()
+
+            screen = app.screen
+            assert isinstance(screen, ConfigureSbomifyJsonScreen)
+            # No crash, and nothing got pre-filled from the unreadable file.
+            assert screen.query_one("#sup-name", Input).value == ""
+
+
 async def test_escape_from_authenticate_returns_to_discover(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Regression: the password Input on AuthenticateScreen must not eat
     Escape. Without priority=True on the screen's Escape binding the

--- a/tests/test_wizard_textual.py
+++ b/tests/test_wizard_textual.py
@@ -8,6 +8,7 @@ visual fidelity checks.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -72,6 +73,54 @@ async def test_app_starts_and_renders_welcome(tmp_path: Path, monkeypatch: pytes
 
         assert isinstance(app.screen, WelcomeScreen)
         await pilot.pause()
+
+
+async def test_configure_sbomify_json_prefills_from_existing_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """P1: when the repo already ships a sbomify.json, the Configure
+    (sbomify.json) form seeds itself from that file instead of opening blank."""
+    from textual.widgets import Input, RadioSet
+
+    from sbomify_action.cli.wizard.screens.configure_sbomify_json import ConfigureSbomifyJsonScreen
+
+    _stub_discovery(monkeypatch, [])
+    (tmp_path / "sbomify.json").write_text(
+        json.dumps(
+            {
+                "supplier": {
+                    "name": "Lithium Project",
+                    "url": ["https://example.com"],
+                    "contacts": [{"name": "Lithium Project", "email": "sec@example.com"}],
+                },
+                "authors": [{"name": "Rana", "email": "rana@example.com"}],
+                "security_contact": "https://example.com/security",
+                "lifecycle_phase": "build",
+                "licenses": ["MIT"],  # a field the form doesn't render — must not crash prefill
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # WizardApp.__init__ runs gather_repo_facts → has_sbomify_json=True.
+    app = WizardApp(_opts(tmp_path))
+    async with app.run_test(size=(120, 60)) as pilot:
+        assert app.state.facts.has_sbomify_json is True
+        await app.push_screen(ConfigureSbomifyJsonScreen())
+        await pilot.pause()
+
+        screen = app.screen
+        assert isinstance(screen, ConfigureSbomifyJsonScreen)
+        assert screen.query_one("#sup-name", Input).value == "Lithium Project"
+        assert screen.query_one("#sup-url", Input).value == "https://example.com"
+        assert screen.query_one("#sup-email", Input).value == "sec@example.com"
+        assert screen.query_one("#author-name", Input).value == "Rana"
+        assert screen.query_one("#author-email", Input).value == "rana@example.com"
+        assert screen.query_one("#security-contact", Input).value == "https://example.com/security"
+        # The lifecycle RadioSet branch of _populate_from is exercised too:
+        # the on-disk "build" phase must be the pressed radio.
+        pressed = screen.query_one("#lifecycle", RadioSet).pressed_button
+        assert pressed is not None and pressed.id == "phase-build"
 
 
 async def test_escape_from_authenticate_returns_to_discover(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_yocto_api.py
+++ b/tests/test_yocto_api.py
@@ -59,10 +59,10 @@ def test_create_component_delegates(stub_client: MagicMock) -> None:
 
     assert comp_id == "new-id"
     assert was_created is True
-    # Yocto must pass component_type='sbom' — the pre-consolidation Yocto
-    # code hard-coded this on every payload, and changing it would silently
-    # mis-categorise every Yocto component on the backend.
-    stub_client.create_component.assert_called_once_with("busybox", component_type="sbom")
+    # Yocto must pass component_type='bom' — the backend ComponentType enum
+    # is {bom, document}; there is no "sbom" value (it 422s), so the facade
+    # pins "bom" explicitly rather than relying on a client default.
+    stub_client.create_component.assert_called_once_with("busybox", component_type="bom")
 
 
 def test_patch_component_visibility_delegates(stub_client: MagicMock) -> None:
@@ -81,7 +81,7 @@ def test_iter_components_delegates(stub_client: MagicMock) -> None:
 
 def test_get_or_create_component_cache_hit(stub_client: MagicMock) -> None:
     # The client provides its own cache check; verify the facade still passes
-    # the cache through and pins component_type='sbom' (legacy Yocto type).
+    # the cache through and pins component_type='bom' (the backend BOM type).
     stub_client.get_or_create_component.return_value = ("cached", False)
 
     cache: dict[str, str] = {"busybox": "cached"}
@@ -89,7 +89,7 @@ def test_get_or_create_component_cache_hit(stub_client: MagicMock) -> None:
 
     assert comp_id == "cached"
     assert was_created is False
-    stub_client.get_or_create_component.assert_called_once_with("busybox", cache, component_type="sbom")
+    stub_client.get_or_create_component.assert_called_once_with("busybox", cache, component_type="bom")
 
 
 def test_get_or_create_component_cache_miss(stub_client: MagicMock) -> None:
@@ -100,7 +100,7 @@ def test_get_or_create_component_cache_miss(stub_client: MagicMock) -> None:
 
     assert comp_id == "new-id"
     assert was_created is True
-    stub_client.get_or_create_component.assert_called_once_with("busybox", cache, component_type="sbom")
+    stub_client.get_or_create_component.assert_called_once_with("busybox", cache, component_type="bom")
 
 
 def test_create_component_error_propagates(stub_client: MagicMock) -> None:


### PR DESCRIPTION
## Summary

Fixes on top of the wizard + consolidated API client feature, targeting its branch (`feat/wizard-and-shared-api-client`) directly so the diff is **just these 6 commits**, not the whole feature. (Supersedes #239, which was opened against `master` and so duplicated the entire feature / #238.)

These can be merged into #238's branch, or cherry-picked onto it.

## Commits

- **`dc4b02c` fix(wizard): valid component_type, existing sbomify.json, error polish**
  - `component_type` `"sbom"` → `"bom"` — the backend `ComponentType` enum is `{bom, document}`; `"sbom"` returned **HTTP 422 on every wizard onboarding and Yocto upload**. Adds a client-side `VALID_COMPONENT_TYPES` guard so a bad literal fails fast instead of as an opaque 422.
  - Wizard now detects and pre-fills an existing repo-root `sbomify.json`, and apply no longer dead-ends on a hand-authored one (keeps it as-is — the action reads it at run time — and logs the unwritten values so they're recoverable).
  - Readable API validation errors (collapses pydantic 422 list-detail into `field: msg`); `run_command(log_errors=)` so cdxgen's expected fallback failures don't spam ERROR; corrected the misleading token-scope warning copy.
- **`cee6d02` fix: harden enrichment, dtrack, cargo, chainguard edge cases** — `has_data()` counts `cle_release_date`; dtrack catches base `RequestException`; cargo generator gets the `check_tool_available` guard its siblings have; chainguard reads `digest` via `.get()`.
- **`55f1a1b` ci: add textual to mypy pre-commit deps so the hook passes** — the mypy hook's isolated env was missing `textual`, so it saw the wizard's Textual base classes as `Any` and failed on every commit (in-venv mypy was already clean). Pinned to `==8.2.7` (the uv.lock version).
- **`f29d96d` refactor: address comprehensive-review findings** — explicit warning when wizard edits aren't written to a hand-authored `sbomify.json`; `log_errors` also covers timeout/missing-binary; regression tests for the apply call-site, `_load_from_disk` error paths, and the chainguard provenance digest path; assorted polish.
- **`a2664dd` docs(wizard)** + **`c611937` fix(wizard)** — Copilot-review follow-ups: corrected stale `.bak` docstrings to match `io.py`; surface the unwritten `sbomify.json` payload in the apply log; document the chainguard `.get("digest")` continue-on-missing semantics.

## Testing

- Full suite: **2315 passed**, 4 skipped.
- `pre-commit run --all-files`: ruff, ruff-format, mypy all green.
- Verified end-to-end via the real Textual TUI and a live config matrix (OIDC/token × trunk/tag/manual × cyclonedx/spdx/both × skip/profile/json_config) against a local sbomify backend.

## Not included

The `sboms.yml` source-SBOM coverage regression from `ee4f28d` (prod + JS self-SBOM jobs replaced by a `ca-certificates` wizard test artifact) is **out of scope** for these fixes and is tracked separately on #238 for the feature author.
