### PR TITLE
feat: add BOM_TYPE to upload VEX/CBOM/HBOM artifacts verbatim

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Setting `LOCK_FILE` (or `SBOM_FILE`) to `none` creates an empty SBOM and injects
 | `DOCKER_IMAGE`             | †        | Docker image name                                                                |
 | `OUTPUT_FILE`              | No       | Write final SBOM to this path                                                    |
 | `SBOM_FORMAT`              | No       | Output format: `cyclonedx` (default) or `spdx`                                   |
-| `BOM_TYPE`                 | No       | Artifact type: `sbom` (default), `vex`, `cbom` or `hbom`. Non-SBOM types upload verbatim to sbomify only (augmentation, enrichment, overrides, additional-package injection and the SBOM-specific finalization fixups are skipped; `dependency-track` in `UPLOAD_DESTINATIONS` is rejected) |
+| `BOM_TYPE`                 | No       | Artifact type: `sbom` (default), `vex`, `cbom` or `hbom`. Non-SBOM types upload verbatim to sbomify only (augmentation, enrichment, overrides, additional-package injection and the SBOM-specific finalization fixups are skipped; `dependency-track` in `UPLOAD_DESTINATIONS` and `PRODUCT_RELEASE` are rejected). Note: sbomify auto-classifies CycloneDX documents containing cryptographic assets as `cbom` |
 | `ENRICH`                   | No       | Add metadata from package registries                                             |
 | `TOKEN`                    | ‡        | sbomify API token                                                                |
 | `COMPONENT_ID`             | ‡        | sbomify component ID                                                             |

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Setting `LOCK_FILE` (or `SBOM_FILE`) to `none` creates an empty SBOM and injects
 | `DOCKER_IMAGE`             | †        | Docker image name                                                                |
 | `OUTPUT_FILE`              | No       | Write final SBOM to this path                                                    |
 | `SBOM_FORMAT`              | No       | Output format: `cyclonedx` (default) or `spdx`                                   |
-| `BOM_TYPE`                 | No       | Artifact type: `sbom` (default), `vex`, `cbom` or `hbom`. Non-SBOM types upload verbatim (augmentation, enrichment and finalization are skipped) |
+| `BOM_TYPE`                 | No       | Artifact type: `sbom` (default), `vex`, `cbom` or `hbom`. Non-SBOM types upload verbatim (augmentation, enrichment, overrides and the SBOM-specific finalization fixups are skipped) |
 | `ENRICH`                   | No       | Add metadata from package registries                                             |
 | `TOKEN`                    | ‡        | sbomify API token                                                                |
 | `COMPONENT_ID`             | ‡        | sbomify component ID                                                             |

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Setting `LOCK_FILE` (or `SBOM_FILE`) to `none` creates an empty SBOM and injects
 | `DOCKER_IMAGE`             | †        | Docker image name                                                                |
 | `OUTPUT_FILE`              | No       | Write final SBOM to this path                                                    |
 | `SBOM_FORMAT`              | No       | Output format: `cyclonedx` (default) or `spdx`                                   |
-| `BOM_TYPE`                 | No       | Artifact type: `sbom` (default), `vex`, `cbom` or `hbom`. Non-SBOM types upload verbatim (augmentation, enrichment, overrides and the SBOM-specific finalization fixups are skipped) |
+| `BOM_TYPE`                 | No       | Artifact type: `sbom` (default), `vex`, `cbom` or `hbom`. Non-SBOM types upload verbatim to sbomify only (augmentation, enrichment, overrides, additional-package injection and the SBOM-specific finalization fixups are skipped; `dependency-track` in `UPLOAD_DESTINATIONS` is rejected) |
 | `ENRICH`                   | No       | Add metadata from package registries                                             |
 | `TOKEN`                    | ‡        | sbomify API token                                                                |
 | `COMPONENT_ID`             | ‡        | sbomify component ID                                                             |

--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Setting `LOCK_FILE` (or `SBOM_FILE`) to `none` creates an empty SBOM and injects
 | `DOCKER_IMAGE`             | †        | Docker image name                                                                |
 | `OUTPUT_FILE`              | No       | Write final SBOM to this path                                                    |
 | `SBOM_FORMAT`              | No       | Output format: `cyclonedx` (default) or `spdx`                                   |
+| `BOM_TYPE`                 | No       | Artifact type: `sbom` (default), `vex`, `cbom` or `hbom`. Non-SBOM types are uploaded verbatim |
 | `ENRICH`                   | No       | Add metadata from package registries                                             |
 | `TOKEN`                    | ‡        | sbomify API token                                                                |
 | `COMPONENT_ID`             | ‡        | sbomify component ID                                                             |

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Setting `LOCK_FILE` (or `SBOM_FILE`) to `none` creates an empty SBOM and injects
 | `DOCKER_IMAGE`             | †        | Docker image name                                                                |
 | `OUTPUT_FILE`              | No       | Write final SBOM to this path                                                    |
 | `SBOM_FORMAT`              | No       | Output format: `cyclonedx` (default) or `spdx`                                   |
-| `BOM_TYPE`                 | No       | Artifact type: `sbom` (default), `vex`, `cbom` or `hbom`. Non-SBOM types are uploaded verbatim |
+| `BOM_TYPE`                 | No       | Artifact type: `sbom` (default), `vex`, `cbom` or `hbom`. Non-SBOM types upload verbatim (augmentation, enrichment and finalization are skipped) |
 | `ENRICH`                   | No       | Add metadata from package registries                                             |
 | `TOKEN`                    | ‡        | sbomify API token                                                                |
 | `COMPONENT_ID`             | ‡        | sbomify component ID                                                             |

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   component-purl:
     description: 'Override the component PURL in the SBOM (e.g., pkg:npm/@scope/name@1.0.0)'
     required: false
+  bom-type:
+    description: 'Artifact type to record on upload: sbom (default), vex, cbom or hbom. Non-SBOM types are uploaded verbatim (no augmentation or finalization).'
+    required: false
   oidc-audience:
     description: 'OIDC audience for trusted publishing (default: sbomify.com; override for self-hosted)'
     required: false
@@ -20,6 +23,7 @@ runs:
   env:
     WORKING_DIR: ${{ inputs['working-dir'] }}
     COMPONENT_PURL: ${{ inputs['component-purl'] }}
+    BOM_TYPE: ${{ inputs['bom-type'] }}
     OIDC_AUDIENCE: ${{ inputs['oidc-audience'] }}
 branding:
   icon: 'upload-cloud'

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,7 @@ inputs:
   bom-type:
     description: 'Artifact type to record on upload: sbom (default), vex, cbom or hbom. Non-SBOM types are uploaded verbatim: augmentation, enrichment, overrides and the SBOM-specific finalization fixups are skipped.'
     required: false
+    default: 'sbom'
   oidc-audience:
     description: 'OIDC audience for trusted publishing (default: sbomify.com; override for self-hosted)'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'Override the component PURL in the SBOM (e.g., pkg:npm/@scope/name@1.0.0)'
     required: false
   bom-type:
-    description: 'Artifact type to record on upload: sbom (default), vex, cbom or hbom. Non-SBOM types are uploaded verbatim: augmentation, enrichment, overrides and the SBOM-specific finalization fixups are skipped.'
+    description: 'Artifact type to record on upload: sbom (default), vex, cbom or hbom. Only the sbomify destination records it. Non-SBOM types are uploaded verbatim: augmentation, enrichment, overrides, additional-package injection and the SBOM-specific finalization fixups are skipped.'
     required: false
     default: 'sbom'
   oidc-audience:

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'Override the component PURL in the SBOM (e.g., pkg:npm/@scope/name@1.0.0)'
     required: false
   bom-type:
-    description: 'Artifact type to record on upload: sbom (default), vex, cbom or hbom. Only the sbomify destination records it. Non-SBOM types are uploaded verbatim: augmentation, enrichment, overrides, additional-package injection and the SBOM-specific finalization fixups are skipped.'
+    description: 'Artifact type to record on upload: sbom (default), vex, cbom or hbom. Only the sbomify destination supports non-SBOM types; other upload-destinations entries are rejected for them. Non-SBOM types are uploaded verbatim: augmentation, enrichment, overrides, additional-package injection and the SBOM-specific finalization fixups are skipped.'
     required: false
     default: 'sbom'
   oidc-audience:

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'Override the component PURL in the SBOM (e.g., pkg:npm/@scope/name@1.0.0)'
     required: false
   bom-type:
-    description: 'Artifact type to record on upload: sbom (default), vex, cbom or hbom. Non-SBOM types are uploaded verbatim (no augmentation or finalization).'
+    description: 'Artifact type to record on upload: sbom (default), vex, cbom or hbom. Non-SBOM types are uploaded verbatim: augmentation, enrichment and finalization are skipped.'
     required: false
   oidc-audience:
     description: 'OIDC audience for trusted publishing (default: sbomify.com; override for self-hosted)'

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'Override the component PURL in the SBOM (e.g., pkg:npm/@scope/name@1.0.0)'
     required: false
   bom-type:
-    description: 'Artifact type to record on upload: sbom (default), vex, cbom or hbom. Non-SBOM types are uploaded verbatim: augmentation, enrichment and finalization are skipped.'
+    description: 'Artifact type to record on upload: sbom (default), vex, cbom or hbom. Non-SBOM types are uploaded verbatim: augmentation, enrichment, overrides and the SBOM-specific finalization fixups are skipped.'
     required: false
   oidc-audience:
     description: 'OIDC audience for trusted publishing (default: sbomify.com; override for self-hosted)'

--- a/sbomify_action/_upload/__init__.py
+++ b/sbomify_action/_upload/__init__.py
@@ -39,7 +39,7 @@ from .destinations import (
     SbomifyDestination,
 )
 from .orchestrator import UploadOrchestrator, create_registry_with_sbomify
-from .protocol import Destination, DestinationConfig, SBOMFormat, UploadInput
+from .protocol import VALID_BOM_TYPES, Destination, DestinationConfig, SBOMFormat, UploadInput
 from .registry import VALID_DESTINATIONS, DestinationRegistry
 from .result import UploadResult
 
@@ -47,6 +47,7 @@ __all__ = [
     # Core types
     "SBOMFormat",
     "UploadInput",
+    "VALID_BOM_TYPES",
     "UploadResult",
     "Destination",
     "DestinationConfig",

--- a/sbomify_action/_upload/destinations/sbomify.py
+++ b/sbomify_action/_upload/destinations/sbomify.py
@@ -185,11 +185,23 @@ class SbomifyDestination:
                     if cleaned:
                         err_msg += f" - {cleaned}"
 
-                # Handle duplicate SBOM error with specific message
+                # Handle duplicate artifact error with specific message. Non-SBOM
+                # artifacts ignore COMPONENT_VERSION (verbatim upload), so the only
+                # actionable version is the one inside the authored document.
                 if response.status_code == 409 and error_code == "DUPLICATE_ARTIFACT":
+                    if artifact_kind == "SBOM":
+                        duplicate_msg = (
+                            "An SBOM already exists for this component version. "
+                            "Use a different version or delete the existing SBOM."
+                        )
+                    else:
+                        duplicate_msg = (
+                            f"A {artifact_kind} already exists for this component version. "
+                            f"Bump the version inside the authored document or delete the existing {artifact_kind}."
+                        )
                     return UploadResult.failure_result(
                         destination_name=self.name,
-                        error_message="An SBOM already exists for this component version. Use a different version or delete the existing SBOM.",
+                        error_message=duplicate_msg,
                         error_code=error_code,
                         validated=validated,
                         validation_error=validation_error,

--- a/sbomify_action/_upload/destinations/sbomify.py
+++ b/sbomify_action/_upload/destinations/sbomify.py
@@ -196,7 +196,7 @@ class SbomifyDestination:
                         )
                     else:
                         duplicate_msg = (
-                            f"A {artifact_kind} already exists for this component version. "
+                            f"A {artifact_kind} with the same document version already exists for this component. "
                             f"Bump the version inside the authored document or delete the existing {artifact_kind}."
                         )
                     return UploadResult.failure_result(

--- a/sbomify_action/_upload/destinations/sbomify.py
+++ b/sbomify_action/_upload/destinations/sbomify.py
@@ -133,6 +133,7 @@ class SbomifyDestination:
                 component_id=str(self._component_id),
                 sbom_payload=upload_data,
                 sbom_format=input.sbom_format,
+                bom_type=input.bom_type,
                 content_encoding=content_encoding,
             )
         except AuthError as e:

--- a/sbomify_action/_upload/destinations/sbomify.py
+++ b/sbomify_action/_upload/destinations/sbomify.py
@@ -110,7 +110,8 @@ class SbomifyDestination:
             )
 
         format_display = "CycloneDX" if input.sbom_format == "cyclonedx" else "SPDX"
