### PR TITLE
feat: make the onboarding wizard fit any terminal (responsive TUI)

### DIFF
--- a/sbomify_action/cli/wizard/screens/_base.py
+++ b/sbomify_action/cli/wizard/screens/_base.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable, ClassVar
 
+from textual import events
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.screen import Screen
@@ -25,6 +26,28 @@ if TYPE_CHECKING:
 
 
 TOTAL_STEPS = 8
+
+# Responsive breakpoints (terminal cells). The wizard is a fit-to-viewport
+# TUI — nothing scrolls — so every screen has to render inside whatever the
+# terminal gives us. Three tiers, each guaranteed to fit at its lower bound:
+#
+#   * Below MIN_* even the fully-compacted layout can't fit, so we replace
+#     the body with a "resize your terminal" prompt (k9s / lazygit do the
+#     same). 80x24 is the classic default terminal size.
+#   * Below ROOMY_* we shed the roomy "comfortable" layout: the welcome
+#     "what we'll do" preview (redundant with the progress crumb) is
+#     dropped and paddings tighten, via the ``-compact`` class.
+#   * The welcome mascot is governed separately by ART_* — it's the single
+#     tallest element, but it still fits in far more terminals than the
+#     full comfortable layout does, so we keep showing the art whenever
+#     there's room for it (its own ``-no-art`` opt-out below the bound).
+MIN_WIDTH = 80
+MIN_HEIGHT = 24
+ART_WIDTH = 100
+ART_HEIGHT = 42
+PREVIEW_HEIGHT = 48
+ROOMY_WIDTH = 100
+ROOMY_HEIGHT = 63
 
 
 class WizardScreen(Screen[None]):
@@ -44,7 +67,56 @@ class WizardScreen(Screen[None]):
             if self.step_subtitle:
                 yield Static(self.step_subtitle, classes="wizard-subtitle")
             yield from self.compose_body()
+        # Shown (and the body hidden) only when the terminal is below the
+        # minimum supported size — see ``_apply_responsive``. The text is
+        # filled in on resize so it can quote the live dimensions.
+        yield Static("", id="too-small")
         yield Footer()
+
+    def on_resize(self, event: events.Resize) -> None:
+        self._apply_responsive(event.size.width, event.size.height)
+
+    def _apply_responsive(self, width: int, height: int) -> None:
+        """Toggle responsive classes from the current terminal size.
+
+        Three independent toggles (CSS in ``styles.tcss`` keys off them):
+
+        * ``-tiny`` — below the supported minimum: swap the whole body for
+          a resize prompt.
+        * ``-compact`` — below the roomy bound: drop the "what we'll do"
+          preview and tighten padding so the content still fits.
+        * ``-no-art`` — below the art bound: hide the welcome mascot. Kept
+          separate from ``-compact`` because the art fits in many terminals
+          that are still too short for the full comfortable layout, so a
+          "compact but show the art" middle tier is the common case.
+        * ``-no-preview`` — below the preview bound: hide the welcome "what
+          we'll do" list. Also its own bound (the list is short text that
+          fits well below the roomy layout) so we keep showing it rather
+          than leaving the screen half-empty on a medium-tall terminal.
+        """
+        too_small = width < MIN_WIDTH or height < MIN_HEIGHT
+        roomy = width >= ROOMY_WIDTH and height >= ROOMY_HEIGHT
+        show_art = width >= ART_WIDTH and height >= ART_HEIGHT
+        show_preview = height >= PREVIEW_HEIGHT
+        self.set_class(too_small, "-tiny")
+        self.set_class(not too_small and not roomy, "-compact")
+        self.set_class(not too_small and not show_art, "-no-art")
+        self.set_class(not too_small and not show_preview, "-no-preview")
+        if too_small:
+            try:
+                self.query_one("#too-small", Static).update(self._too_small_markup(width, height))
+            except Exception:  # noqa: BLE001 — node not mounted yet; next resize repaints
+                pass
+
+    @staticmethod
+    def _too_small_markup(width: int, height: int) -> str:
+        """Centered 'please resize' notice quoting the live terminal size."""
+        return (
+            "[b #F4B57F]⚠  Terminal too small[/]\n\n"
+            f"[#CBCCCE]Current size[/]  [b]{width}×{height}[/]\n"
+            f"[#CBCCCE]Minimum size[/]  [b]{MIN_WIDTH}×{MIN_HEIGHT}[/]\n\n"
+            "[#8A7DFF]Resize this window to continue.[/]"
+        )
 
     def compose_body(self) -> ComposeResult:
         """Override to yield body widgets (panels, inputs, tables, …)."""

--- a/sbomify_action/cli/wizard/screens/_base.py
+++ b/sbomify_action/cli/wizard/screens/_base.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Callable, ClassVar
 from textual import events
 from textual.app import ComposeResult
 from textual.containers import Vertical
+from textual.css.query import NoMatches
 from textual.screen import Screen
 from textual.widgets import Button, Footer, Header, RadioSet, Static
 
@@ -105,7 +106,10 @@ class WizardScreen(Screen[None]):
         if too_small:
             try:
                 self.query_one("#too-small", Static).update(self._too_small_markup(width, height))
-            except Exception:  # noqa: BLE001 — node not mounted yet; next resize repaints
+            except NoMatches:
+                # The guard node isn't mounted yet (resize fired mid-compose);
+                # the next resize repaints. Narrow to NoMatches so a real
+                # rendering/markup error still surfaces instead of being swallowed.
                 pass
 
     @staticmethod

--- a/sbomify_action/cli/wizard/screens/_paged.py
+++ b/sbomify_action/cli/wizard/screens/_paged.py
@@ -45,13 +45,21 @@ class PagedFormScreen(WizardScreen):
         # Enter advances / saves; Escape steps back (or pops from page 1).
         # priority=True so a focused Input can't swallow them — navigation
         # is routed through ``route_enter`` so a focused Back button still
