### PR TITLE
fix(wizard): derive repo name from git remote; ship git in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -173,6 +173,14 @@ LABEL com.sbomify.maintainer="sbomify <hello@sbomify.com>" \
       com.sbomify.vcs.branch="${VCS_REF}" \
       com.sbomify.vcs.commit="${COMMIT_SHA}"
 
+# git is needed at runtime: the wizard reads repo facts (remote name,
+# branch, visibility) from the bind-mounted workspace, and slim images
+# don't ship it. Without it those facts silently degrade to folder-name
+# and "unknown" visibility.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    rm -rf /var/lib/apt/lists/*
+
 # Note: Java/Maven is installed on-demand at runtime when processing Java/Scala projects
 # This reduces the base image size by ~330MB for non-Java workloads
 

--- a/README.md
+++ b/README.md
@@ -634,6 +634,8 @@ sbomify-license-db --distro alpine --version 3.20 --output alpine-3.20.json.gz
 
 </details>
 
+<a id="lifecycle-enrichment"></a>
+
 <details>
 <summary><strong>Lifecycle enrichment details</strong></summary>
 
@@ -779,6 +781,8 @@ All timestamps are in UTC (ISO 8601 format with Z suffix).
 
 </details>
 
+<a id="product-releases"></a>
+
 <details>
 <summary><strong>Product releases</strong></summary>
 
@@ -917,6 +921,8 @@ Use `actions/cache` before calling the sbomify action:
 For caching in other CI environments (GitLab, Bitbucket, Docker), see [Other CI/CD Platforms](#other-cicd-platforms).
 
 </details>
+
+<a id="other-cicd-platforms"></a>
 
 <details>
 <summary><strong>Other CI/CD platforms</strong> (GitLab, Bitbucket, Docker, pip)</summary>

--- a/sbomify_action/cli/wizard/repo_facts.py
+++ b/sbomify_action/cli/wizard/repo_facts.py
@@ -33,8 +33,13 @@ def gather_repo_facts(repo_root: Path) -> RepoFacts:
     if is_git:
         remote_url = _git(["config", "--get", "remote.origin.url"], cwd=repo_root) or None
         if remote_url:
+            # owner_repo_slug stays github-only (it feeds OIDC binding
+            # instructions where a wrong value is harmful), but the bare
+            # repo *name* can be read from any remote — GitLab, Bitbucket,
+            # self-hosted, nested groups — so we don't fall back to the
+            # checkout's directory name just because the host isn't github.
             owner_repo_slug = _parse_owner_repo_slug(remote_url)
-            suggested_repo_name = owner_repo_slug.split("/", 1)[1] if owner_repo_slug else None
+            suggested_repo_name = _repo_name_from_remote(remote_url)
         head_ref = _git(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], cwd=repo_root)
         if head_ref and "/" in head_ref:
             default_branch = head_ref.split("/", 1)[1]
@@ -67,10 +72,18 @@ def gather_repo_facts(repo_root: Path) -> RepoFacts:
 
 
 def _git(args: list[str], *, cwd: Path) -> str | None:
