### PR TITLE
fix: bundle wizard styles.tcss in published package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ dev = [
 include = [
     "sbomify_action/**/*.py",
     "sbomify_action/**/*.json",
+    "sbomify_action/**/*.tcss",
     "sbomify-action.cdx.json",
 ]
 core-metadata-version = "2.3"
@@ -83,6 +84,7 @@ sbom-files = ["sbomify-action.cdx.json"]
 include = [
     "sbomify_action/**/*.py",
     "sbomify_action/**/*.json",
+    "sbomify_action/**/*.tcss",
 ]
 
 [build-system]


### PR DESCRIPTION
## Problem

Running the wizard from the published Docker image crashes immediately:

```
StylesheetError: unable to read CSS file
'/opt/venv/lib/python3.13/site-packages/sbomify_action/cli/wizard/styles.tcss'
```

The Textual wizard loads its stylesheet from `sbomify_action/cli/wizard/styles.tcss` (`WizardApp.CSS_PATH`), but the hatchling build config only included `*.py` and `*.json` files. The `.tcss` asset was silently dropped from the wheel — so the wizard worked when run from source but broke once installed via `pip` in the Docker image / PyPI package.

## Fix

Add `sbomify_action/**/*.tcss` to the `[tool.hatch.build.targets.sdist]` and `[tool.hatch.build]` include lists (the wheel target inherits the latter). Confirmed no other non-`.py`/`.json` assets exist in the package.

## Verification

- Built the wheel: `styles.tcss` is now bundled.
- Built the Docker image and confirmed the file lands at `/opt/venv/.../wizard/styles.tcss`.
- `Stylesheet().read(path)` succeeds in-container, and `sbomify-action wizard` now reaches the TUI driver instead of crashing at CSS load.

> Requires a new release for the fix to reach `ghcr.io/sbomify/sbomify-action:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)