-        # acts as Back. (Mirrors the other wizard screens.)
-        Binding("enter", "submit", "Next ▸", show=True, priority=True),
+        # acts as Back. (Mirrors the other wizard screens.) The footer hint
+        # is the page-agnostic "Continue" because Enter means Next on every
+        # page but the last and Save on the last — the primary button itself
+        # carries the precise "Next ▸" / "Save ▸" label.
+        Binding("enter", "submit", "Continue", show=True, priority=True),
         Binding("escape", "back", "Back", show=True, priority=True),
     ]
 
     def __init__(self) -> None:
         super().__init__()
+        # Fail fast on a subclass that forgot PAGE_TITLES — otherwise the
+        # indicator reads "Step 1 of 0" and the navigation math treats page 0
+        # as the last page, silently breaking the form.
+        if not self.PAGE_TITLES:
+            raise ValueError(f"{type(self).__name__} must define a non-empty PAGE_TITLES (one entry per page).")
         self._page = 0
 
     # -- subclass hooks ------------------------------------------------

--- a/sbomify_action/cli/wizard/screens/_paged.py
+++ b/sbomify_action/cli/wizard/screens/_paged.py
@@ -1,0 +1,157 @@
+"""Paged-form scaffolding for the wizard's long data-entry screens.
+
+The wizard is a fit-to-viewport TUI — nothing scrolls — but a couple of
+screens collect more fields than fit on an 80×24 terminal (the contact
+profile form, the sbomify.json form). Rather than scroll them, we split
+them into a handful of fit-to-viewport *pages*: all the panels stay
+mounted (so the inputs keep their values when you move between pages),
+but only the current page is displayed.
+
+A subclass supplies:
+
+* ``PAGE_TITLES`` — one title per page (drives the "Step n of N" header);
+* ``compose_page(index)`` — yields that page's panels;
+* ``save()`` — called when the user presses Next/Save on the last page.
+
+The base renders the page indicator, the mounted-but-hidden page
+containers, a shared status line, and the Back / Next button row, and
+wires up the navigation:
+
+* Next advances a page, or calls ``save()`` on the last page.
+* Back steps back a page, or pops the screen from the first page (so
+  Back / Escape from page 1 returns to whoever pushed the form).
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Button, Static
+
+from sbomify_action.cli.wizard.screens._base import WizardScreen
+
+
+class PagedFormScreen(WizardScreen):
+    """A ``WizardScreen`` whose body is a sequence of fit-to-viewport pages."""
+
+    # One entry per page; subclasses override. ``compose_page`` is called
+    # once per index in range(len(PAGE_TITLES)).
+    PAGE_TITLES: ClassVar[list[str]] = []
+
+    BINDINGS = [
+        # Enter advances / saves; Escape steps back (or pops from page 1).
+        # priority=True so a focused Input can't swallow them — navigation
+        # is routed through ``route_enter`` so a focused Back button still
+        # acts as Back. (Mirrors the other wizard screens.)
+        Binding("enter", "submit", "Next ▸", show=True, priority=True),
+        Binding("escape", "back", "Back", show=True, priority=True),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._page = 0
+
+    # -- subclass hooks ------------------------------------------------
+
+    def compose_page(self, index: int) -> ComposeResult:
+        """Yield the panels for page ``index``. Override in subclasses."""
+        return iter(())
+
+    def save(self) -> None:
+        """Commit the form. Called on Next/Save from the last page."""
+
+    # -- composition ---------------------------------------------------
+
+    def compose_body(self) -> ComposeResult:
+        yield Static(
+            self._indicator_markup(),
+            id="form-page-indicator",
+            classes="wizard-page-indicator",
+        )
+        for index in range(self._page_count):
+            page = Vertical(classes="form-page", id=f"form-page-{index}")
+            # Only the first page is visible on mount; the rest stay
+            # mounted-but-hidden so their inputs preserve values.
+            if index != 0:
+                page.display = False
+            with page:
+                yield from self.compose_page(index)
+        yield Static("", id="form-status", markup=True)
+        with Horizontal(classes="button-row"):
+            yield Button("◂ Back", id="form-back")
+            yield Button(self._next_label(), id="form-next", variant="primary")
+
+    # -- navigation ----------------------------------------------------
+
+    @property
+    def _page_count(self) -> int:
+        return len(self.PAGE_TITLES)
+
+    def _is_last_page(self) -> bool:
+        return self._page >= self._page_count - 1
+
+    def _next_label(self) -> str:
+        return "Save  ▸" if self._is_last_page() else "Next  ▸"
+
+    def _indicator_markup(self) -> str:
+        title = self.PAGE_TITLES[self._page] if self.PAGE_TITLES else ""
+        return f"[#8A7DFF]Step {self._page + 1} of {self._page_count}[/]  [#37306B]│[/]  [b]{title}[/]"
+
+    def action_submit(self) -> None:
+        self.route_enter(self._advance)
+
+    def action_back(self) -> None:
+        if self._page == 0:
+            self.app.pop_screen()
+        else:
+            self._show_page(self._page - 1)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "form-next":
+            self._advance()
+        elif event.button.id == "form-back":
+            self.action_back()
+
+    def _advance(self) -> None:
+        if self._is_last_page():
+            self.save()
+        else:
+            self._show_page(self._page + 1)
+
+    def _show_page(self, index: int) -> None:
+        index = max(0, min(index, self._page_count - 1))
+        self._page = index
+        for i in range(self._page_count):
+            self.query_one(f"#form-page-{i}").display = i == index
+        self.query_one("#form-page-indicator", Static).update(self._indicator_markup())
+        self.query_one("#form-next", Button).label = self._next_label()
+        self._set_status("")
+        self._focus_first(index)
+
+    def _focus_first(self, index: int) -> None:
+        """Move focus to the first interactive control on the given page,
+        in DOM order — a page may lead with a RadioSet (lifecycle) rather
+        than an Input."""
+        page = self.query_one(f"#form-page-{index}")
+        for widget in page.query("Input, RadioSet"):
+            widget.focus()
+            return
+
+    # -- helpers for subclasses ---------------------------------------
+
+    def _set_status(self, markup: str) -> None:
+        self.query_one("#form-status", Static).update(markup)
+
+    @property
+    def next_button(self) -> Button:
+        """The primary Next/Save button — subclasses disable it mid-save."""
+        return self.query_one("#form-next", Button)
+
+    def _goto_page(self, index: int) -> None:
+        """Public-ish jump used by ``save()`` to surface a field error on
+        the page that owns the offending input."""
+        if index != self._page:
+            self._show_page(index)

--- a/sbomify_action/cli/wizard/screens/components.py
+++ b/sbomify_action/cli/wizard/screens/components.py
@@ -62,7 +62,7 @@ class ComponentsScreen(WizardScreen):
                 "existing component (or leave on [b]Create new[/]), then "
                 "[b]Tab[/] to edit the new-component name. [b]Enter[/] / "
                 "[b]Next[/] when done.",
-                classes="wizard-muted",
+                classes="wizard-help",
             )
 
         # Each lockfile gets its own card so the relationship between

--- a/sbomify_action/cli/wizard/screens/configure_sbom.py
+++ b/sbomify_action/cli/wizard/screens/configure_sbom.py
@@ -65,7 +65,7 @@ class ConfigureSbomScreen(WizardScreen):
                 "license compliance, and [b]NTIA minimum elements[/]. Enrichment fills these "
                 "from package registries (PyPI, crates.io, deps.dev, Repology, LicenseDB) "
                 "so the SBOMs the workflow produces meet the bar regulators ask for.[/]",
-                classes="wizard-muted",
+                classes="wizard-help",
             )
             with RadioSet(id="enrich"):
                 yield StatefulRadioButton(
@@ -96,7 +96,7 @@ class ConfigureSbomScreen(WizardScreen):
                 "and the [b]EU Cyber Resilience Act[/], so SBOMs without them fail compliance "
                 "checks. A sbomify contact profile fills these in for every SBOM the workflow "
                 "produces.[/]",
-                classes="wizard-muted",
+                classes="wizard-help",
             )
             with RadioSet(id="augmentation"):
                 yield StatefulRadioButton("Skip — leave metadata blank for now", id="aug-skip", value=True)
@@ -153,7 +153,13 @@ class ConfigureSbomScreen(WizardScreen):
         attest.border_title = "◆  Build provenance"
         attest.border_subtitle = "signed attestations via sigstore"
         with attest:
-            yield Static(self._attestation_note(), classes="wizard-muted")
+            headline, detail = self._attestation_note()
+            yield Static(headline, classes="wizard-muted")
+            # The plan-tier breakdown is several rows of detail — keep it
+            # on roomy terminals but let it drop on tight ones (the
+            # headline already carries the public/private verdict). Both
+            # branches of _attestation_note always return a detail string.
+            yield Static(detail, classes="wizard-help")
             with RadioSet(id="attestation"):
                 yield StatefulRadioButton(
                     "Sign SBOMs with attest-build-provenance  [#86EFAC]✓ recommended for releases[/]",
@@ -170,27 +176,33 @@ class ConfigureSbomScreen(WizardScreen):
             yield Button("◂ Back", id="back")
             yield Button("Next  ▸", id="next", variant="primary")
 
-    def _attestation_note(self) -> str:
-        """Visibility-gated note above the attestation radio set."""
+    def _attestation_note(self) -> tuple[str, str]:
+        """Visibility-gated note above the attestation radio set.
+
+        Returns ``(headline, detail)`` — the headline carries the
+        public/private verdict and always renders; the detail is the
+        plan-tier breakdown, shown on roomy terminals and dropped on
+        tight ones (it's tagged ``wizard-help`` by the caller).
+        """
         visibility = self.wizard.state.facts.visibility
         if visibility == "public":
             return (
                 "[#86EFAC]✓  Public repository[/] — attestation is supported on any GitHub plan, "
-                "signed via the public-good Sigstore instance.\n"
-                "[#5E5E5E]The same note is emitted as a comment in the generated workflow.[/]"
+                "signed via the public-good Sigstore instance.",
+                "[#5E5E5E]The same note is emitted as a comment in the generated workflow.[/]",
             )
         warning_tone = (
             "[#F4B57F]⚠  Private repository[/]" if visibility == "private" else "[#5E5E5E]◌  Visibility unknown[/]"
         )
         return (
-            f"{warning_tone} — attestation has plan-tier requirements:\n"
+            f"{warning_tone} — attestation has plan-tier requirements.",
             "[#86EFAC]✓  Supported[/]\n"
             "    • Public repos on any GitHub plan  (public-good Sigstore)\n"
             "    • Private/internal repos on [b]GitHub Enterprise Cloud[/]  (private Sigstore)\n"
             "[#F87171]✗  Not supported[/]\n"
             "    • Private/internal repos on Free, Pro, or Team — the workflow will fail\n"
             "    • Any repo on GitHub Enterprise Server\n"
-            "[#5E5E5E]The same note is emitted as a comment in the generated workflow.[/]"
+            "[#5E5E5E]The same note is emitted as a comment in the generated workflow.[/]",
         )
 
     # Sentinel id used by the "+ Create a new profile" row at the top

--- a/sbomify_action/cli/wizard/screens/configure_sbomify_json.py
+++ b/sbomify_action/cli/wizard/screens/configure_sbomify_json.py
@@ -22,13 +22,12 @@ from __future__ import annotations
 import json
 
 from textual.app import ComposeResult
-from textual.binding import Binding
-from textual.containers import Horizontal, Vertical
+from textual.containers import Vertical
 from textual.css.query import NoMatches
-from textual.widgets import Button, Input, RadioButton, RadioSet, Static
+from textual.widgets import Input, RadioButton, RadioSet, Static
 
 from sbomify_action.cli.wizard.io import WIZARD_JSON_SENTINEL_KEY, sbomify_json_has_wizard_sentinel
-from sbomify_action.cli.wizard.screens._base import WizardScreen
+from sbomify_action.cli.wizard.screens._paged import PagedFormScreen
 
 # Constructor calls use the wizard's state-aware glyph subclass; the
 # base RadioButton import stays for ``rs.query(RadioButton)`` below.
@@ -47,19 +46,29 @@ _LIFECYCLE_PHASES: list[tuple[str, str]] = [
 ]
 
 
-class ConfigureSbomifyJsonScreen(WizardScreen):
-    """Collect the fields written to ``sbomify.json``."""
+class ConfigureSbomifyJsonScreen(PagedFormScreen):
+    """Collect the fields written to ``sbomify.json``.
+
+    The field set is larger than an 80×24 terminal can hold, so it's
+    split into three fit-to-viewport pages (see ``PagedFormScreen``):
+    Supplier → Manufacturer / author / security → Lifecycle.
+    """
 
     step_index = 7
     step_title = "Configure (sbomify.json)"
     step_subtitle = "Organisational metadata written to the repo, version-controlled alongside the code."
 
-    BINDINGS = [
-        Binding("enter", "submit", "Save ▸", show=True, priority=True),
-        Binding("escape", "app.pop_screen", "Back", show=True, priority=True),
-    ]
+    PAGE_TITLES = ["Supplier", "Manufacturer · author · security", "Lifecycle"]
 
-    def compose_body(self) -> ComposeResult:
+    def compose_page(self, index: int) -> ComposeResult:
+        if index == 0:
+            yield from self._compose_supplier_page()
+        elif index == 1:
+            yield from self._compose_parties_page()
+        else:
+            yield from self._compose_lifecycle_page()
+
+    def _compose_supplier_page(self) -> ComposeResult:
         intro = Vertical(classes="wizard-panel")
         intro.border_title = "◆  sbomify.json fields"
         intro.border_subtitle = "saved to the repository root"
@@ -68,7 +77,7 @@ class ConfigureSbomifyJsonScreen(WizardScreen):
                 "[#5E5E5E]Fields marked [#F4B57F]required[/] satisfy NTIA / CISA / EU CRA "
                 "minimum elements. The rest are optional — most are CRA-recommended and can be "
                 "added later by editing [b]sbomify.json[/] directly.[/]",
-                classes="wizard-muted",
+                classes="wizard-help",
             )
             # If a hand-authored sbomify.json is already on disk (no wizard
             # sentinel), apply will refuse to overwrite it — any edits the
@@ -76,7 +85,8 @@ class ConfigureSbomifyJsonScreen(WizardScreen):
             # only. Warn loudly at the top of the form so the user can decide
             # whether to delete the file or skip the edit. Wizard-stamped
             # files don't surface a warning (apply rewrites them as part of
-            # the normal flow, with a .bak fallback).
+            # the normal flow, with a .bak fallback). This is a warning, not
+            # help text, so it keeps the ``wizard-muted`` class (never hidden).
             if self._existing_file_is_hand_authored():
                 yield Static(
                     "[#F4B57F]⚠ Heads up:[/] [b]sbomify.json[/] already exists in this "
@@ -95,19 +105,20 @@ class ConfigureSbomifyJsonScreen(WizardScreen):
         with sup:
             yield Static(
                 "[#F4B57F]Name required[/] — email + website strongly recommended.",
-                classes="wizard-muted",
+                classes="wizard-help",
             )
             yield Input(placeholder="Supplier name (e.g. Acme Inc.)", id="sup-name")
             yield Input(placeholder="Supplier email (e.g. hello@acme.com)", id="sup-email")
             yield Input(placeholder="Supplier website (e.g. https://acme.com)", id="sup-url")
 
+    def _compose_parties_page(self) -> ComposeResult:
         man = Vertical(classes="wizard-panel")
         man.border_title = "◇  Manufacturer"
         man.border_subtitle = "the entity that created the software (optional, may differ from supplier)"
         with man:
             yield Static(
                 "[#5E5E5E]Optional — leave blank when supplier and manufacturer are the same.[/]",
-                classes="wizard-muted",
+                classes="wizard-help",
             )
             yield Input(placeholder="Manufacturer name (optional)", id="man-name")
             yield Input(placeholder="Manufacturer email (optional)", id="man-email")
@@ -120,7 +131,7 @@ class ConfigureSbomifyJsonScreen(WizardScreen):
             yield Static(
                 "[#5E5E5E]Optional but [b]recommended[/] — satisfies NTIA's "
                 "[b]Author of SBOM Data[/] minimum element.[/]",
-                classes="wizard-muted",
+                classes="wizard-help",
             )
             yield Input(placeholder="Author name (optional)", id="author-name")
             yield Input(placeholder="Author email (optional)", id="author-email")
@@ -132,13 +143,14 @@ class ConfigureSbomifyJsonScreen(WizardScreen):
             yield Static(
                 "[#5E5E5E]URL, [b]mailto:[/], or [b]tel:[/] — eg "
                 "[#8A7DFF u]https://example.com/.well-known/security.txt[/]. CRA-recommended.[/]",
-                classes="wizard-muted",
+                classes="wizard-help",
             )
             yield Input(
                 placeholder="Security contact URI (optional)",
                 id="security-contact",
             )
 
+    def _compose_lifecycle_page(self) -> ComposeResult:
         lifecycle = Vertical(classes="wizard-panel")
         lifecycle.border_title = "◇  Lifecycle phase"
         lifecycle.border_subtitle = "CycloneDX 1.5+ field, CISA framing"
@@ -147,7 +159,7 @@ class ConfigureSbomifyJsonScreen(WizardScreen):
                 "[#5E5E5E]Where this software sits in its lifecycle today. Most repos that "
                 "produce shipped artifacts pick [b]Build[/]; libraries in active development "
                 "pick [b]Development[/].[/]",
-                classes="wizard-muted",
+                classes="wizard-help",
             )
             with RadioSet(id="lifecycle"):
                 for phase, label in _LIFECYCLE_PHASES:
@@ -160,17 +172,11 @@ class ConfigureSbomifyJsonScreen(WizardScreen):
             yield Static(
                 "[#5E5E5E]Required for some EU CRA submissions and helpful for any consumer "
                 "needing EOL / EOS planning.[/]",
-                classes="wizard-muted",
+                classes="wizard-help",
             )
             yield Input(placeholder="Release date (YYYY-MM-DD)", id="release-date")
             yield Input(placeholder="Support period end (YYYY-MM-DD)", id="support-end")
             yield Input(placeholder="End of life (YYYY-MM-DD)", id="end-of-life")
-
-        yield Static("", id="sbomify-json-status", markup=True)
-
-        with Horizontal(classes="button-row"):
-            yield Button("◂ Back", id="back")
-            yield Button("Save  ▸", id="save", variant="primary")
 
     def on_mount(self) -> None:
         # Pre-populate from previously-saved plan data so the user can come
@@ -184,22 +190,13 @@ class ConfigureSbomifyJsonScreen(WizardScreen):
             self._populate_from(prior)
         self.query_one("#sup-name", Input).focus()
 
-    def action_submit(self) -> None:
-        # Enter is handled here only — the priority=True binding on
-        # this screen consumes Enter before any focused Input can fire
-        # Input.Submitted, so an on_input_submitted handler would be
-        # unreachable dead code.
-        self.route_enter(self._save)
-
-    def on_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id == "back":
-            self.app.pop_screen()
-        elif event.button.id == "save":
-            self._save()
-
-    def _save(self) -> None:
+    def save(self) -> None:
         sup_name = self.query_one("#sup-name", Input).value.strip()
         if not sup_name:
+            # Supplier name is the only required field and it lives on the
+            # first page (index 0) — jump back to it so the error points at
+            # the empty input even if the user pressed Save from a later page.
+            self._goto_page(0)
             self._set_status("[#F87171]Supplier name is required (it's an NTIA minimum element).[/]")
             return
 
@@ -263,9 +260,6 @@ class ConfigureSbomifyJsonScreen(WizardScreen):
         if pressed is None or not pressed.id:
             return None
         return pressed.id.split("-", 1)[1]
-
-    def _set_status(self, markup: str) -> None:
-        self.query_one("#sbomify-json-status", Static).update(markup)
 
     def _populate_from(self, data: dict[str, object]) -> None:
         """Re-fill inputs from a previously-saved sbomify_json_data dict.

--- a/sbomify_action/cli/wizard/screens/create_profile.py
+++ b/sbomify_action/cli/wizard/screens/create_profile.py
@@ -21,22 +21,25 @@ ConfigureSbom, which auto-selects the freshly-created profile.
 from __future__ import annotations
 
 from textual.app import ComposeResult
-from textual.binding import Binding
-from textual.containers import Horizontal, Vertical
-from textual.widgets import Button, Input, Static
+from textual.containers import Vertical
+from textual.widgets import Input, Static
 from textual.worker import Worker, WorkerState
 
-from sbomify_action.cli.wizard.screens._base import WizardScreen
+from sbomify_action.cli.wizard.screens._paged import PagedFormScreen
 from sbomify_action.exceptions import APIError
 from sbomify_action.logging_config import logger
 
 
-class CreateProfileScreen(WizardScreen):
+class CreateProfileScreen(PagedFormScreen):
     """Modal-style screen for creating a new contact profile via the API.
 
     Doesn't claim its own step in the crumb track — it's a sub-flow off
     Configure (SBOM). The user lands back on ConfigureSbom afterwards
     with the new profile selected.
+
+    The field set doesn't fit an 80×24 terminal, so it's split into two
+    fit-to-viewport pages (see ``PagedFormScreen``): identity +
+    organisation, then security contact + author.
     """
 
     step_index = 7
@@ -46,12 +49,15 @@ class CreateProfileScreen(WizardScreen):
         "and the EU CRA list as minimum SBOM elements."
     )
 