-        logger.info(f"Uploading {format_display} SBOM to component: {self._component_id}")
+        artifact_kind = input.bom_type.upper() if input.bom_type and input.bom_type != "sbom" else "SBOM"
+        logger.info(f"Uploading {format_display} {artifact_kind} to component: {self._component_id}")
 
         # Gzip-compress large payloads to avoid upstream timeouts.
         upload_data: bytes = sbom_bytes

--- a/sbomify_action/_upload/protocol.py
+++ b/sbomify_action/_upload/protocol.py
@@ -14,6 +14,10 @@ if TYPE_CHECKING:
 # Supported SBOM formats (same as generation)
 SBOMFormat = Literal["cyclonedx", "spdx"]
 
+# Artifact types the sbomify backend accepts via the ?bom_type= query param.
+# None/"sbom" is the default plain SBOM upload; the others are uploaded as-is.
+VALID_BOM_TYPES = ("sbom", "vex", "cbom", "hbom")
+
 
 @dataclass
 class UploadInput:
@@ -23,6 +27,8 @@ class UploadInput:
     Attributes:
         sbom_file: Path to the SBOM file to upload
         sbom_format: Format of the SBOM ("cyclonedx" or "spdx")
+        bom_type: Artifact type to record on upload (sbom/vex/cbom/hbom). None
+            uploads as a plain SBOM; non-SBOM types are sent verbatim.
         component_name: Name of the component (used by destinations like Dependency Track)
         component_version: Version of the component (used by destinations like Dependency Track)
         validate_before_upload: Whether to validate SBOM before uploading
@@ -30,6 +36,7 @@ class UploadInput:
 
     sbom_file: str
     sbom_format: SBOMFormat
+    bom_type: Optional[str] = None
     component_name: Optional[str] = None
     component_version: Optional[str] = None
     validate_before_upload: bool = True
@@ -40,6 +47,8 @@ class UploadInput:
             raise ValueError("sbom_file is required")
         if self.sbom_format not in ("cyclonedx", "spdx"):
             raise ValueError(f"Invalid sbom_format: {self.sbom_format}")
+        if self.bom_type is not None and self.bom_type not in VALID_BOM_TYPES:
+            raise ValueError(f"Invalid bom_type: {self.bom_type}. Must be one of: {', '.join(VALID_BOM_TYPES)}")
 
 
 class DestinationConfig(ABC):

--- a/sbomify_action/_upload/protocol.py
+++ b/sbomify_action/_upload/protocol.py
@@ -48,6 +48,8 @@ class UploadInput:
         if self.sbom_format not in ("cyclonedx", "spdx"):
             raise ValueError(f"Invalid sbom_format: {self.sbom_format}")
         if self.bom_type is not None:
+            if not isinstance(self.bom_type, str):
+                raise ValueError(f"Invalid bom_type: {self.bom_type!r}. Must be one of: {', '.join(VALID_BOM_TYPES)}")
             self.bom_type = self.bom_type.lower()
             if self.bom_type not in VALID_BOM_TYPES:
                 raise ValueError(f"Invalid bom_type: {self.bom_type}. Must be one of: {', '.join(VALID_BOM_TYPES)}")

--- a/sbomify_action/_upload/protocol.py
+++ b/sbomify_action/_upload/protocol.py
@@ -22,7 +22,9 @@ VALID_BOM_TYPES = ("sbom", "vex", "cbom", "hbom")
 @dataclass
 class UploadInput:
     """
-    Input parameters for SBOM upload (SBOM-specific, not destination-specific).
+    Input parameters for an artifact upload (artifact-specific, not
+    destination-specific). The artifact is an SBOM by default; ``bom_type``
+    selects a non-SBOM kind (VEX/CBOM/HBOM) uploaded verbatim.
 
     Attributes:
         sbom_file: Path to the SBOM file to upload

--- a/sbomify_action/_upload/protocol.py
+++ b/sbomify_action/_upload/protocol.py
@@ -47,8 +47,10 @@ class UploadInput:
             raise ValueError("sbom_file is required")
         if self.sbom_format not in ("cyclonedx", "spdx"):
             raise ValueError(f"Invalid sbom_format: {self.sbom_format}")
-        if self.bom_type is not None and self.bom_type not in VALID_BOM_TYPES:
-            raise ValueError(f"Invalid bom_type: {self.bom_type}. Must be one of: {', '.join(VALID_BOM_TYPES)}")
+        if self.bom_type is not None:
+            self.bom_type = self.bom_type.lower()
+            if self.bom_type not in VALID_BOM_TYPES:
+                raise ValueError(f"Invalid bom_type: {self.bom_type}. Must be one of: {', '.join(VALID_BOM_TYPES)}")
 
 
 class DestinationConfig(ABC):

--- a/sbomify_action/_upload/protocol.py
+++ b/sbomify_action/_upload/protocol.py
@@ -8,15 +8,14 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal, Optional, Protocol
 
+# Canonical VALID_BOM_TYPES definition lives next to the backend contract.
+from ..sbomify_api import VALID_BOM_TYPES as VALID_BOM_TYPES
+
 if TYPE_CHECKING:
     from .result import UploadResult
 
 # Supported SBOM formats (same as generation)
 SBOMFormat = Literal["cyclonedx", "spdx"]
-
-# Artifact types the sbomify backend accepts via the ?bom_type= query param.
-# None/"sbom" is the default plain SBOM upload; the others are uploaded as-is.
-VALID_BOM_TYPES = ("sbom", "vex", "cbom", "hbom")
 
 
 @dataclass

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -348,7 +348,7 @@ class Config:
         # action does not synthesize them. Reject any generation source so a generated SBOM can't
         # be uploaded mislabeled as a non-SBOM artifact.
         if self.bom_type and self.bom_type != "sbom":
-            has_real_sbom_file = bool(self.sbom_file) and self.sbom_file.lower() != NONE_SENTINEL
+            has_real_sbom_file = bool(self.sbom_file and self.sbom_file.lower() != NONE_SENTINEL)
             if self.lock_file or self.docker_image or not has_real_sbom_file:
                 raise ConfigurationError(
                     f"BOM_TYPE='{self.bom_type}' uploads a pre-authored artifact verbatim and cannot be "

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -364,6 +364,12 @@ class Config:
                         f"BOM_TYPE='{self.bom_type}' can only be uploaded to sbomify; remove "
                         f"{', '.join(non_sbomify)} from UPLOAD_DESTINATIONS."
                     )
+            # A release holds one SBOM per component and format; tagging a non-SBOM artifact
+            # would either collide with the component's SBOM or wrongly occupy its slot.
+            if self.product_releases:
+                raise ConfigurationError(
+                    f"BOM_TYPE='{self.bom_type}' cannot be tagged into a product release; remove PRODUCT_RELEASE."
+                )
             has_real_sbom_file = bool(self.sbom_file and self.sbom_file.lower() != NONE_SENTINEL)
             if self.lock_file or self.docker_image or not has_real_sbom_file:
                 raise ConfigurationError(
@@ -617,7 +623,7 @@ def build_config(
     # Non-SBOM artifacts (VEX, CBOM, ...) are authored elsewhere and uploaded
     # exactly as written. Augmentation and enrichment rewrite the document, so
     # they are not applied to them regardless of the flags.
-    normalized_bom_type = bom_type.lower() if bom_type else "sbom"
+    normalized_bom_type = str(bom_type).lower() if bom_type else "sbom"
     if normalized_bom_type != "sbom":
         if augment or enrich:
             logger.warning(f"BOM_TYPE={normalized_bom_type} is uploaded verbatim; ignoring AUGMENT/ENRICH.")
@@ -1351,6 +1357,14 @@ def run_pipeline(config: Config) -> None:
             if FILE_TYPE == "SBOM":
                 logger.info(f"Processing existing SBOM file: {FILE}")
                 FORMAT = validate_sbom(FILE)
+                # The config-level CycloneDX-only guard sees the declared SBOM_FORMAT; an
+                # SPDX-content file would slip past it and get byte-rewritten by the SPDX
+                # license sanitization below, so re-check against the detected format.
+                if config.bom_type and config.bom_type != "sbom" and FORMAT != "cyclonedx":
+                    raise SBOMValidationError(
+                        f"BOM_TYPE='{config.bom_type}' requires a CycloneDX artifact, but the file "
+                        f"content is {FORMAT}; it would be re-serialized and break the verbatim upload."
+                    )
                 shutil.copy(FILE, STEP_1_FILE)
 
                 # Sanitize SPDX licenses in input SBOMs (e.g. RPM-style "GPLv2+", "ASL 2.0")
@@ -1701,9 +1715,12 @@ def run_pipeline(config: Config) -> None:
 
         _write_final_output(final_sbom_file, config.output_file, config.bom_type)
 
-        # Clean up temporary files
-        while temp_file := get_last_sbom_from_last_step():
-            Path(temp_file).unlink()
+        # Clean up temporary step files — never the final output itself, which
+        # OUTPUT_FILE may resolve to (the write above is then a copy-to-self no-op).
+        output_realpath = os.path.realpath(config.output_file)
+        for temp_file in (STEP_3_FILE, STEP_2_FILE, STEP_1_FILE):
+            if Path(temp_file).is_file() and os.path.realpath(temp_file) != output_realpath:
+                Path(temp_file).unlink()
 
         logger.info(f"Final {artifact_label} saved to: {config.output_file}")
         _log_step_end(4)
@@ -1745,7 +1762,9 @@ def run_pipeline(config: Config) -> None:
                             f"component_id={config.component_id}, format={FORMAT}, "
                             f"version={config.component_version}"
                         )
-                        print_duplicate_sbom_error(config.component_id, FORMAT, config.component_version)
+                        print_duplicate_sbom_error(
+                            config.component_id, FORMAT, config.component_version, artifact_kind=artifact_label
+                        )
                     elif upload_result.error_code == "COMPONENT_NOT_FOUND":
                         logger.error(
                             f"Upload to {destination} failed: component not found (component_id={config.component_id})"

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -623,7 +623,9 @@ def build_config(
     # Non-SBOM artifacts (VEX, CBOM, ...) are authored elsewhere and uploaded
     # exactly as written. Augmentation and enrichment rewrite the document, so
     # they are not applied to them regardless of the flags.
-    normalized_bom_type = str(bom_type).lower() if bom_type else "sbom"
+    # Only None and "" mean unset (click treats an empty env var the same way);
+    # any other value must survive to validation so garbage is rejected.
+    normalized_bom_type = "sbom" if bom_type is None or bom_type == "" else str(bom_type).lower()
     if normalized_bom_type != "sbom":
         if augment or enrich:
             logger.warning(f"BOM_TYPE={normalized_bom_type} is uploaded verbatim; ignoring AUGMENT/ENRICH.")

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -1212,10 +1212,10 @@ def _write_final_output(src_path: str, dst_path: str, bom_type: Optional[str]) -
     # Read, fix any PURL encoding bugs, and write final SBOM
     # This fixes double-encoded %40%40 or double @@ issues
     # Note: We preserve canonical %40 encoding per PURL spec
-    with open(src_path, "r") as f:
+    with open(src_path, "r", encoding="utf-8") as f:
         content = f.read()
     content = _finalize_output_content(content, bom_type)
-    with open(dst_path, "w") as f:
+    with open(dst_path, "w", encoding="utf-8") as f:
         f.write(content)
 
 

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -608,8 +608,8 @@ def build_config(
     # Non-SBOM artifacts (VEX, CBOM, ...) are authored elsewhere and uploaded
     # exactly as written. Augmentation and enrichment rewrite the document, so
     # they are not applied to them regardless of the flags.
-    normalized_bom_type = bom_type.lower() if bom_type else None
-    if normalized_bom_type and normalized_bom_type != "sbom":
+    normalized_bom_type = bom_type.lower() if bom_type else "sbom"
+    if normalized_bom_type != "sbom":
         if augment or enrich:
             logger.warning(f"BOM_TYPE={normalized_bom_type} is uploaded verbatim; ignoring AUGMENT/ENRICH.")
         augment = False
@@ -2459,9 +2459,9 @@ def _parse_upload_destinations_callback(
     "--bom-type",
     envvar="BOM_TYPE",
     type=click.Choice(list(VALID_BOM_TYPES), case_sensitive=False),
-    default=None,
-    help="Artifact type recorded on upload: sbom (default when unset), vex, cbom or hbom. "
-    "Non-SBOM types are uploaded verbatim.",
+    default="sbom",
+    show_default=True,
+    help="Artifact type recorded on upload. Non-SBOM types are uploaded verbatim.",
 )
 @click.option(
     "--spec-version",

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -142,6 +142,9 @@ SBOMIFY_TOOL_NAME = "sbomify-action"
 SBOMIFY_VENDOR_NAME = "sbomify"
 LOCALHOST_PATTERNS = ["127.0.0.1", "localhost", "0.0.0.0"]
 VALID_SBOM_FORMATS: tuple[str, ...] = ("cyclonedx", "spdx")
+# Artifact types accepted by the backend's ?bom_type= upload param. None/"sbom"
+# is a plain SBOM; "vex"/"cbom"/"hbom" are uploaded verbatim (no finalization).
+VALID_BOM_TYPES: tuple[str, ...] = ("sbom", "vex", "cbom", "hbom")
 NONE_SENTINEL = "none"
 
 # Intermediate SBOM files for pipeline steps
@@ -226,6 +229,7 @@ class Config:
     product_releases: Optional[str | list[str]] = None
     api_base_url: str = SBOMIFY_PRODUCTION_API
     sbom_format: SBOMFormat = "cyclonedx"
+    bom_type: Optional[str] = None
     spec_version: Optional[str] = None
     oidc_audience: str | None = None
     # Set to True at runtime when config.token was obtained via OIDC exchange;
@@ -333,6 +337,12 @@ class Config:
         if self.sbom_format not in VALID_SBOM_FORMATS:
             raise ConfigurationError(
                 f"Invalid SBOM_FORMAT: '{self.sbom_format}'. Must be one of: {', '.join(VALID_SBOM_FORMATS)}"
+            )
+
+        # Validate bom_type (artifact kind recorded on upload)
+        if self.bom_type is not None and self.bom_type not in VALID_BOM_TYPES:
+            raise ConfigurationError(
+                f"Invalid BOM_TYPE: '{self.bom_type}'. Must be one of: {', '.join(VALID_BOM_TYPES)}"
             )
 
         # Validate spec_version against sbom_format
@@ -518,6 +528,7 @@ def build_config(
     product_releases: Optional[str] = None,
     api_base_url: str = SBOMIFY_PRODUCTION_API,
     sbom_format: str = "cyclonedx",
+    bom_type: Optional[str] = None,
     spec_version: Optional[str] = None,
     oidc_audience: Optional[str] = None,
 ) -> Config:
@@ -597,6 +608,7 @@ def build_config(
         product_releases=product_releases,
         api_base_url=api_base_url,
         sbom_format=sbom_format_lower,
+        bom_type=bom_type.lower() if bom_type else None,
         spec_version=spec_version,
         oidc_audience=oidc_audience,
     )
@@ -644,6 +656,7 @@ def load_config() -> Config:
         product_releases=os.getenv("PRODUCT_RELEASE"),
         api_base_url=os.getenv("API_BASE_URL", SBOMIFY_PRODUCTION_API),
         sbom_format=os.getenv("SBOM_FORMAT", "cyclonedx"),
+        bom_type=os.getenv("BOM_TYPE"),
         oidc_audience=os.getenv("OIDC_AUDIENCE"),
     )
 
@@ -1128,6 +1141,24 @@ def _log_step_end(step_num: int | float, success: bool = True) -> None:
     print_step_end(step_num, success)
 
 
+def _finalize_output_content(content: str, bom_type: Optional[str]) -> str:
+    """Return the bytes to upload after format-specific output fixes.
+
+    CycloneDX SBOMs get PURL-encoding repairs and a compositions completeness
+    indicator. Non-SBOM CycloneDX artifacts (VEX, CBOM, ...) are uploaded
+    exactly as authored — sbomify never rewrites a security artifact — so the
+    fixes are skipped. SPDX and other content pass through unchanged.
+    """
+    is_cyclonedx = '"bomFormat"' in content and '"CycloneDX"' in content
+    if not is_cyclonedx:
+        return content
+    if bom_type and bom_type != "sbom":
+        return content
+    content = _fix_purl_encoding_bugs_in_json(content)
+    content = _add_compositions_if_missing(content)
+    return content
+
+
 def run_pipeline(config: Config) -> None:
     """
     Run the SBOM pipeline with the given configuration.
