### PR TITLE
fix: render wizard in truecolor inside Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -200,6 +200,14 @@ RUN conan profile detect --force
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 
+# Advertise 24-bit colour so the Textual wizard renders the sbomify brand
+# palette correctly. `docker run -it` allocates a TTY with TERM=xterm and
+# never sets COLORTERM, so Rich/Textual would otherwise detect only the
+# 16-colour "standard" system and downsample the brand hex colours
+# (#141035, #8A7DFF, …) to muddy ANSI greys. COLORTERM is the deciding
+# lever (Docker never sets it, so the image value always wins).
+ENV COLORTERM=truecolor
+
 # Runtime version information (from build args)
 ENV SBOMIFY_GITHUB_ACTION_VERSION=${VERSION}
 ENV SBOMIFY_GITHUB_ACTION_COMMIT_SHA=${COMMIT_SHA}

--- a/Dockerfile
+++ b/Dockerfile
@@ -205,7 +205,8 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # never sets COLORTERM, so Rich/Textual would otherwise detect only the
 # 16-colour "standard" system and downsample the brand hex colours
 # (#141035, #8A7DFF, …) to muddy ANSI greys. COLORTERM is the deciding
-# lever (Docker never sets it, so the image value always wins).
+# lever: Docker never sets it implicitly, so this image value is the
+# effective default (a runtime `-e COLORTERM=…` still overrides it).
 ENV COLORTERM=truecolor
 
 # Runtime version information (from build args)


### PR DESCRIPTION
## Problem

The Textual setup wizard's sbomify brand palette renders as washed-out greys when launched via the README's `docker run -it … sbomify-action wizard` command — the layout, borders, and panels are all correct (recent `.tcss` packaging fixes worked), but the colors are wrong.

## Root cause

It's a color-depth detection issue, not a styling one. Docker's `-it` allocates a TTY with `TERM=xterm` and **never sets `COLORTERM`**. Confirmed with Rich's own detection inside that environment:

| Env (inside container)                          | Detected color system |
|-------------------------------------------------|-----------------------|
| `TERM=xterm`, no `COLORTERM` (docker `-it` default) | `standard` (16-color) ← the bug |
| `TERM=xterm-256color`                            | `256`                 |
| `COLORTERM=truecolor`                            | `truecolor` (24-bit)  |

With only the 16-color `standard` system, the brand hex colors (`#141035` background, `#8A7DFF` accent, …) get downsampled to the nearest ANSI greys.

## Fix

Set `ENV COLORTERM=truecolor` in the final image stage. Because the wizard renders *inside* the container and Docker never sets `COLORTERM` itself, the image value always wins — so the **existing README command works unchanged**, with no `-e` flag needed.

Color is only restored when the host terminal supports truecolor (modern terminals do); this is strictly an improvement over the prior behavior, which degraded even on capable terminals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)