-    BINDINGS = [
-        Binding("enter", "submit", "Create profile ▸", show=True, priority=True),
-        Binding("escape", "app.pop_screen", "Back", show=True, priority=True),
-    ]
+    PAGE_TITLES = ["Identity & organisation", "Security & author"]
 
-    def compose_body(self) -> ComposeResult:
+    def compose_page(self, index: int) -> ComposeResult:
+        if index == 0:
+            yield from self._compose_org_page()
+        else:
+            yield from self._compose_contacts_page()
+
+    def _compose_org_page(self) -> ComposeResult:
         intro = Vertical(classes="wizard-panel")
         intro.border_title = "◆  New contact profile"
         intro.border_subtitle = "saved to your sbomify workspace"
@@ -60,7 +66,7 @@ class CreateProfileScreen(WizardScreen):
                 "[#5E5E5E]Fields marked [#F4B57F]required[/] are needed for the API call AND "
                 "for NTIA / CISA / EU CRA compliance. Everything else is optional and can be "
                 "edited later in the sbomify UI.[/]",
-                classes="wizard-muted",
+                classes="wizard-help",
             )
 
         # Profile identity — internal label used to pick this profile
@@ -69,7 +75,7 @@ class CreateProfileScreen(WizardScreen):
         ident.border_title = "◇  Profile name"
         ident.border_subtitle = "internal label, free-text"
         with ident:
-            yield Static("[#F4B57F]required[/]", classes="wizard-muted")
+            yield Static("[#F4B57F]required[/]", classes="wizard-help")
             yield Input(
                 placeholder="e.g. 'Acme default' or 'Production releases'",
                 id="profile-name",
@@ -82,7 +88,7 @@ class CreateProfileScreen(WizardScreen):
         with org:
             yield Static(
                 "[#F4B57F]Name and email required[/] — feed the SBOM's [b]supplier[/] and [b]manufacturer[/] fields.",
-                classes="wizard-muted",
+                classes="wizard-help",
             )
             yield Input(placeholder="Organisation name (e.g. Acme Inc.)", id="org-name")
             yield Input(placeholder="Organisation email (e.g. hello@acme.com)", id="org-email")
@@ -93,6 +99,7 @@ class CreateProfileScreen(WizardScreen):
                 id="org-website",
             )
 
+    def _compose_contacts_page(self) -> ComposeResult:
         # Security contact — the backend rejects entities without at
         # least one contact, and the EU CRA requires a security contact.
         sec = Vertical(classes="wizard-panel")
@@ -102,7 +109,7 @@ class CreateProfileScreen(WizardScreen):
             yield Static(
                 "[#F4B57F]Name and email required[/] — listed as the "
                 "[b]security contact[/] on every SBOM this workflow generates.",
-                classes="wizard-muted",
+                classes="wizard-help",
             )
             yield Input(placeholder="Security contact name", id="sec-name")
             yield Input(placeholder="Security contact email", id="sec-email")