@@ -1574,10 +1605,7 @@ def run_pipeline(config: Config) -> None:
         with open(final_sbom_file, "r") as f:
             content = f.read()
 
-        # Detect format and fix any PURL encoding bugs in CycloneDX
-        if '"bomFormat"' in content and '"CycloneDX"' in content:
-            content = _fix_purl_encoding_bugs_in_json(content)
-            content = _add_compositions_if_missing(content)
+        content = _finalize_output_content(content, config.bom_type)
 
         with open(config.output_file, "w") as f:
             f.write(content)
@@ -1616,6 +1644,7 @@ def run_pipeline(config: Config) -> None:
                     component_version=config.component_version,
                     destination=destination,
                     validate_before_upload=(FORMAT == "cyclonedx"),
+                    bom_type=config.bom_type,
                 )
 
                 if not upload_result.success:
@@ -2355,6 +2384,13 @@ def _parse_upload_destinations_callback(
     help="Output SBOM format.",
 )
 @click.option(
+    "--bom-type",
+    envvar="BOM_TYPE",
+    type=click.Choice(list(VALID_BOM_TYPES), case_sensitive=False),
+    default=None,
+    help="Artifact type recorded on upload (vex/cbom/hbom). Non-SBOM types are uploaded verbatim.",
+)
+@click.option(
     "--spec-version",
     envvar="SPEC_VERSION",
     default=None,
@@ -2414,6 +2450,7 @@ def cli(
     product_releases: Optional[str],
     api_base_url: str,
     sbom_format: str,
+    bom_type: Optional[str],
     spec_version: Optional[str],
     oidc_audience: Optional[str],
     working_dir: str | None,
@@ -2537,6 +2574,7 @@ def cli(
         product_releases=product_releases,
         api_base_url=api_base_url,
         sbom_format=sbom_format,
+        bom_type=bom_type,
         spec_version=spec_version,
         oidc_audience=oidc_audience,
     )

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -19,7 +19,7 @@ import sentry_sdk
 from cyclonedx.model.bom import Bom
 
 from .. import format_display_name
-from .._upload import VALID_DESTINATIONS
+from .._upload import VALID_BOM_TYPES, VALID_DESTINATIONS
 from ..additional_packages import inject_additional_packages
 from ..augmentation import augment_sbom_from_file
 from ..console import (
@@ -142,9 +142,6 @@ SBOMIFY_TOOL_NAME = "sbomify-action"
 SBOMIFY_VENDOR_NAME = "sbomify"
 LOCALHOST_PATTERNS = ["127.0.0.1", "localhost", "0.0.0.0"]
 VALID_SBOM_FORMATS: tuple[str, ...] = ("cyclonedx", "spdx")
-# Artifact types accepted by the backend's ?bom_type= upload param. None/"sbom"
-# is a plain SBOM; "vex"/"cbom"/"hbom" are uploaded verbatim (no finalization).
-VALID_BOM_TYPES: tuple[str, ...] = ("sbom", "vex", "cbom", "hbom")
 NONE_SENTINEL = "none"
 
 # Intermediate SBOM files for pipeline steps

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -348,6 +348,13 @@ class Config:
         # action does not synthesize them. Reject any generation source so a generated SBOM can't
         # be uploaded mislabeled as a non-SBOM artifact.
         if self.bom_type and self.bom_type != "sbom":
+            # SPDX goes through a json.load/json.dump license sanitization that rewrites the
+            # bytes, which would break the verbatim upload. Non-SBOM artifacts are CycloneDX.
+            if self.sbom_format and self.sbom_format.lower() != "cyclonedx":
+                raise ConfigurationError(
+                    f"BOM_TYPE='{self.bom_type}' is only supported for CycloneDX; SBOM_FORMAT="
+                    f"'{self.sbom_format}' would be re-serialized and break the verbatim upload."
+                )
             has_real_sbom_file = bool(self.sbom_file and self.sbom_file.lower() != NONE_SENTINEL)
             if self.lock_file or self.docker_image or not has_real_sbom_file:
                 raise ConfigurationError(

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -577,6 +577,16 @@ def build_config(
     sbom_format_lower: SBOMFormat = cast(SBOMFormat, sbom_format.lower())
     logger.info(f"SBOM format: {format_display_name(sbom_format_lower)}")
 
+    # Non-SBOM artifacts (VEX, CBOM, ...) are authored elsewhere and uploaded
+    # exactly as written. Augmentation and enrichment rewrite the document, so
+    # they are not applied to them regardless of the flags.
+    normalized_bom_type = bom_type.lower() if bom_type else None
+    if normalized_bom_type and normalized_bom_type != "sbom":
+        if augment or enrich:
+            logger.warning(f"BOM_TYPE={normalized_bom_type} is uploaded verbatim; ignoring AUGMENT/ENRICH.")
+        augment = False
+        enrich = False
+
     # Expand paths if provided (skip expansion for "none" sentinel)
     expanded_sbom_file = (
         sbom_file
@@ -608,7 +618,7 @@ def build_config(
         product_releases=product_releases,
         api_base_url=api_base_url,
         sbom_format=sbom_format_lower,
-        bom_type=bom_type.lower() if bom_type else None,
+        bom_type=normalized_bom_type,
         spec_version=spec_version,
         oidc_audience=oidc_audience,
     )

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -1180,7 +1180,10 @@ def _write_final_output(src_path: str, dst_path: str, bom_type: Optional[str]) -
     text path so the CycloneDX fixups in :func:`_finalize_output_content` apply.
     """
     if bom_type and bom_type != "sbom":
-        shutil.copyfile(src_path, dst_path)
+        # When OUTPUT_FILE resolves to the final step file, it is already in place;
+        # copyfile would raise SameFileError, so treat copy-to-self as a no-op.
+        if os.path.realpath(src_path) != os.path.realpath(dst_path):
+            shutil.copyfile(src_path, dst_path)
         return
     # Read, fix any PURL encoding bugs, and write final SBOM
     # This fixes double-encoded %40%40 or double @@ issues

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -387,6 +387,12 @@ class Config:
                 self.component_version = None
                 self.component_purl = None
                 self.override_name = False
+            # Augmentation and enrichment rewrite the document, which also breaks
+            # the verbatim contract.
+            if self.augment or self.enrich:
+                logger.warning(f"BOM_TYPE={self.bom_type} is uploaded verbatim; ignoring AUGMENT/ENRICH.")
+                self.augment = False
+                self.enrich = False
 
         # Validate spec_version against sbom_format
         if self.spec_version:
@@ -620,17 +626,10 @@ def build_config(
     sbom_format_lower: SBOMFormat = cast(SBOMFormat, sbom_format.lower())
     logger.info(f"SBOM format: {format_display_name(sbom_format_lower)}")
 
-    # Non-SBOM artifacts (VEX, CBOM, ...) are authored elsewhere and uploaded
-    # exactly as written. Augmentation and enrichment rewrite the document, so
-    # they are not applied to them regardless of the flags.
     # Only None and "" mean unset (click treats an empty env var the same way);
-    # any other value must survive to validation so garbage is rejected.
+    # any other value must survive to Config.validate() so garbage is rejected.
+    # The verbatim guards (ignoring AUGMENT/ENRICH etc.) live in validate().
     normalized_bom_type = "sbom" if bom_type is None or bom_type == "" else str(bom_type).lower()
-    if normalized_bom_type != "sbom":
-        if augment or enrich:
-            logger.warning(f"BOM_TYPE={normalized_bom_type} is uploaded verbatim; ignoring AUGMENT/ENRICH.")
-        augment = False
-        enrich = False
 
     # Expand paths if provided (skip expansion for "none" sentinel)
     expanded_sbom_file = (

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -344,6 +344,18 @@ class Config:
                 f"Invalid BOM_TYPE: '{self.bom_type}'. Must be one of: {', '.join(VALID_BOM_TYPES)}"
             )
 
+        # Non-SBOM artifacts (VEX/CBOM/HBOM) are authored elsewhere and uploaded verbatim; the
+        # action does not synthesize them. Reject any generation source so a generated SBOM can't
+        # be uploaded mislabeled as a non-SBOM artifact.
+        if self.bom_type and self.bom_type != "sbom":
+            has_real_sbom_file = bool(self.sbom_file) and self.sbom_file.lower() != NONE_SENTINEL
+            if self.lock_file or self.docker_image or not has_real_sbom_file:
+                raise ConfigurationError(
+                    f"BOM_TYPE='{self.bom_type}' uploads a pre-authored artifact verbatim and cannot be "
+                    "generated: provide it via SBOM_FILE (a real path), and do not set LOCK_FILE, "
+                    "DOCKER_IMAGE, or SBOM_FILE=none."
+                )
+
         # Validate spec_version against sbom_format
         if self.spec_version:
             from .._generation import CYCLONEDX_VERSIONS, SPDX_VERSIONS
@@ -1151,7 +1163,7 @@ def _log_step_end(step_num: int | float, success: bool = True) -> None:
 
 
 def _finalize_output_content(content: str, bom_type: Optional[str]) -> str:
-    """Return the bytes to upload after format-specific output fixes.
+    """Return the content to upload after format-specific output fixes.
 
     CycloneDX SBOMs get PURL-encoding repairs and a compositions completeness
     indicator. Non-SBOM CycloneDX artifacts (VEX, CBOM, ...) are uploaded

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -355,6 +355,15 @@ class Config:
                     f"BOM_TYPE='{self.bom_type}' is only supported for CycloneDX; SBOM_FORMAT="
                     f"'{self.sbom_format}' would be re-serialized and break the verbatim upload."
                 )
+            # Only the sbomify backend records bom_type; other destinations re-encode the
+            # payload and would ingest the artifact as a plain SBOM.
+            if self.upload:
+                non_sbomify = [d for d in (self.upload_destinations or []) if d != "sbomify"]
+                if non_sbomify:
+                    raise ConfigurationError(
+                        f"BOM_TYPE='{self.bom_type}' can only be uploaded to sbomify; remove "
+                        f"{', '.join(non_sbomify)} from UPLOAD_DESTINATIONS."
+                    )
             has_real_sbom_file = bool(self.sbom_file and self.sbom_file.lower() != NONE_SENTINEL)
             if self.lock_file or self.docker_image or not has_real_sbom_file:
                 raise ConfigurationError(
@@ -1676,7 +1685,8 @@ def run_pipeline(config: Config) -> None:
         _log_step_end(3)
 
     # Step 4: Finalize output
-    _log_step_header(4, "Finalizing SBOM Output")
+    artifact_label = config.bom_type.upper() if config.bom_type and config.bom_type != "sbom" else "SBOM"
+    _log_step_header(4, f"Finalizing {artifact_label} Output")
     try:
         final_sbom_file = get_last_sbom_from_last_step()
         if not final_sbom_file:
@@ -1695,7 +1705,7 @@ def run_pipeline(config: Config) -> None:
         while temp_file := get_last_sbom_from_last_step():
             Path(temp_file).unlink()
 
-        logger.info(f"Final SBOM saved to: {config.output_file}")
+        logger.info(f"Final {artifact_label} saved to: {config.output_file}")
         _log_step_end(4)
 
     except (FileProcessingError, OSError) as e:
@@ -1706,7 +1716,7 @@ def run_pipeline(config: Config) -> None:
     # Step 5: Upload SBOM to configured destinations
     sbom_id = None  # Store SBOM ID for potential release tagging (from sbomify)
     if config.upload:
-        _log_step_header(5, "Uploading SBOM")
+        _log_step_header(5, f"Uploading {artifact_label}")
         try:
             # Upload to each configured destination
             logger.info(f"Upload destinations: {config.upload_destinations}")

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -355,6 +355,16 @@ class Config:
                     "generated: provide it via SBOM_FILE (a real path), and do not set LOCK_FILE, "
                     "DOCKER_IMAGE, or SBOM_FILE=none."
                 )
+            # Component overrides rewrite the document, which breaks the verbatim contract.
+            if self.component_name or self.component_version or self.component_purl or self.override_name:
+                logger.warning(
+                    f"BOM_TYPE={self.bom_type} is uploaded verbatim; ignoring "
+                    "COMPONENT_NAME/COMPONENT_VERSION/COMPONENT_PURL/OVERRIDE_NAME."
+                )
+                self.component_name = None
+                self.component_version = None
+                self.component_purl = None
+                self.override_name = False
 
         # Validate spec_version against sbom_format
         if self.spec_version:
@@ -1162,13 +1172,35 @@ def _log_step_end(step_num: int | float, success: bool = True) -> None:
     print_step_end(step_num, success)
 
 
+def _write_final_output(src_path: str, dst_path: str, bom_type: Optional[str]) -> None:
+    """Write the final artifact to ``dst_path``.
+
+    Non-SBOM artifacts (VEX, CBOM, ...) are copied byte-for-byte so the upload matches the
+    authored file exactly (a text round-trip could normalise newlines). SBOMs go through the
+    text path so the CycloneDX fixups in :func:`_finalize_output_content` apply.
+    """
+    if bom_type and bom_type != "sbom":
+        shutil.copyfile(src_path, dst_path)
+        return
+    # Read, fix any PURL encoding bugs, and write final SBOM
+    # This fixes double-encoded %40%40 or double @@ issues
+    # Note: We preserve canonical %40 encoding per PURL spec
+    with open(src_path, "r") as f:
+        content = f.read()
+    content = _finalize_output_content(content, bom_type)
+    with open(dst_path, "w") as f:
+        f.write(content)
+
+
 def _finalize_output_content(content: str, bom_type: Optional[str]) -> str:
     """Return the content to upload after format-specific output fixes.
 
     CycloneDX SBOMs get PURL-encoding repairs and a compositions completeness
-    indicator. Non-SBOM CycloneDX artifacts (VEX, CBOM, ...) are uploaded
-    exactly as authored — sbomify never rewrites a security artifact — so the
-    fixes are skipped. SPDX and other content pass through unchanged.
+    indicator. For non-SBOM CycloneDX artifacts (VEX, CBOM, ...) this helper
+    skips those SBOM-specific fixups; the wider verbatim contract (no
+    augment/enrich, no overrides, byte-copy on write) is enforced by Config
+    validation and the finalize step. SPDX and other content pass through
+    unchanged.
     """
     is_cyclonedx = '"bomFormat"' in content and '"CycloneDX"' in content
     if not is_cyclonedx:
@@ -1464,9 +1496,15 @@ def run_pipeline(config: Config) -> None:
         logger.info(f"Applying component PURL override: {config.component_purl}")
         _apply_sbom_purl_override(STEP_1_FILE, config)
 
-    # Inject additional packages if specified (file or environment variables)
+    # Inject additional packages if specified (file or environment variables).
+    # Non-SBOM artifacts upload verbatim, so injection is skipped for them.
+    if config.bom_type and config.bom_type != "sbom":
+        logger.info(f"BOM_TYPE={config.bom_type} is uploaded verbatim; skipping additional package injection.")
+        _skip_injection = True
+    else:
+        _skip_injection = False
     try:
-        injected_count = inject_additional_packages(STEP_1_FILE)
+        injected_count = 0 if _skip_injection else inject_additional_packages(STEP_1_FILE)
         if injected_count > 0:
             logger.info(f"Successfully injected {injected_count} additional package(s) into SBOM")
         elif config.is_additional_packages_only:
@@ -1641,16 +1679,7 @@ def run_pipeline(config: Config) -> None:
         if parent_dir != Path(".") and not parent_dir.exists():
             parent_dir.mkdir(parents=True, exist_ok=True)
 
-        # Read, fix any PURL encoding bugs, and write final SBOM
-        # This fixes double-encoded %40%40 or double @@ issues
-        # Note: We preserve canonical %40 encoding per PURL spec
-        with open(final_sbom_file, "r") as f:
-            content = f.read()
-
-        content = _finalize_output_content(content, config.bom_type)
-
-        with open(config.output_file, "w") as f:
-            f.write(content)
+        _write_final_output(final_sbom_file, config.output_file, config.bom_type)
 
         # Clean up temporary files
         while temp_file := get_last_sbom_from_last_step():
@@ -2421,7 +2450,8 @@ def _parse_upload_destinations_callback(
     envvar="BOM_TYPE",
     type=click.Choice(list(VALID_BOM_TYPES), case_sensitive=False),
     default=None,
-    help="Artifact type recorded on upload (vex/cbom/hbom). Non-SBOM types are uploaded verbatim.",
+    help="Artifact type recorded on upload: sbom (default when unset), vex, cbom or hbom. "
+    "Non-SBOM types are uploaded verbatim.",
 )
 @click.option(
     "--spec-version",

--- a/sbomify_action/console.py
+++ b/sbomify_action/console.py
@@ -395,11 +395,14 @@ def print_duplicate_sbom_error(
     panel = Panel(content, title=f"[bold red]Duplicate {artifact_kind}[/bold red]", border_style="red")
     console.print(panel)
 
-    # Also emit GHA error annotation
-    gha_error(
-        f"{artifact_kind} already exists for this component version",
-        title=f"Duplicate {artifact_kind}",
-    )
+    # Also emit GHA error annotation, mirroring the panel guidance
+    if artifact_kind == "SBOM":
+        gha_error("SBOM already exists for this component version", title="Duplicate SBOM")
+    else:
+        gha_error(
+            f"{artifact_kind} already exists for this component; bump the version inside the authored document",
+            title=f"Duplicate {artifact_kind}",
+        )
 
 
 def print_component_not_found_error(component_id: str) -> None:

--- a/sbomify_action/console.py
+++ b/sbomify_action/console.py
@@ -357,35 +357,49 @@ def print_upload_summary(
             console.print(f"  Error: {error_message}")
 
 
-def print_duplicate_sbom_error(component_id: str, sbom_format: str, component_version: Optional[str] = None) -> None:
+def print_duplicate_sbom_error(
+    component_id: str,
+    sbom_format: str,
+    component_version: Optional[str] = None,
+    artifact_kind: str = "SBOM",
+) -> None:
     """
-    Print a styled error panel for duplicate SBOM upload.
+    Print a styled error panel for a duplicate artifact upload.
 
-    This provides a clear, user-friendly error message when an SBOM
+    This provides a clear, user-friendly error message when an artifact
     already exists for the component, with suggested solutions.
 
     Args:
         component_id: The component ID that has the duplicate
         sbom_format: SBOM format (cyclonedx/spdx)
         component_version: The component version that has the duplicate
+        artifact_kind: Display kind of the artifact (SBOM, VEX, CBOM, HBOM);
+            non-SBOM kinds upload verbatim, so COMPONENT_VERSION advice does
+            not apply to them
     """
     content = Text()
-    content.append("An SBOM already exists for this component.\n\n", style="bold")
+    content.append(f"A duplicate {artifact_kind} already exists for this component.\n\n", style="bold")
     content.append("Details:\n", style="cyan")
     content.append(f"  Component ID: {component_id}\n")
     if component_version:
         content.append(f"  Version: {component_version}\n")
     content.append(f"  Format: {format_display_name(sbom_format)}\n\n")
     content.append("Possible solutions:\n", style="cyan")
-    content.append("  1. Set a unique version via COMPONENT_VERSION or --component-version\n")
-    content.append("  2. Delete the existing SBOM in the sbomify dashboard\n")
+    if artifact_kind == "SBOM":
+        content.append("  1. Set a unique version via COMPONENT_VERSION or --component-version\n")
+    else:
+        content.append("  1. Bump the version inside the authored document (COMPONENT_VERSION is ignored)\n")
+    content.append(f"  2. Delete the existing {artifact_kind} in the sbomify dashboard\n")
     content.append("  3. Use a different component ID\n")
 
-    panel = Panel(content, title="[bold red]Duplicate SBOM[/bold red]", border_style="red")
+    panel = Panel(content, title=f"[bold red]Duplicate {artifact_kind}[/bold red]", border_style="red")
     console.print(panel)
 
     # Also emit GHA error annotation
-    gha_error("SBOM already exists for this component version", title="Duplicate SBOM")
+    gha_error(
+        f"{artifact_kind} already exists for this component version",
+        title=f"Duplicate {artifact_kind}",
+    )
 
 
 def print_component_not_found_error(component_id: str) -> None:

--- a/sbomify_action/sbomify_api.py
+++ b/sbomify_action/sbomify_api.py
@@ -808,6 +808,8 @@ class SbomifyApiClient:
         if content_encoding:
             extra["Content-Encoding"] = content_encoding
         # Lower-case like the rest of the stack; the backend enum is lowercase.
+        if bom_type is not None and not isinstance(bom_type, str):
+            raise ValueError(f"Invalid bom_type: {bom_type!r}. Must be a string (sbom/vex/cbom/hbom) or None.")
         normalized_bom_type = bom_type.lower() if bom_type else None
         params = {"bom_type": normalized_bom_type} if normalized_bom_type and normalized_bom_type != "sbom" else None
         return self._request(

--- a/sbomify_action/sbomify_api.py
+++ b/sbomify_action/sbomify_api.py
@@ -794,7 +794,7 @@ class SbomifyApiClient:
         content_encoding: str | None = None,
         timeout: int | None = None,
     ) -> requests.Response:
-        """POST raw SBOM bytes to ``/api/v1/sboms/artifact/{format}/{id}``.
+        """POST a raw artifact (SBOM/VEX/CBOM/HBOM) to ``/api/v1/sboms/artifact/{format}/{id}``.
 
         ``bom_type`` (sbom/vex/cbom/hbom) is forwarded as the ``?bom_type=``
         query param when set, so the same endpoint can record a VEX or CBOM

--- a/sbomify_action/sbomify_api.py
+++ b/sbomify_action/sbomify_api.py
@@ -807,7 +807,7 @@ class SbomifyApiClient:
         extra: dict[str, str] = {"Content-Type": "application/json"}
         if content_encoding:
             extra["Content-Encoding"] = content_encoding
-        params = {"bom_type": bom_type} if bom_type else None
+        params = {"bom_type": bom_type} if bom_type and bom_type != "sbom" else None
         return self._request(
             "POST",
             path,

--- a/sbomify_action/sbomify_api.py
+++ b/sbomify_action/sbomify_api.py
@@ -25,6 +25,10 @@ DEFAULT_TIMEOUT = 60
 DEFAULT_PAGE_SIZE = 100
 MAX_PAGES = 500  # Safety limit against runaway pagination.
 
+# Artifact types the sbomify backend accepts via the ?bom_type= query param.
+# None/"sbom" is the default plain SBOM upload; the others are uploaded as-is.
+VALID_BOM_TYPES = ("sbom", "vex", "cbom", "hbom")
+
 # Component types the sbomify backend accepts (mirrors
 # ``core.schemas.ComponentType``: BOM="bom", DOCUMENT="document"). There is
 # NO "sbom" value — passing one trips a server-side 422. We validate
@@ -809,8 +813,10 @@ class SbomifyApiClient:
             extra["Content-Encoding"] = content_encoding
         # Lower-case like the rest of the stack; the backend enum is lowercase.
         if bom_type is not None and not isinstance(bom_type, str):
-            raise ValueError(f"Invalid bom_type: {bom_type!r}. Must be a string (sbom/vex/cbom/hbom) or None.")
+            raise ValueError(f"Invalid bom_type: {bom_type!r}. Must be one of: {', '.join(VALID_BOM_TYPES)}")
         normalized_bom_type = bom_type.lower() if bom_type else None
+        if normalized_bom_type is not None and normalized_bom_type not in VALID_BOM_TYPES:
+            raise ValueError(f"Invalid bom_type: {bom_type!r}. Must be one of: {', '.join(VALID_BOM_TYPES)}")
         params = {"bom_type": normalized_bom_type} if normalized_bom_type and normalized_bom_type != "sbom" else None
         return self._request(
             "POST",

--- a/sbomify_action/sbomify_api.py
+++ b/sbomify_action/sbomify_api.py
@@ -790,23 +790,29 @@ class SbomifyApiClient:
         sbom_payload: bytes,
         *,
         sbom_format: str = "cyclonedx",
+        bom_type: str | None = None,
         content_encoding: str | None = None,
         timeout: int | None = None,
     ) -> requests.Response:
         """POST raw SBOM bytes to ``/api/v1/sboms/artifact/{format}/{id}``.
 
-        The destination layer owns error-to-``UploadResult`` translation, so
-        this method returns the raw response (including non-2xx) instead of
-        raising. Network/timeout failures still bubble up as ``APIError``.
+        ``bom_type`` (sbom/vex/cbom/hbom) is forwarded as the ``?bom_type=``
+        query param when set, so the same endpoint can record a VEX or CBOM
+        rather than a plain SBOM. The destination layer owns
+        error-to-``UploadResult`` translation, so this method returns the raw
+        response (including non-2xx) instead of raising. Network/timeout
+        failures still bubble up as ``APIError``.
         """
         path = f"/api/v1/sboms/artifact/{sbom_format}/{component_id}"
         extra: dict[str, str] = {"Content-Type": "application/json"}
         if content_encoding:
             extra["Content-Encoding"] = content_encoding
+        params = {"bom_type": bom_type} if bom_type else None
         return self._request(
             "POST",
             path,
             data=sbom_payload,
+            params=params,
             extra_headers=extra,
             timeout=timeout,
         )

--- a/sbomify_action/sbomify_api.py
+++ b/sbomify_action/sbomify_api.py
@@ -807,7 +807,9 @@ class SbomifyApiClient:
         extra: dict[str, str] = {"Content-Type": "application/json"}
         if content_encoding:
             extra["Content-Encoding"] = content_encoding
-        params = {"bom_type": bom_type} if bom_type and bom_type != "sbom" else None
+        # Lower-case like the rest of the stack; the backend enum is lowercase.
+        normalized_bom_type = bom_type.lower() if bom_type else None
+        params = {"bom_type": normalized_bom_type} if normalized_bom_type and normalized_bom_type != "sbom" else None
         return self._request(
             "POST",
             path,

--- a/sbomify_action/upload.py
+++ b/sbomify_action/upload.py
@@ -73,6 +73,8 @@ def upload_sbom(
         component_version: Component version (for Dependency Track project)
         destination: Destination to upload to (default: "sbomify")
         validate_before_upload: Whether to validate SBOM before uploading
+        bom_type: Artifact type recorded on upload (sbom/vex/cbom/hbom). None
+            uploads a plain SBOM; non-SBOM types are sent verbatim.
 
     Returns:
         UploadResult with success status, sbom_id, and metadata
@@ -140,6 +142,8 @@ def upload_to_all(
         component_name: Component name (for Dependency Track)
         component_version: Component version (for Dependency Track)
         validate_before_upload: Whether to validate SBOM before uploading
+        bom_type: Artifact type recorded on upload (sbom/vex/cbom/hbom). None
+            uploads a plain SBOM; non-SBOM types are sent verbatim.
 
     Returns:
         List of UploadResult from each configured destination

--- a/sbomify_action/upload.py
+++ b/sbomify_action/upload.py
@@ -58,6 +58,7 @@ def upload_sbom(
     component_version: Optional[str] = None,
     destination: str = "sbomify",
     validate_before_upload: bool = True,
+    bom_type: Optional[str] = None,
 ) -> UploadResult:
     """
     Upload an SBOM to a specific destination.
@@ -97,6 +98,7 @@ def upload_sbom(
     input_params = UploadInput(
         sbom_file=sbom_file,
         sbom_format=sbom_format,  # type: ignore[arg-type]
+        bom_type=bom_type,
         component_name=component_name,
         component_version=component_version,
         validate_before_upload=validate_before_upload,
@@ -120,6 +122,7 @@ def upload_to_all(
     component_name: Optional[str] = None,
     component_version: Optional[str] = None,
     validate_before_upload: bool = True,
+    bom_type: Optional[str] = None,
 ) -> List[UploadResult]:
     """
     Upload an SBOM to all configured destinations.
@@ -157,6 +160,7 @@ def upload_to_all(
     input_params = UploadInput(
         sbom_file=sbom_file,
         sbom_format=sbom_format,  # type: ignore[arg-type]
+        bom_type=bom_type,
         component_name=component_name,
         component_version=component_version,
         validate_before_upload=validate_before_upload,

--- a/sbomify_action/upload.py
+++ b/sbomify_action/upload.py
@@ -73,8 +73,10 @@ def upload_sbom(
         component_version: Component version (for Dependency Track project)
         destination: Destination to upload to (default: "sbomify")
         validate_before_upload: Whether to validate SBOM before uploading
-        bom_type: Artifact type recorded on upload (sbom/vex/cbom/hbom). None
-            uploads a plain SBOM; non-SBOM types are sent verbatim.
+        bom_type: Artifact type recorded on upload (sbom/vex/cbom/hbom).
+            Meaningful only for the sbomify destination, which records it via
+            ?bom_type=; other destinations (e.g. dependency-track) ignore it and
+            may re-encode the payload. None uploads a plain SBOM.
 
     Returns:
         UploadResult with success status, sbom_id, and metadata
@@ -142,8 +144,10 @@ def upload_to_all(
         component_name: Component name (for Dependency Track)
         component_version: Component version (for Dependency Track)
         validate_before_upload: Whether to validate SBOM before uploading
-        bom_type: Artifact type recorded on upload (sbom/vex/cbom/hbom). None
-            uploads a plain SBOM; non-SBOM types are sent verbatim.
+        bom_type: Artifact type recorded on upload (sbom/vex/cbom/hbom).
+            Meaningful only for the sbomify destination, which records it via
+            ?bom_type=; other destinations (e.g. dependency-track) ignore it and
+            may re-encode the payload. None uploads a plain SBOM.
 
     Returns:
         List of UploadResult from each configured destination

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -129,6 +129,34 @@ class TestConfig(unittest.TestCase):
             config.validate()
         self.assertIn("CycloneDX", str(cm.exception))
 
+    def test_bom_type_non_sbom_rejects_non_sbomify_destinations(self):
+        """Non-SBOM artifacts are only recorded by the sbomify backend; other
+        destinations re-encode the payload and treat it as a plain SBOM."""
+        config = Config(
+            token="test-token",
+            component_id="test-component",
+            bom_type="vex",
+            sbom_file="/path/to/authored.vex.cdx.json",
+            upload=True,
+            upload_destinations=["sbomify", "dependency-track"],
+        )
+        with self.assertRaises(ConfigurationError) as cm:
+            config.validate()
+        self.assertIn("dependency-track", str(cm.exception))
+
+    def test_bom_type_non_sbom_no_upload_allows_other_destinations(self):
+        """With UPLOAD=false nothing is sent anywhere, so configured
+        destinations are irrelevant and must not fail validation."""
+        config = Config(
+            token="test-token",
+            component_id="test-component",
+            bom_type="vex",
+            sbom_file="/path/to/authored.vex.cdx.json",
+            upload=False,
+            upload_destinations=["sbomify", "dependency-track"],
+        )
+        config.validate()  # no error
+
     def test_config_validation_valid_config(self):
         """Test that Config validation passes with valid configuration."""
         config = Config(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -104,6 +104,21 @@ class TestConfig(unittest.TestCase):
         self.assertIsNone(config.component_purl)
         self.assertFalse(config.override_name)
 
+    def test_bom_type_non_sbom_clears_augment_enrich(self):
+        """The verbatim guard lives in validate() itself, so directly
+        constructed configs cannot augment/enrich a non-SBOM artifact."""
+        config = Config(
+            token="test-token",
+            component_id="test-component",
+            bom_type="vex",
+            sbom_file="/path/to/authored.vex.cdx.json",
+            augment=True,
+            enrich=True,
+        )
+        config.validate()
+        self.assertFalse(config.augment)
+        self.assertFalse(config.enrich)
+
     def test_bom_type_non_sbom_with_real_file_ok(self):
         """A non-SBOM BOM_TYPE with a real SBOM_FILE (pre-authored artifact) validates."""
         config = Config(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -61,6 +61,42 @@ class TestConfig(unittest.TestCase):
 
         self.assertIn("Please provide one of", str(cm.exception))
 
+    def test_bom_type_non_sbom_rejects_generation(self):
+        """A non-SBOM BOM_TYPE with a generation source is rejected (it would generate an SBOM and
+        upload it mislabeled)."""
+        config = Config(
+            token="test-token",
+            component_id="test-component",
+            bom_type="vex",
+            lock_file="/path/to/requirements.txt",
+        )
+        with self.assertRaises(ConfigurationError) as cm:
+            config.validate()
+        self.assertIn("cannot be", str(cm.exception))
+
+    def test_bom_type_non_sbom_rejects_docker_generation(self):
+        """A non-SBOM BOM_TYPE with a docker image (generation) is rejected."""
+        config = Config(
+            token="test-token",
+            component_id="test-component",
+            bom_type="hbom",
+            docker_image="alpine:latest",
+        )
+        with self.assertRaises(ConfigurationError) as cm:
+            config.validate()
+        self.assertIn("verbatim", str(cm.exception))
+
+    def test_bom_type_non_sbom_with_real_file_ok(self):
+        """A non-SBOM BOM_TYPE with a real SBOM_FILE (pre-authored artifact) validates."""
+        config = Config(
+            token="test-token",
+            component_id="test-component",
+            bom_type="vex",
+            sbom_file="/path/to/authored.vex.cdx.json",
+            upload=True,
+        )
+        config.validate()  # no error
+
     def test_config_validation_valid_config(self):
         """Test that Config validation passes with valid configuration."""
         config = Config(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -115,6 +115,20 @@ class TestConfig(unittest.TestCase):
         )
         config.validate()  # no error
 
+    def test_bom_type_non_sbom_rejects_spdx_format(self):
+        """A non-SBOM BOM_TYPE with SPDX is rejected: SPDX sanitization would rewrite the bytes."""
+        config = Config(
+            token="test-token",
+            component_id="test-component",
+            bom_type="vex",
+            sbom_file="/path/to/authored.vex.cdx.json",
+            sbom_format="spdx",
+            upload=True,
+        )
+        with self.assertRaises(ConfigurationError) as cm:
+            config.validate()
+        self.assertIn("CycloneDX", str(cm.exception))
+
     def test_config_validation_valid_config(self):
         """Test that Config validation passes with valid configuration."""
         config = Config(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1002,7 +1002,7 @@ class TestBuildConfig(unittest.TestCase):
             )
             self.assertTrue(config.augment)
             self.assertTrue(config.enrich)
-            self.assertIsNone(config.bom_type)
+            self.assertEqual(config.bom_type, "sbom")
 
     def test_build_config_defaults(self):
         """Test build_config uses correct defaults."""
@@ -1026,6 +1026,15 @@ class TestBuildConfig(unittest.TestCase):
             self.assertFalse(config.override_sbom_metadata)
             self.assertEqual(config.api_base_url, SBOMIFY_PRODUCTION_API)
             self.assertEqual(config.sbom_format, "cyclonedx")
+            self.assertEqual(config.bom_type, "sbom")
+
+    def test_cli_bom_type_option_defaults_to_sbom(self):
+        """The --bom-type click option itself defaults to 'sbom' so --help and
+        the parsed value agree; unset must not reach the pipeline as None."""
+        from sbomify_action.cli.main import cli
+
+        param = next(p for p in cli.params if p.name == "bom_type")
+        self.assertEqual(param.default, "sbom")
 
     def test_build_config_normalizes_sbom_format_case(self):
         """Test that build_config normalizes SBOM format to lowercase."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -86,6 +86,24 @@ class TestConfig(unittest.TestCase):
             config.validate()
         self.assertIn("verbatim", str(cm.exception))
 
+    def test_bom_type_non_sbom_clears_component_overrides(self):
+        """Non-SBOM BOM_TYPE ignores document-rewriting override inputs (verbatim contract)."""
+        config = Config(
+            token="test-token",
+            component_id="test-component",
+            bom_type="vex",
+            sbom_file="/path/to/authored.vex.cdx.json",
+            component_name="renamed",
+            component_version="9.9.9",
+            component_purl="pkg:npm/renamed@9.9.9",
+            override_name=True,
+        )
+        config.validate()
+        self.assertIsNone(config.component_name)
+        self.assertIsNone(config.component_version)
+        self.assertIsNone(config.component_purl)
+        self.assertFalse(config.override_name)
+
     def test_bom_type_non_sbom_with_real_file_ok(self):
         """A non-SBOM BOM_TYPE with a real SBOM_FILE (pre-authored artifact) validates."""
         config = Config(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1083,6 +1083,30 @@ class TestBuildConfig(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 build_config(sbom_file=str(sbom_file), upload=False, bom_type=123)  # type: ignore[arg-type]
 
+    def test_build_config_falsy_non_string_bom_type_rejected(self):
+        """Only None and '' mean unset; other falsy garbage (0, False) must be
+        rejected by validation, not silently coerced to the default."""
+        from sbomify_action.cli.main import build_config
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            sbom_file = Path(tmp_dir) / "sbom.cdx.json"
+            sbom_file.write_text('{"bomFormat": "CycloneDX", "specVersion": "1.6"}')
+
+            with self.assertRaises(SystemExit):
+                build_config(sbom_file=str(sbom_file), upload=False, bom_type=0)  # type: ignore[arg-type]
+
+    def test_build_config_empty_string_bom_type_means_unset(self):
+        """An empty BOM_TYPE means unset, mirroring click's empty-envvar
+        semantics, and resolves to the sbom default."""
+        from sbomify_action.cli.main import build_config
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            sbom_file = Path(tmp_dir) / "sbom.cdx.json"
+            sbom_file.write_text('{"bomFormat": "CycloneDX", "specVersion": "1.6"}')
+
+            config = build_config(sbom_file=str(sbom_file), upload=False, bom_type="")
+            self.assertEqual(config.bom_type, "sbom")
+
     def test_cli_bom_type_option_defaults_to_sbom(self):
         """The --bom-type click option itself defaults to 'sbom' so --help and
         the parsed value agree; unset must not reach the pipeline as None."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -898,6 +898,44 @@ class TestBuildConfig(unittest.TestCase):
             self.assertEqual(config.api_base_url, "https://custom.api.com")
             self.assertEqual(config.sbom_format, "spdx")
 
+    def test_build_config_non_sbom_bom_type_forces_verbatim(self):
+        """A non-SBOM bom_type (VEX/CBOM) disables augment/enrich so the
+        artifact is uploaded exactly as authored."""
+        from sbomify_action.cli.main import build_config
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            vex_file = Path(tmp_dir) / "x.vex.cdx.json"
+            vex_file.write_text('{"bomFormat": "CycloneDX", "specVersion": "1.6"}')
+
+            config = build_config(
+                sbom_file=str(vex_file),
+                upload=False,
+                augment=True,
+                enrich=True,
+                bom_type="vex",
+            )
+            self.assertEqual(config.bom_type, "vex")
+            self.assertFalse(config.augment)
+            self.assertFalse(config.enrich)
+
+    def test_build_config_sbom_keeps_augment_enrich(self):
+        """A plain SBOM upload still augments and enriches."""
+        from sbomify_action.cli.main import build_config
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            sbom_file = Path(tmp_dir) / "sbom.cdx.json"
+            sbom_file.write_text('{"bomFormat": "CycloneDX", "specVersion": "1.6"}')
+
+            config = build_config(
+                sbom_file=str(sbom_file),
+                upload=False,
+                augment=True,
+                enrich=True,
+            )
+            self.assertTrue(config.augment)
+            self.assertTrue(config.enrich)
+            self.assertIsNone(config.bom_type)
+
     def test_build_config_defaults(self):
         """Test build_config uses correct defaults."""
         from sbomify_action.cli.main import SBOMIFY_PRODUCTION_API, build_config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -144,6 +144,21 @@ class TestConfig(unittest.TestCase):
             config.validate()
         self.assertIn("dependency-track", str(cm.exception))
 
+    def test_bom_type_non_sbom_rejects_product_release(self):
+        """Releases hold one SBOM per component and format; tagging a VEX/CBOM
+        into a release either collides with the component's SBOM or occupies
+        its slot, so PRODUCT_RELEASE is rejected for non-SBOM artifacts."""
+        config = Config(
+            token="test-token",
+            component_id="test-component",
+            bom_type="vex",
+            sbom_file="/path/to/authored.vex.cdx.json",
+            product_releases='["myproduct:v1.0.0"]',
+        )
+        with self.assertRaises(ConfigurationError) as cm:
+            config.validate()
+        self.assertIn("PRODUCT_RELEASE", str(cm.exception))
+
     def test_bom_type_non_sbom_no_upload_allows_other_destinations(self):
         """With UPLOAD=false nothing is sent anywhere, so configured
         destinations are irrelevant and must not fail validation."""
@@ -1055,6 +1070,18 @@ class TestBuildConfig(unittest.TestCase):
             self.assertEqual(config.api_base_url, SBOMIFY_PRODUCTION_API)
             self.assertEqual(config.sbom_format, "cyclonedx")
             self.assertEqual(config.bom_type, "sbom")
+
+    def test_build_config_non_string_bom_type_exits_cleanly(self):
+        """A non-string bom_type from an untyped caller must exit via the
+        ConfigurationError path, not crash with AttributeError on .lower()."""
+        from sbomify_action.cli.main import build_config
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            sbom_file = Path(tmp_dir) / "sbom.cdx.json"
+            sbom_file.write_text('{"bomFormat": "CycloneDX", "specVersion": "1.6"}')
+
+            with self.assertRaises(SystemExit):
+                build_config(sbom_file=str(sbom_file), upload=False, bom_type=123)  # type: ignore[arg-type]
 
     def test_cli_bom_type_option_defaults_to_sbom(self):
         """The --bom-type click option itself defaults to 'sbom' so --help and

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -375,6 +375,26 @@ class TestDuplicateSbomError(unittest.TestCase):
             component_version="2.0.0",
         )
 
+    @patch("sbomify_action.console.IS_GITHUB_ACTIONS", True)
+    def test_print_duplicate_non_sbom_annotation_matches_guidance(self):
+        """The GHA annotation for a non-SBOM duplicate must mirror the panel:
+        the version to bump lives inside the authored document, and
+        COMPONENT_VERSION advice does not apply."""
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            print_duplicate_sbom_error(
+                component_id="c1",
+                sbom_format="cyclonedx",
+                artifact_kind="VEX",
+            )
+        annotations = [line for line in buf.getvalue().splitlines() if line.startswith("::error")]
+        self.assertTrue(annotations)
+        self.assertIn("authored document", annotations[0])
+        self.assertNotIn("component version", annotations[0])
+
 
 class TestFinalMessages(unittest.TestCase):
     """Tests for final success/failure messages."""

--- a/tests/test_finalize_bom_type.py
+++ b/tests/test_finalize_bom_type.py
@@ -1,0 +1,34 @@
+"""Output finalization must leave non-SBOM artifacts (e.g. VEX) untouched."""
+
+from __future__ import annotations
+
+from sbomify_action.cli.main import _finalize_output_content
+
+CYCLONEDX = '{"bomFormat": "CycloneDX", "specVersion": "1.6", "components": []}'
+
+
+def test_sbom_gets_compositions_injected() -> None:
+    out = _finalize_output_content(CYCLONEDX, None)
+    assert '"compositions"' in out
+
+
+def test_explicit_sbom_bom_type_still_finalized() -> None:
+    out = _finalize_output_content(CYCLONEDX, "sbom")
+    assert '"compositions"' in out
+
+
+def test_vex_is_uploaded_verbatim() -> None:
+    # A VEX is an immutable security artifact: no composition injection, no
+    # PURL rewriting, byte-for-byte what was authored.
+    out = _finalize_output_content(CYCLONEDX, "vex")
+    assert out == CYCLONEDX
+
+
+def test_cbom_is_uploaded_verbatim() -> None:
+    out = _finalize_output_content(CYCLONEDX, "cbom")
+    assert out == CYCLONEDX
+
+
+def test_non_cyclonedx_passthrough() -> None:
+    spdx = '{"spdxVersion": "SPDX-2.3", "name": "x"}'
+    assert _finalize_output_content(spdx, None) == spdx

--- a/tests/test_finalize_bom_type.py
+++ b/tests/test_finalize_bom_type.py
@@ -32,3 +32,26 @@ def test_cbom_is_uploaded_verbatim() -> None:
 def test_non_cyclonedx_passthrough() -> None:
     spdx = '{"spdxVersion": "SPDX-2.3", "name": "x"}'
     assert _finalize_output_content(spdx, None) == spdx
+
+
+def test_write_final_output_copies_non_sbom_bytes_exactly(tmp_path):
+    """VEX/CBOM write is a byte copy: CRLF newlines and exact bytes survive."""
+    from sbomify_action.cli.main import _write_final_output
+
+    src = tmp_path / "authored.vex.cdx.json"
+    raw = b'{"bomFormat": "CycloneDX",\r\n "specVersion": "1.6"}\r\n'
+    src.write_bytes(raw)
+    dst = tmp_path / "out.json"
+    _write_final_output(str(src), str(dst), "vex")
+    assert dst.read_bytes() == raw
+
+
+def test_write_final_output_sbom_still_applies_fixups(tmp_path):
+    """The plain-SBOM path still goes through the text fixups (compositions added)."""
+    from sbomify_action.cli.main import _write_final_output
+
+    src = tmp_path / "sbom.cdx.json"
+    src.write_text('{"bomFormat": "CycloneDX", "specVersion": "1.6", "components": []}')
+    dst = tmp_path / "out.json"
+    _write_final_output(str(src), str(dst), None)
+    assert "compositions" in dst.read_text()

--- a/tests/test_finalize_bom_type.py
+++ b/tests/test_finalize_bom_type.py
@@ -46,6 +46,17 @@ def test_write_final_output_copies_non_sbom_bytes_exactly(tmp_path):
     assert dst.read_bytes() == raw
 
 
+def test_write_final_output_non_sbom_same_path_is_noop(tmp_path):
+    """When OUTPUT_FILE == the final step file, a non-SBOM write is a no-op, not a SameFileError."""
+    from sbomify_action.cli.main import _write_final_output
+
+    p = tmp_path / "authored.vex.cdx.json"
+    raw = b'{"bomFormat": "CycloneDX", "specVersion": "1.6"}'
+    p.write_bytes(raw)
+    _write_final_output(str(p), str(p), "vex")  # must not raise
+    assert p.read_bytes() == raw
+
+
 def test_write_final_output_sbom_still_applies_fixups(tmp_path):
     """The plain-SBOM path still goes through the text fixups (compositions added)."""
     from sbomify_action.cli.main import _write_final_output

--- a/tests/test_pipeline_bom_type.py
+++ b/tests/test_pipeline_bom_type.py
@@ -1,0 +1,71 @@
+"""End-to-end pipeline behavior for non-SBOM artifacts (BOM_TYPE=vex/cbom/hbom).
+
+These run the real pipeline (UPLOAD=false) in a temp working directory and pin
+the verbatim contract at the level users experience it: the bytes written to
+OUTPUT_FILE are exactly the authored bytes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sbomify_action.cli.main import build_config, run_pipeline
+
+AUTHORED_VEX = (
+    b'{"bomFormat": "CycloneDX",\r\n'
+    b'  "specVersion": "1.6",\n'
+    b'  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",\n'
+    b'  "version": 7,\n'
+    b'  "vulnerabilities": [{"id": "CVE-2026-0001"}]}\n'
+)
+
+
+def _vex_config(tmp_path, monkeypatch, **overrides):
+    monkeypatch.chdir(tmp_path)
+    src = tmp_path / "authored.vex.cdx.json"
+    src.write_bytes(AUTHORED_VEX)
+    kwargs = dict(
+        sbom_file=str(src),
+        upload=False,
+        bom_type="vex",
+        output_file="out.vex.json",
+    )
+    kwargs.update(overrides)
+    return build_config(**kwargs), src
+
+
+def test_pipeline_vex_verbatim_end_to_end(tmp_path, monkeypatch):
+    """The full pipeline must not alter a single byte of an authored VEX —
+    CRLF, key order, indentation and the document's own version survive,
+    even with additional-package injection configured."""
+    monkeypatch.setenv("ADDITIONAL_PACKAGES", "extra-package==1.0.0")
+    config, _ = _vex_config(tmp_path, monkeypatch)
+    run_pipeline(config)
+    assert (tmp_path / "out.vex.json").read_bytes() == AUTHORED_VEX
+
+
+def test_pipeline_non_sbom_rejects_spdx_content(tmp_path, monkeypatch):
+    """An SPDX-content file with a non-SBOM BOM_TYPE must fail loud in step 1:
+    the declared-format guard in Config.validate() cannot see file content, and
+    the SPDX license sanitization would rewrite the authored bytes."""
+    monkeypatch.chdir(tmp_path)
+    src = tmp_path / "doc.json"
+    src.write_bytes(b'{"spdxVersion": "SPDX-2.3", "name": "x", "packages": []}')
+    config = build_config(
+        sbom_file=str(src),
+        upload=False,
+        bom_type="vex",
+        output_file="out.json",
+    )
+    with pytest.raises(SystemExit) as exc:
+        run_pipeline(config)
+    assert exc.value.code == 1
+
+
+def test_pipeline_output_file_colliding_with_step_file_survives_cleanup(tmp_path, monkeypatch):
+    """OUTPUT_FILE resolving to the internal step file must not be deleted by
+    the temp-file cleanup: the write is a copy-to-self no-op and the cleanup
+    loop must never unlink the final output."""
+    config, _ = _vex_config(tmp_path, monkeypatch, output_file="step_1.json")
+    run_pipeline(config)
+    assert (tmp_path / "step_1.json").read_bytes() == AUTHORED_VEX

--- a/tests/test_sbomify_api.py
+++ b/tests/test_sbomify_api.py
@@ -518,6 +518,14 @@ def test_upload_sbom_non_string_bom_type_raises_value_error() -> None:
         client.upload_sbom("c1", b"{}", sbom_format="cyclonedx", bom_type=123)  # type: ignore[arg-type]
 
 
+def test_upload_sbom_invalid_bom_type_raises_value_error() -> None:
+    """The client rejects unknown bom_type values instead of forwarding
+    ?bom_type=nope to the backend."""
+    client, _ = _client_with([_FakeResponse(200, {"sbom_id": "s1"})])
+    with pytest.raises(ValueError, match="Invalid bom_type"):
+        client.upload_sbom("c1", b"{}", sbom_format="cyclonedx", bom_type="nope")
+
+
 def test_upload_sbom_normalizes_bom_type_case() -> None:
     """The public client API lower-cases bom_type like the rest of the stack;
     the backend enum is lowercase and would reject ?bom_type=VEX."""

--- a/tests/test_sbomify_api.py
+++ b/tests/test_sbomify_api.py
@@ -510,6 +510,14 @@ def test_upload_sbom_sends_bom_type_param() -> None:
     assert call.kwargs["params"] == {"bom_type": "vex"}
 
 
+def test_upload_sbom_non_string_bom_type_raises_value_error() -> None:
+    """The public client fails a non-string bom_type as ValueError, matching
+    UploadInput, instead of an AttributeError on .lower()."""
+    client, _ = _client_with([_FakeResponse(200, {"sbom_id": "s1"})])
+    with pytest.raises(ValueError, match="Invalid bom_type"):
+        client.upload_sbom("c1", b"{}", sbom_format="cyclonedx", bom_type=123)  # type: ignore[arg-type]
+
+
 def test_upload_sbom_normalizes_bom_type_case() -> None:
     """The public client API lower-cases bom_type like the rest of the stack;
     the backend enum is lowercase and would reject ?bom_type=VEX."""

--- a/tests/test_sbomify_api.py
+++ b/tests/test_sbomify_api.py
@@ -510,6 +510,15 @@ def test_upload_sbom_sends_bom_type_param() -> None:
     assert call.kwargs["params"] == {"bom_type": "vex"}
 
 
+def test_upload_sbom_normalizes_bom_type_case() -> None:
+    """The public client API lower-cases bom_type like the rest of the stack;
+    the backend enum is lowercase and would reject ?bom_type=VEX."""
+    client, session = _client_with([_FakeResponse(200, {"sbom_id": "s1"})])
+    client.upload_sbom("c1", b"{}", sbom_format="cyclonedx", bom_type="VEX")
+    call = session.request.call_args
+    assert call.kwargs["params"] == {"bom_type": "vex"}
+
+
 def test_upload_sbom_omits_bom_type_param_by_default() -> None:
     client, session = _client_with([_FakeResponse(200, {"sbom_id": "s1"})])
     client.upload_sbom("c1", b"{}", sbom_format="cyclonedx")

--- a/tests/test_sbomify_api.py
+++ b/tests/test_sbomify_api.py
@@ -503,6 +503,20 @@ def test_upload_sbom_does_not_raise_on_non_2xx() -> None:
     assert response.status_code == 409
 
 
+def test_upload_sbom_sends_bom_type_param() -> None:
+    client, session = _client_with([_FakeResponse(200, {"sbom_id": "s1"})])
+    client.upload_sbom("c1", b"{}", sbom_format="cyclonedx", bom_type="vex")
+    call = session.request.call_args
+    assert call.kwargs["params"] == {"bom_type": "vex"}
+
+
+def test_upload_sbom_omits_bom_type_param_by_default() -> None:
+    client, session = _client_with([_FakeResponse(200, {"sbom_id": "s1"})])
+    client.upload_sbom("c1", b"{}", sbom_format="cyclonedx")
+    call = session.request.call_args
+    assert call.kwargs["params"] is None
+
+
 # ----------------------------------------------------------------------
 # OIDC trusted publishing
 

--- a/tests/test_sbomify_api.py
+++ b/tests/test_sbomify_api.py
@@ -552,7 +552,7 @@ def test_create_oidc_binding_other_errors_raise(status: int) -> None:
         client.create_oidc_binding("comp-1", "acme/widget")
 
 
-def test_upload_sbom_explicit_sbom_sends_no_bom_type_param():
+def test_upload_sbom_explicit_sbom_sends_no_bom_type_param() -> None:
     """bom_type='sbom' is the default artifact kind; the request matches an unset bom_type."""
     from unittest.mock import MagicMock, patch
 

--- a/tests/test_sbomify_api.py
+++ b/tests/test_sbomify_api.py
@@ -550,3 +550,15 @@ def test_create_oidc_binding_other_errors_raise(status: int) -> None:
     client, _ = _client_with([_FakeResponse(status, {"detail": "nope"})])
     with pytest.raises(APIError):
         client.create_oidc_binding("comp-1", "acme/widget")
+
+
+def test_upload_sbom_explicit_sbom_sends_no_bom_type_param(requests_mock_client=None):
+    """bom_type='sbom' is the default artifact kind; the request matches an unset bom_type."""
+    from unittest.mock import MagicMock, patch
+
+    from sbomify_action.sbomify_api import SbomifyApiClient
+
+    client = SbomifyApiClient("https://api.example.com", "tok")
+    with patch.object(client, "_request", return_value=MagicMock()) as req:
+        client.upload_sbom(component_id="c1", sbom_payload=b"{}", sbom_format="cyclonedx", bom_type="sbom")
+    assert req.call_args.kwargs["params"] is None

--- a/tests/test_sbomify_api.py
+++ b/tests/test_sbomify_api.py
@@ -552,7 +552,7 @@ def test_create_oidc_binding_other_errors_raise(status: int) -> None:
         client.create_oidc_binding("comp-1", "acme/widget")
 
 
-def test_upload_sbom_explicit_sbom_sends_no_bom_type_param(requests_mock_client=None):
+def test_upload_sbom_explicit_sbom_sends_no_bom_type_param():
     """bom_type='sbom' is the default artifact kind; the request matches an unset bom_type."""
     from unittest.mock import MagicMock, patch
 

--- a/tests/test_upload_module.py
+++ b/tests/test_upload_module.py
@@ -1533,5 +1533,17 @@ def test_upload_input_normalises_bom_type_case(tmp_path):
     assert inp.bom_type == "vex"
 
 
+def test_upload_input_non_string_bom_type_raises_value_error(tmp_path):
+    """A non-string bom_type from an untyped caller fails as ValueError, not AttributeError."""
+    import pytest
+
+    from sbomify_action._upload.protocol import UploadInput
+
+    f = tmp_path / "a.json"
+    f.write_text("{}")
+    with pytest.raises(ValueError, match="Invalid bom_type"):
+        UploadInput(sbom_file=str(f), sbom_format="cyclonedx", bom_type=123)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_upload_module.py
+++ b/tests/test_upload_module.py
@@ -1525,3 +1525,13 @@ class TestSbomifyTimeout(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+def test_upload_input_normalises_bom_type_case(tmp_path):
+    """Programmatic callers passing 'VEX' get the lowercase canonical value, not a ValueError."""
+    from sbomify_action._upload.protocol import UploadInput
+
+    f = tmp_path / "a.json"
+    f.write_text("{}")
+    inp = UploadInput(sbom_file=str(f), sbom_format="cyclonedx", bom_type="VEX")
+    assert inp.bom_type == "vex"

--- a/tests/test_upload_module.py
+++ b/tests/test_upload_module.py
@@ -492,6 +492,7 @@ class TestSbomifyDestination(unittest.TestCase):
             self.assertIn("VEX", result.error_message)
             self.assertIn("inside the authored document", result.error_message)
             self.assertNotIn("COMPONENT_VERSION", result.error_message)
+            self.assertNotIn("for this component version", result.error_message)
         finally:
             Path(sbom_file).unlink()
 

--- a/tests/test_upload_module.py
+++ b/tests/test_upload_module.py
@@ -64,6 +64,22 @@ class TestUploadInput(unittest.TestCase):
             UploadInput(sbom_file="sbom.json", sbom_format="invalid")  # type: ignore
         self.assertIn("Invalid sbom_format", str(ctx.exception))
 
+    def test_bom_type_defaults_to_none(self):
+        """bom_type is optional and defaults to None (plain SBOM upload)."""
+        input = UploadInput(sbom_file="sbom.json", sbom_format="cyclonedx")
+        self.assertIsNone(input.bom_type)
+
+    def test_bom_type_accepted(self):
+        """A valid bom_type is stored."""
+        input = UploadInput(sbom_file="sbom.json", sbom_format="cyclonedx", bom_type="vex")
+        self.assertEqual(input.bom_type, "vex")
+
+    def test_invalid_bom_type_raises(self):
+        """An unknown bom_type is rejected before any upload is attempted."""
+        with self.assertRaises(ValueError) as ctx:
+            UploadInput(sbom_file="sbom.json", sbom_format="cyclonedx", bom_type="nope")
+        self.assertIn("Invalid bom_type", str(ctx.exception))
+
 
 class TestUploadResult(unittest.TestCase):
     """Tests for UploadResult dataclass."""
@@ -272,6 +288,35 @@ class TestSbomifyDestination(unittest.TestCase):
             call_kwargs = mock_client.upload_sbom.call_args.kwargs
             self.assertEqual(call_kwargs["component_id"], "my-component")
             self.assertEqual(call_kwargs["sbom_format"], "cyclonedx")
+            # No bom_type by default → plain SBOM upload.
+            self.assertIsNone(call_kwargs.get("bom_type"))
+        finally:
+            Path(sbom_file).unlink()
+
+    @patch("sbomify_action._upload.destinations.sbomify.SbomifyApiClient")
+    def test_upload_threads_bom_type(self, mock_client_cls):
+        """bom_type from the input reaches the API client (e.g. for VEX)."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"bomFormat": "CycloneDX", "specVersion": "1.6"}, f)
+            sbom_file = f.name
+
+        try:
+            mock_response = Mock()
+            mock_response.ok = True
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"sbom_id": "vex-1"}
+            mock_response.headers = {}
+            mock_client = Mock()
+            mock_client.upload_sbom.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            dest = SbomifyDestination(token="test-token", component_id="my-component")
+            input = UploadInput(sbom_file=sbom_file, sbom_format="cyclonedx", bom_type="vex")
+
+            result = dest.upload(input)
+
+            self.assertTrue(result.success)
+            self.assertEqual(mock_client.upload_sbom.call_args.kwargs["bom_type"], "vex")
         finally:
             Path(sbom_file).unlink()
 

--- a/tests/test_upload_module.py
+++ b/tests/test_upload_module.py
@@ -462,6 +462,40 @@ class TestSbomifyDestination(unittest.TestCase):
             Path(sbom_file).unlink()
 
     @patch("sbomify_action._upload.destinations.sbomify.SbomifyApiClient")
+    def test_upload_duplicate_non_sbom_advises_document_version(self, mock_client_cls):
+        """A duplicate VEX must not advise COMPONENT_VERSION (ignored for verbatim
+        uploads); the actionable version lives inside the authored document."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"bomFormat": "CycloneDX", "specVersion": "1.6"}, f)
+            sbom_file = f.name
+
+        try:
+            mock_response = Mock()
+            mock_response.ok = False
+            mock_response.status_code = 409
+            mock_response.json.return_value = {
+                "detail": "Artifact already exists",
+                "error_code": "DUPLICATE_ARTIFACT",
+            }
+            mock_response.headers = {}
+            mock_client = Mock()
+            mock_client.upload_sbom.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            dest = SbomifyDestination(token="test-token", component_id="my-component")
+            input = UploadInput(sbom_file=sbom_file, sbom_format="cyclonedx", bom_type="vex")
+
+            result = dest.upload(input)
+
+            self.assertFalse(result.success)
+            self.assertEqual(result.error_code, "DUPLICATE_ARTIFACT")
+            self.assertIn("VEX", result.error_message)
+            self.assertIn("inside the authored document", result.error_message)
+            self.assertNotIn("COMPONENT_VERSION", result.error_message)
+        finally:
+            Path(sbom_file).unlink()
+
+    @patch("sbomify_action._upload.destinations.sbomify.SbomifyApiClient")
     def test_upload_other_409_error(self, mock_client_cls):
         """Test upload with 409 error without DUPLICATE_ARTIFACT still returns generic error."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:

--- a/tests/test_upload_module.py
+++ b/tests/test_upload_module.py
@@ -1523,10 +1523,6 @@ class TestSbomifyTimeout(unittest.TestCase):
             Path(sbom_file).unlink()
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 def test_upload_input_normalises_bom_type_case(tmp_path):
     """Programmatic callers passing 'VEX' get the lowercase canonical value, not a ValueError."""
     from sbomify_action._upload.protocol import UploadInput
@@ -1535,3 +1531,7 @@ def test_upload_input_normalises_bom_type_case(tmp_path):
     f.write_text("{}")
     inp = UploadInput(sbom_file=str(f), sbom_format="cyclonedx", bom_type="VEX")
     assert inp.bom_type == "vex"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

A `BOM_TYPE` input so the action can upload a VEX (or CBOM/HBOM), not only a plain SBOM.

## Why

The action hardcodes the SBOM artifact endpoint and never sends `?bom_type=`, and its finalize step rewrites every CycloneDX document (injects a `compositions` block, re-serializes). So a VEX can't be published through it: it lands as a plain SBOM and is mutated before upload. We hit this dogfooding sbomify's own self-VEX.

## What changed

- `BOM_TYPE` (env `BOM_TYPE`, `--bom-type`, `bom-type:` input): `sbom` (default), `vex`, `cbom`, `hbom`. Forwarded as `?bom_type=` on upload.
- Non-SBOM types upload verbatim, guaranteed by the type:
  - `_finalize_output_content` skips the PURL repair and composition injection.
  - augment and enrich are forced off for non-SBOM types (warned if set), since both rewrite the document.
  - so a hand-authored VEX is byte-for-byte what ships (sbomify never modifies a security artifact).
- Validation in both `Config` and `UploadInput`; documented in `action.yml` and the README env table.

Generation/augmentation/enrichment stay SBOM-only by design: a VEX verdict is a human judgment and a CBOM is authored elsewhere, so the action records and uploads them, it does not synthesize them.

## Tests

- `?bom_type=` sent when set, omitted by default (`upload_sbom`)
- `bom_type` threads through `UploadInput` to destination to client
- finalize skips mutation for `vex`/`cbom`, still applies for `sbom`/default
- non-SBOM `bom_type` forces augment/enrich off; plain SBOM keeps them
- invalid `bom_type` rejected

Full suite green locally (2366+ passed); `uv run mypy sbomify_action` and ruff clean.