-    """Run ``git <args>``; return stripped stdout, or None on any failure."""
+    """Run ``git <args>``; return stripped stdout, or None on any failure.
+
+    ``-c safe.directory=*`` is prepended so the wizard still reads facts
+    when the repo is bind-mounted into a container owned by a different
+    UID than the process — git's "detected dubious ownership" guard would
+    otherwise make every command fail and silently degrade the suggested
+    repo name and visibility to their no-git fallbacks. All commands here
+    are read-only, so disabling the guard for them is safe.
+    """
     try:
         result = subprocess.run(
-            ["git", *args],
+            ["git", "-c", "safe.directory=*", *args],
             cwd=cwd,
             capture_output=True,
             text=True,
@@ -112,6 +125,27 @@ def _parse_owner_repo_slug(remote_url: str) -> str | None:
     if not match:
         return None
     return f"{match.group('owner')}/{match.group('repo')}"
+
+
+def _repo_name_from_remote(remote_url: str) -> str | None:
+    """Extract the bare repository name from any git remote URL.
+
+    Host-agnostic, unlike :func:`_parse_owner_repo_slug`: it takes the
+    final path segment and strips a trailing ``.git``, so it works for
+    SSH and HTTPS remotes on GitHub, GitLab, Bitbucket, self-hosted
+    forges, and nested-group URLs alike. Only the leaf name is used (for
+    the suggested component name), so nested groups are not a problem
+    here the way they are for the OIDC slug.
+
+    Returns None when nothing usable remains.
+    """
+    cleaned = remote_url.strip().rstrip("/")
+    if cleaned.endswith(".git"):
+        cleaned = cleaned[: -len(".git")]
+    # The repo name follows the final path separator ("/") or the
+    # scp-style host separator (":") in "git@host:owner/repo".
+    name = re.split(r"[/:]", cleaned)[-1].strip()
+    return name or None
 
 
 # Matches both SSH (git@github.com:...) and HTTPS

--- a/tests/test_wizard_discovery.py
+++ b/tests/test_wizard_discovery.py
@@ -14,6 +14,7 @@ from sbomify_action.cli.wizard.io import WIZARD_HEADER_SENTINEL
 from sbomify_action.cli.wizard.repo_facts import (
     _is_github_remote,
     _parse_owner_repo_slug,
+    _repo_name_from_remote,
     detect_visibility,
     gather_repo_facts,
 )
@@ -157,6 +158,35 @@ def test_gather_repo_facts_non_git_dir(tmp_path: Path) -> None:
 )
 def test_parse_owner_repo_slug(url: str, expected: str | None) -> None:
     assert _parse_owner_repo_slug(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("git@github.com:acme/widget.git", "widget"),
+        ("https://github.com/acme/widget.git", "widget"),
+        ("https://x:y@github.com/acme/widget", "widget"),
+        # Unlike the OIDC slug, the bare name is read from *any* remote.
+        ("ssh://git@gitlab.example.com/acme/widget.git", "widget"),
+        ("https://git.example.com/team/group/subgroup/repo.git", "repo"),
+        ("git@bitbucket.org:acme/widget.git", "widget"),
+        ("https://github.com/acme/widget/", "widget"),
+        ("", None),
+    ],
+)
+def test_repo_name_from_remote(url: str, expected: str | None) -> None:
+    assert _repo_name_from_remote(url) == expected
+
+
+def test_gather_repo_facts_non_github_remote_uses_git_name(tmp_path: Path) -> None:
+    """A non-github remote still yields a git-derived name, not the folder."""
+    _init_git_repo(tmp_path, remote="git@gitlab.com:acme/cool-widget.git")
+    facts = gather_repo_facts(tmp_path)
+    assert facts.is_git is True
+    # owner_repo_slug stays github-only…
+    assert facts.owner_repo_slug is None
+    # …but the suggested name comes from the remote, not tmp_path.name.
+    assert facts.suggested_repo_name == "cool-widget"
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The wizard's **Repository** line was naive: it only used the git remote when that remote was a `github.com` URL, and otherwise fell back to the checkout's **folder name**. Worse, when git facts couldn't be read at all (the common case inside the published Docker image), it silently degraded to folder-name *and* a permanent **Visibility: unknown**.

Root cause for the Docker case: the final runtime stage (`python:3.13-slim-trixie`) **doesn't ship `git`**, so every git call hit `FileNotFoundError`. And even with git present, the container runs as root against a host-owned bind mount, which trips git's *dubious-ownership* guard.

## Changes

- **`repo_facts`**: new `_repo_name_from_remote()` derives the bare repo name from *any* remote (GitLab, Bitbucket, self-hosted, nested groups) host-agnostically. `owner_repo_slug` stays github-only — it feeds OIDC binding instructions where a wrong value is worse than none. Folder name remains the genuine no-git fallback.
- **`repo_facts`**: harden `_git` with `-c safe.directory=*` so a host-owned bind mount accessed by root-in-container doesn't trip git's dubious-ownership guard. All calls here are read-only.
- **`Dockerfile`**: install `git` in the final runtime stage.
- **`README`**: add explicit `<a id>` anchors for the `lifecycle-enrichment`, `product-releases`, and `other-cicd-platforms` `<details>` sections — their internal links were broken because GitHub doesn't anchor `<summary>` text.

## Tests

Added `_repo_name_from_remote` parametrized coverage and a `gather_repo_facts` case asserting a non-github (GitLab) remote yields the git-derived name rather than the folder name. Full wizard suite (88 tests) green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)