@@ -118,35 +125,15 @@ class CreateProfileScreen(WizardScreen):
                 "CycloneDX [b]authors[/] field and satisfies NTIA's [b]Author of SBOM Data[/] "
                 "minimum element. Skip if a tool (eg sbomify-action itself) will be credited "
                 "as the author instead.[/]",
-                classes="wizard-muted",
+                classes="wizard-help",
             )
             yield Input(placeholder="Author name (optional)", id="author-name")
             yield Input(placeholder="Author email (optional)", id="author-email")
 
-        # Status line for inline error/progress feedback.
-        yield Static("", id="profile-status", markup=True)
-
-        with Horizontal(classes="button-row"):
-            yield Button("◂ Back", id="back")
-            yield Button("Create profile  ▸", id="submit", variant="primary")
-
     def on_mount(self) -> None:
         self.query_one("#profile-name", Input).focus()
 
-    def action_submit(self) -> None:
-        # Enter is handled here only — the priority=True binding on
-        # this screen consumes Enter before any focused Input can fire
-        # Input.Submitted, so an on_input_submitted handler would be
-        # unreachable dead code.
-        self.route_enter(self._submit)
-
-    def on_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id == "back":
-            self.app.pop_screen()
-        elif event.button.id == "submit":
-            self._submit()
-
-    def _submit(self) -> None:
+    def save(self) -> None:
         """Validate, build the payload, and POST it on a worker thread."""
         if self.wizard.state.workspace is None or not self.wizard.state.workspace.team_key:
             self._set_status("[#F87171]No workspace key available — can't create a profile.[/]")
@@ -158,6 +145,9 @@ class CreateProfileScreen(WizardScreen):
         sec_name = self.query_one("#sec-name", Input).value.strip()
         sec_email = self.query_one("#sec-email", Input).value.strip()
 
+        # Profile name + organisation live on page 1, the security contact
+        # on page 2. Jump to whichever page owns the first missing field so
+        # the error lands next to the empty input.
         missing: list[str] = []
         if not name:
             missing.append("profile name")
@@ -170,6 +160,8 @@ class CreateProfileScreen(WizardScreen):
         if not sec_email:
             missing.append("security contact email")
         if missing:
+            page_for_missing = 0 if (not name or not org_name or not org_email) else 1
+            self._goto_page(page_for_missing)
             self._set_status(f"[#F87171]Missing required field(s): {', '.join(missing)}.[/]")
             return
 
@@ -207,7 +199,7 @@ class CreateProfileScreen(WizardScreen):
             payload["authors"] = [{"name": author_name, "email": author_email}]
 
         self._set_status("[#CBCCCE]Creating profile…[/]")
-        self.query_one("#submit", Button).disabled = True
+        self.next_button.disabled = True
         self.run_worker(
             lambda: self._create_worker(payload),
             name="create-profile",
@@ -243,7 +235,7 @@ class CreateProfileScreen(WizardScreen):
             # the user to submit a duplicate.
             if isinstance(result, str):
                 self._set_status(f"[#F87171]✗  {result}[/]")
-                self.query_one("#submit", Button).disabled = False
+                self.next_button.disabled = False
                 return
             if isinstance(result, dict) and result.get("id"):
                 # Append to the workspace snapshot so ConfigureSbom's
@@ -264,10 +256,7 @@ class CreateProfileScreen(WizardScreen):
                 "unexpected. Check the sbomify UI under Settings → Contacts before "
                 "re-submitting to avoid creating a duplicate.[/]"
             )
-            self.query_one("#submit", Button).disabled = False
+            self.next_button.disabled = False
         elif event.state == WorkerState.ERROR:
             self._set_status(f"[#F87171]✗  Unexpected error: {event.worker.error}[/]")
-            self.query_one("#submit", Button).disabled = False
-
-    def _set_status(self, markup: str) -> None:
-        self.query_one("#profile-status", Static).update(markup)
+            self.next_button.disabled = False

--- a/sbomify_action/cli/wizard/screens/discover.py
+++ b/sbomify_action/cli/wizard/screens/discover.py
@@ -36,7 +36,7 @@ class DiscoverScreen(WizardScreen):
             yield Static(
                 "Use [b]Space[/] to toggle each lockfile, [b]a[/] to select all, "
                 "[b]n[/] to select none, [b]Enter[/] when you're done.",
-                classes="wizard-muted",
+                classes="wizard-help",
             )
             yield SelectionList[int](id="lockfile-list")
             yield Static("", id="discover-status", markup=True)

--- a/sbomify_action/cli/wizard/screens/product.py
+++ b/sbomify_action/cli/wizard/screens/product.py
@@ -36,7 +36,7 @@ class ProductScreen(WizardScreen):
                 "Use [b]↑/↓[/] to highlight a product (or leave on "
                 "[b]Create new[/]), then [b]Tab[/] to edit the new-product "
                 "name. [b]Enter[/] when done.",
-                classes="wizard-muted",
+                classes="wizard-help",
             )
             # Escape API-supplied names before passing them as picker
             # labels — PickOrCreate's OptionList renders labels as Rich

--- a/sbomify_action/cli/wizard/screens/review.py
+++ b/sbomify_action/cli/wizard/screens/review.py
@@ -40,7 +40,7 @@ class ReviewScreen(WizardScreen):
         with components:
             yield DataTable(id="components-table", cursor_type="none", zebra_stripes=True)
 
-        diff_panel = Vertical(classes="wizard-panel")
+        diff_panel = Vertical(classes="wizard-panel", id="diff-panel")
         target = workflow_path(self.wizard.state.facts.repo_root)
         verb = "overwrite" if self.wizard.state.workflow_exists else "create"
         diff_panel.border_title = f"◆  Diff — {verb} {target}"

--- a/sbomify_action/cli/wizard/screens/welcome.py
+++ b/sbomify_action/cli/wizard/screens/welcome.py
@@ -118,7 +118,7 @@ class WelcomeScreen(WizardScreen):
         # step indicator at the top of every screen so the mental model
         # is consistent throughout the wizard.
         if self.wizard.state.discovered:
-            steps = Vertical(classes="wizard-panel")
+            steps = Vertical(classes="wizard-panel", id="what-well-do")
             steps.border_title = "What we'll do"
             steps.border_subtitle = "8 steps · ~3 minutes"
             with steps:

--- a/sbomify_action/cli/wizard/styles.tcss
+++ b/sbomify_action/cli/wizard/styles.tcss
@@ -69,6 +69,23 @@ Footer > .footer--key {
     margin-bottom: 1;
 }
 
+/* Paged forms (see screens/_paged.py) — the "Step n of N · Title" header
+ * that replaces the static subtitle on multi-page forms. Unlike the
+ * subtitle it stays visible in compact mode (it's the only cue to which
+ * page you're on). */
+.wizard-page-indicator {
+    color: $sbom-purple;
+    margin-bottom: 1;
+}
+
+.form-page {
+    height: auto;
+}
+
+#form-status {
+    height: auto;
+}
+
 /* Card panels — modern devsecops-CLI shape: rounded border with a
  * named title bar (set via widget.border_title). Padding gives the
  * content room to breathe; bottom margin keeps stacked cards from
@@ -104,6 +121,16 @@ Footer > .footer--key {
 }
 
 .wizard-muted {
+    color: $sbom-text-muted;
+    margin-bottom: 1;
+}
+
+/* Explanatory / rationale prose (the "why" copy and keyboard hints above
+ * a control) — styled like muted text, but tagged separately so the
+ * responsive layer can drop it on tight terminals while keeping warnings
+ * and status lines (which stay ``wizard-muted``). See the ``-compact``
+ * rule near the foot of this file. */
+.wizard-help {
     color: $sbom-text-muted;
     margin-bottom: 1;
 }
@@ -289,9 +316,17 @@ SelectionList, OptionList, ListView {
     max-height: 20;
 }
 
-/* Product / Components: per-widget sizing now lives on the
- * PickOrCreate widget's DEFAULT_CSS — both screens render identical
- * pickers via the shared component. */
+/* Product / Components: the picker's OptionList must size to its
+ * content (a "create new" row + however many existing items), NOT grab
+ * 1fr. PickOrCreate's DEFAULT_CSS says as much, but the generic
+ * ``OptionList { height: 1fr }`` rule above is app-origin and outranks
+ * widget DEFAULT_CSS, so without this app-level override the picker
+ * balloons to fill the screen and shoves the Next button off the
+ * bottom. Re-assert auto + a cap here where it can win. */
+PickOrCreate > OptionList {
+    height: auto;
+    max-height: 10;
+}
 
 /* Review screen — DataTable of planned components defaults to 1fr
  * from the generic `DataTable` rule above. Override for #components-
@@ -324,13 +359,17 @@ SelectionList, OptionList, ListView {
     color: $sbom-text-muted;
 }
 
-/* Review screen — RichLog rendering the unified diff between the
- * existing workflow file (if any) and what apply will write. Cap
- * height so a large diff scrolls inside the panel instead of pushing
- * the Apply / Back buttons off-screen. */
+/* Review screen — the diff panel is the screen's flexible region: it
+ * takes 1fr so it soaks up whatever vertical space is left after the
+ * (fixed-height) plan summary, components table, and button row, and
+ * the RichLog inside scrolls. This pins Apply / Back on screen at any
+ * terminal height without the page itself ever scrolling. */
+#diff-panel {
+    height: 1fr;
+}
+
 #workflow-diff {
-    height: auto;
-    max-height: 20;
+    height: 1fr;
 }
 
 /* Apply screen — live log of apply_plan's progress. Same problem as
@@ -413,4 +452,178 @@ RichLog {
     border: round $sbom-primary-600;
     height: 1fr;
     color: $sbom-text-muted;
+}
+
+/* ---------------------------------------------------------------------
+ * Responsive layout
+ *
+ * The wizard fits the viewport — nothing scrolls. ``WizardScreen``
+ * (_base.py) toggles ``-compact`` / ``-tiny`` on the screen from the
+ * live terminal size; the rules below react to those classes.
+ * --------------------------------------------------------------------- */
+
+/* Too-small guard — below the supported minimum (80x24) we hide the
+ * normal body and show a centered resize prompt in its place. Hidden by
+ * default; the screen only carries ``-tiny`` when it's genuinely too
+ * small to render. */
+#too-small {
+    display: none;
+    height: 1fr;
+    width: 1fr;
+    content-align: center middle;
+    text-align: center;
+}
+
+.-tiny .wizard-body {
+    display: none;
+}
+
+.-tiny #too-small {
+    display: block;
+}
+
+/* Art opt-out — the welcome mascot is the single tallest element, so it
+ * has its own breakpoint (see ART_* in _base.py): we keep showing it
+ * wherever it fits, and only hide it on terminals too short/narrow for
+ * the two-column hero. The text column carries the message on its own. */
+.-no-art .wizard-hero-mascot {
+    display: none;
+}
+
+/* The welcome "What we'll do" preview has its own bound (PREVIEW_HEIGHT)
+ * rather than riding on ``-compact``: it's a short text list that fits in
+ * far more terminals than the full comfortable layout, so we keep showing
+ * it down to medium-tall terminals and only drop it when genuinely short.
+ * (The progress crumb already communicates the eight steps regardless.) */
+.-no-preview #what-well-do {
+    display: none;
+}
+
+/* Compact mode — terminal is usable but below the roomy bound. Flatten
+ * the vertical padding / margins that exist purely to let the comfortable
+ * layout breathe. Everything here is additive over the comfortable
+ * defaults above, so a roomy terminal is completely unaffected. */
+
+.-compact .wizard-body {
+    padding: 0 2;
+}
+
+.-compact .wizard-hero {
+    padding: 0 2;
+    margin-bottom: 1;
+}
+
+.-compact .wizard-panel,
+.-compact .wizard-panel-emphasis {
+    padding: 0 2;
+    margin-bottom: 0;
+}
+
+.-compact .wizard-step-crumb,
+.-compact .wizard-hero-title,
+.-compact .wizard-hero-tagline,
+.-compact .wizard-title,
+.-compact .wizard-muted,
+.-compact .wizard-page-indicator {
+    margin-bottom: 0;
+}
+
+/* The per-screen subtitle is a secondary one-liner — the progress crumb
+ * already names the current step — so drop it on tight terminals to
+ * reclaim a row (two when it wraps). */
+.-compact .wizard-subtitle {
+    display: none;
+}
+
+/* Form controls: in the comfortable layout each Label has a top margin
+ * and each Input a bottom margin so fields breathe. On tight terminals
+ * those single-row gaps add up fast across a multi-field form — collapse
+ * them so the form body reclaims a row per control. */
+.-compact Label {
+    margin-top: 0;
+}
+
+/* A full Textual Input box is 3 rows (top border + text + bottom border).
+ * Across a multi-field form that's the dominant cost, so on tight
+ * terminals slim each Input to 2 rows — a single underline border that
+ * still separates adjacent fields and still carries the focus / invalid
+ * cue (purple when focused, red when invalid). */
+.-compact Input {
+    margin: 0;
+    height: 2;
+    min-height: 2;
+    border: none;
+    border-bottom: tall $sbom-primary-600;
+}
+
+.-compact Input:focus {
+    border: none;
+    border-bottom: tall $sbom-purple;
+}
+
+.-compact Input.-invalid {
+    border: none;
+    border-bottom: tall #F87171;
+}
+
+/* Progressive disclosure — drop the explanatory rationale prose so the
+ * controls fit. Warnings and status lines stay (they're ``wizard-muted``,
+ * not ``wizard-help``). The full copy returns on roomy terminals. */
+.-compact .wizard-help {
+    display: none;
+}
+
+/* Capped scrollable regions — lists / tables / logs already scroll
+ * inside their own box, so on tight terminals we just lower the cap.
+ * The content is still fully reachable via the widget's own scrollbar;
+ * only the page itself never scrolls. */
+.-compact PickOrCreate > OptionList {
+    max-height: 6;
+}
+
+.-compact #lockfile-list {
+    max-height: 8;
+}
+
+.-compact #apply-log {
+    max-height: 8;
+}
+
+/* Review's components table scrolls internally; cap it hard on tight
+ * terminals so a long component list can't crowd out the plan summary
+ * or the diff (which is the 1fr flex region — see #diff-panel above). */
+.-compact #components-table {
+    max-height: 4;
+}
+
+.-compact #profile-picker {
+    max-height: 5;
+}
+
+.-compact .button-row {
+    padding-top: 0;
+    height: 1;
+}
+
+/* Flatten the action buttons on tight terminals: a bordered Textual
+ * Button is 3 rows tall (top border + label + bottom border); dropping
+ * the border makes each row-of-buttons 1 row instead of 3, reclaimed on
+ * every screen. The border normally doubles as the focus ring, so swap
+ * in a background/bold focus cue that reads without it. */
+.-compact .button-row Button {
+    border: none;
+    height: 1;
+    min-height: 1;
+}
+
+.-compact .button-row Button:focus {
+    background: $sbom-purple;
+    color: $sbom-primary;
+    text-style: bold;
+}
+
+.-compact .button-row Button.-primary:focus {
+    background: $sbom-grad-peach;
+    color: $sbom-primary;
+    text-style: bold;
 }


### PR DESCRIPTION
## Problem

The Textual onboarding wizard was laid out for a large window. The welcome screen's content wanted **~58 rows**, so on a standard **80×24** terminal the **Start button was clipped off the bottom** — and because the body didn't scroll, it was unreachable. You effectively needed a **157×65** terminal to see everything.

## Approach — fit-to-viewport, not scrolling

A wizard page that scrolls hides the primary CTA, so instead of adding a scrollbar the wizard now adapts its content to whatever the terminal gives it. A small responsive system lives in the shared screen base (`screens/_base.py`) + stylesheet (`styles.tcss`):

- **`WizardScreen.on_resize`** toggles size classes from the live terminal size:
  - **`-tiny`** (below 80×24): swap the body for a centered _"Terminal too small — current N×M, minimum 80×24"_ prompt (k9s/lazygit style).
  - **`-compact`** (below the roomy bound): flatten padding, slim the action buttons to one row and inputs to a single underline, drop the per-screen subtitle and the explanatory/compliance prose. Prose is tagged `wizard-help` (hidden when tight); **warnings stay `wizard-muted` and are always shown**.
  - **`-no-art` / `-no-preview`**: the welcome ASCII mascot and the "what we'll do" preview each get their **own** size bound, so they reappear as soon as there's room rather than only on a huge terminal.
- **Review**'s diff panel becomes the `1fr` flex region so it absorbs slack and keeps Apply/Back on screen; the product/components pickers size to content again (they were grabbing `1fr` and shoving the buttons off).

### Long forms → paged

Two forms genuinely can't fit 80×24 (create-profile ~12 inputs, sbomify.json ~14 inputs). They're split into fit-to-viewport **pages** via a new `PagedFormScreen` base — all panels stay mounted so input values persist across Back/Next, and validation jumps to the page owning the offending field.

## Behavior by terminal size (welcome)

| Size | Result |
|---|---|
| < 80×24 | "Terminal too small" resize prompt |
| 80×24 | compact, mascot + preview hidden, **Start button visible** |
| ~100×42+ | ASCII mascot returns |
| ~48+ rows | "what we'll do" preview returns |
| 100×63+ | full comfortable layout |

## Verification

- Measured every screen's button-row position at 80×24 — **all 12 screens fit** (or show the resize prompt below it).
- Full test suite passes (2339 passed, 4 skipped); `ruff check` + `ruff format` clean.
- Eyeballed rendered screenshots at 80×24 / 120×50 / 160×66 and the resize guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)