### PR TITLE
feat: generate a CBOM (cdxgen --include-crypto) and cross-link it with the SBOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Setting `LOCK_FILE` (or `SBOM_FILE`) to `none` creates an empty SBOM and injects
 | `DOCKER_IMAGE`             | †        | Docker image name                                                                |
 | `OUTPUT_FILE`              | No       | Write final SBOM to this path                                                    |
 | `SBOM_FORMAT`              | No       | Output format: `cyclonedx` (default) or `spdx`                                   |
-| `BOM_TYPE`                 | No       | Artifact type: `sbom` (default), `vex`, `cbom` or `hbom`. Non-SBOM types upload verbatim (augmentation, enrichment and finalization are skipped) |
+| `BOM_TYPE`                 | No       | Artifact type: `sbom` (default), `vex`, `cbom` or `hbom`. Non-SBOM types skip augmentation and enrichment |
 | `GENERATE_CBOM`            | No       | Also generate a CBOM (`cdxgen --include-crypto`) and upload it as `bom_type=cbom`, cross-linked with the SBOM. Crypto detection is best-effort (Java/JS/TS source); the CBOM is marked `aggregate=incomplete` |
 | `ENRICH`                   | No       | Add metadata from package registries                                             |
 | `TOKEN`                    | ‡        | sbomify API token                                                                |

--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Setting `LOCK_FILE` (or `SBOM_FILE`) to `none` creates an empty SBOM and injects
 | `DOCKER_IMAGE`             | †        | Docker image name                                                                |
 | `OUTPUT_FILE`              | No       | Write final SBOM to this path                                                    |
 | `SBOM_FORMAT`              | No       | Output format: `cyclonedx` (default) or `spdx`                                   |
+| `BOM_TYPE`                 | No       | Artifact type: `sbom` (default), `vex`, `cbom` or `hbom`. Non-SBOM types are uploaded verbatim |
 | `ENRICH`                   | No       | Add metadata from package registries                                             |
 | `TOKEN`                    | ‡        | sbomify API token                                                                |
 | `COMPONENT_ID`             | ‡        | sbomify component ID                                                             |

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Setting `LOCK_FILE` (or `SBOM_FILE`) to `none` creates an empty SBOM and injects
 | `DOCKER_IMAGE`             | †        | Docker image name                                                                |
 | `OUTPUT_FILE`              | No       | Write final SBOM to this path                                                    |
 | `SBOM_FORMAT`              | No       | Output format: `cyclonedx` (default) or `spdx`                                   |
-| `BOM_TYPE`                 | No       | Artifact type: `sbom` (default), `vex`, `cbom` or `hbom`. Non-SBOM types are uploaded verbatim |
+| `BOM_TYPE`                 | No       | Artifact type: `sbom` (default), `vex`, `cbom` or `hbom`. Non-SBOM types upload verbatim (augmentation, enrichment and finalization are skipped) |
 | `ENRICH`                   | No       | Add metadata from package registries                                             |
 | `TOKEN`                    | ‡        | sbomify API token                                                                |
 | `COMPONENT_ID`             | ‡        | sbomify component ID                                                             |

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ Setting `LOCK_FILE` (or `SBOM_FILE`) to `none` creates an empty SBOM and injects
 | `OUTPUT_FILE`              | No       | Write final SBOM to this path                                                    |
 | `SBOM_FORMAT`              | No       | Output format: `cyclonedx` (default) or `spdx`                                   |
 | `BOM_TYPE`                 | No       | Artifact type: `sbom` (default), `vex`, `cbom` or `hbom`. Non-SBOM types upload verbatim (augmentation, enrichment and finalization are skipped) |
+| `GENERATE_CBOM`            | No       | Also generate a CBOM (`cdxgen --include-crypto`) and upload it as `bom_type=cbom`, cross-linked with the SBOM. Crypto detection is best-effort (Java/JS/TS source); the CBOM is marked `aggregate=incomplete` |
 | `ENRICH`                   | No       | Add metadata from package registries                                             |
 | `TOKEN`                    | ‡        | sbomify API token                                                                |
 | `COMPONENT_ID`             | ‡        | sbomify component ID                                                             |

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   component-purl:
     description: 'Override the component PURL in the SBOM (e.g., pkg:npm/@scope/name@1.0.0)'
     required: false
+  bom-type:
+    description: 'Artifact type to record on upload: sbom (default), vex, cbom or hbom. Non-SBOM types are uploaded verbatim (no augmentation or finalization).'
+    required: false
   oidc-audience:
     description: 'OIDC audience for trusted publishing (default: sbomify.com; override for self-hosted)'
     required: false
@@ -20,6 +23,7 @@ runs:
   env:
     WORKING_DIR: ${{ inputs['working-dir'] }}
     COMPONENT_PURL: ${{ inputs['component-purl'] }}
+    BOM_TYPE: ${{ inputs['bom-type'] }}
     OIDC_AUDIENCE: ${{ inputs['oidc-audience'] }}
 branding:
   icon: 'upload-cloud'

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'Override the component PURL in the SBOM (e.g., pkg:npm/@scope/name@1.0.0)'
     required: false
   bom-type:
-    description: 'Artifact type to record on upload: sbom (default), vex, cbom or hbom. Non-SBOM types are uploaded verbatim: augmentation, enrichment and finalization are skipped.'
+    description: 'Artifact type to record on upload: sbom (default), vex, cbom or hbom. Non-SBOM types skip augmentation and enrichment.'
     required: false
   generate-cbom:
     description: 'Also generate a CBOM (cdxgen --include-crypto) and upload it as bom_type=cbom, cross-linked with the SBOM. Crypto detection is best-effort (Java/JS/TS source); the CBOM is marked aggregate=incomplete.'

--- a/action.yml
+++ b/action.yml
@@ -13,9 +13,11 @@ inputs:
   bom-type:
     description: 'Artifact type to record on upload: sbom (default), vex, cbom or hbom. Non-SBOM types skip augmentation and enrichment.'
     required: false
+    default: 'sbom'
   generate-cbom:
     description: 'Also generate a CBOM (cdxgen --include-crypto) and upload it as bom_type=cbom, cross-linked with the SBOM. Crypto detection is best-effort (Java/JS/TS source); the CBOM is marked aggregate=incomplete.'
     required: false
+    default: 'false'
   oidc-audience:
     description: 'OIDC audience for trusted publishing (default: sbomify.com; override for self-hosted)'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   bom-type:
     description: 'Artifact type to record on upload: sbom (default), vex, cbom or hbom. Non-SBOM types are uploaded verbatim: augmentation, enrichment and finalization are skipped.'
     required: false
+  generate-cbom:
+    description: 'Also generate a CBOM (cdxgen --include-crypto) and upload it as bom_type=cbom, cross-linked with the SBOM. Crypto detection is best-effort (Java/JS/TS source); the CBOM is marked aggregate=incomplete.'
+    required: false
   oidc-audience:
     description: 'OIDC audience for trusted publishing (default: sbomify.com; override for self-hosted)'
     required: false
@@ -24,6 +27,7 @@ runs:
     WORKING_DIR: ${{ inputs['working-dir'] }}
     COMPONENT_PURL: ${{ inputs['component-purl'] }}
     BOM_TYPE: ${{ inputs['bom-type'] }}
+    GENERATE_CBOM: ${{ inputs['generate-cbom'] }}
     OIDC_AUDIENCE: ${{ inputs['oidc-audience'] }}
 branding:
   icon: 'upload-cloud'

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'Override the component PURL in the SBOM (e.g., pkg:npm/@scope/name@1.0.0)'
     required: false
   bom-type:
-    description: 'Artifact type to record on upload: sbom (default), vex, cbom or hbom. Non-SBOM types are uploaded verbatim (no augmentation or finalization).'
+    description: 'Artifact type to record on upload: sbom (default), vex, cbom or hbom. Non-SBOM types are uploaded verbatim: augmentation, enrichment and finalization are skipped.'
     required: false
   oidc-audience:
     description: 'OIDC audience for trusted publishing (default: sbomify.com; override for self-hosted)'

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "github-action",
@@ -16,57 +15,69 @@
     },
   },
   "packages": {
-    "@appthreat/atom": ["@appthreat/atom@2.4.3", "", { "dependencies": { "@appthreat/atom-common": "*", "@appthreat/atom-parsetools": "*" }, "bin": { "atom": "index.js", "astgen": "packages/atom-parsetools/astgen.js", "rbastgen": "packages/atom-parsetools/rbastgen.js", "scalasem": "packages/atom-parsetools/scalasem.js", "phpastgen": "packages/atom-parsetools/phpastgen.js" } }, "sha512-xOfXDQbRVoworcxaKPYtXJaaBct4GUkDxKseBgxvvK4deqK7lkW3QYBybaQqNynzEmb1yCaqdFcLQYw5bhEyvA=="],
+    "@appthreat/atom": ["@appthreat/atom@2.5.6", "", { "dependencies": { "@appthreat/atom-common": "^1.1.0" }, "bin": { "atom": "index.js" } }, "sha512-AhMd7hwEVRJCu3ZuAaF2Snmw7o/9x+2F222qycIQaUNbVvwW+++ns3WjcQnIRMkhXRao6Oczx09A2/rFiRShfg=="],
 
     "@appthreat/atom-common": ["@appthreat/atom-common@1.1.0", "", {}, "sha512-vGZpJdy9e0l83o8XwDAsQUDpkMVzR4DLb7mbi5npu8Nz/R+2m5oyHlpBGuLYBKm5+KkjTInXP9eNTcMa0Mn3Uw=="],
 
-    "@appthreat/atom-parsetools": ["@appthreat/atom-parsetools@1.1.2", "", { "dependencies": { "@appthreat/atom-common": "^1.1.0", "@babel/parser": "^7.28.5", "hermes-parser": "^0.33.1", "typescript": "^5.9.3", "yargs": "^17.7.2" }, "bin": { "astgen": "astgen.js", "phpastgen": "phpastgen.js", "rbastgen": "rbastgen.js", "scalasem": "scalasem.js" } }, "sha512-nnIv3WuySPEF1s7nOZdvHJ0XhSFg+tKSWexNNxKMl3YppDYJ/SOUiJGk/qSHkm3AVRmdUaEQbsSRnZLqLitxZg=="],
+    "@appthreat/atom-parsetools": ["@appthreat/atom-parsetools@1.2.2", "", { "dependencies": { "@appthreat/atom-common": "^1.1.0", "@babel/parser": "^7.29.3", "hermes-parser": "^0.36.1", "typescript": "^6.0.3" }, "bin": { "astgen": "astgen.js", "phpastgen": "phpastgen.js", "rbastgen": "rbastgen.js", "scalasem": "scalasem.js" } }, "sha512-uH93lVI2H53x3ZbcXWUBhcm25Kv4Iz+bWHtrghCn5YHtsm223kGRKqDx3hqmfUNybz+ZqFs1WhHFW7ah4HIqEA=="],
 
-    "@appthreat/cdx-proto": ["@appthreat/cdx-proto@1.2.0", "", { "dependencies": { "@bufbuild/protobuf": "2.10.1" } }, "sha512-r2g4CLo2wx16Xz3v6vVdIC8DqpFNXcFM9Fyv1p/8cLGWGqo0NCdUEahqfS0ANTeNbFM6x8faWO72BrPMlVF3LQ=="],
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
-    "@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
+    "@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
 
-    "@babel/generator": ["@babel/generator@7.28.6", "", { "dependencies": { "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw=="],
+    "@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
-    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
-    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
-    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+    "@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
-    "@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
+    "@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
 
-    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+    "@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
 
-    "@babel/traverse": ["@babel/traverse@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/generator": "^7.28.6", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.6", "@babel/template": "^7.28.6", "@babel/types": "^7.28.6", "debug": "^4.3.1" } }, "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg=="],
+    "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
-    "@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
+    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.0", "", {}, "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="],
 
-    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.10.2", "", {}, "sha512-uFsRXwIGyu+r6AMdz+XijIIZJYpoWeYzILt5yZ2d3mCjQrWUTVpVD9WL/jZAbvp+Ed04rOhrsk7FiTcEDseB5A=="],
+    "@cdxgen/cdx-hbom": ["@cdxgen/cdx-hbom@0.5.1", "", { "bin": { "cdx-hbom": "bin/cdx-hbom.js" } }, "sha512-mGXOwVZhApxRUo8g+fwGQHe/rNVlidpltfy5wcchhN/46yLokJcA4EkwA6mv3T6fh8IpQ5xd1xhYmvo5/ILEVw=="],
 
-    "@cyclonedx/cdxgen": ["@cyclonedx/cdxgen@github:cyclonedx/cdxgen#ed1928d", { "dependencies": { "@babel/parser": "7.28.6", "@babel/traverse": "7.28.6", "@iarna/toml": "2.2.5", "@isaacs/string-locale-compare": "1.1.0", "@npmcli/fs": "5.0.0", "@npmcli/map-workspaces": "5.0.3", "@npmcli/name-from-folder": "4.0.0", "@npmcli/package-json": "7.0.4", "ajv": "8.17.1", "ajv-formats": "3.0.1", "bin-links": "6.0.0", "cheerio": "1.1.2", "common-ancestor-path": "1.0.1", "edn-data": "1.1.2", "glob": "13.0.0", "global-agent": "3.0.0", "got": "14.6.6", "iconv-lite": "0.7.2", "json-stringify-nice": "1.1.4", "jws": "4.0.1", "keyv": "5.5.5", "node-stream-zip": "1.15.0", "npm-package-arg": "13.0.2", "packageurl-js": "1.0.2", "parse-conflict-json": "5.0.1", "proc-log": "6.1.0", "properties-reader": "2.3.0", "read-package-json-fast": "5.0.0", "semver": "7.7.3", "ssri": "13.0.0", "table": "6.9.0", "tar": "7.5.2", "treeverse": "3.0.0", "uuid": "13.0.0", "walk-up-path": "4.0.0", "xml-js": "1.6.11", "yaml": "2.8.2", "yargs": "18.0.0", "yoctocolors": "2.1.2" }, "optionalDependencies": { "@appthreat/atom": "2.4.3", "@appthreat/cdx-proto": "1.2.0", "@bufbuild/protobuf": "2.10.2", "@cyclonedx/cdxgen-plugins-bin": "1.8.0", "@cyclonedx/cdxgen-plugins-bin-darwin-amd64": "1.8.0", "@cyclonedx/cdxgen-plugins-bin-darwin-arm64": "1.8.0", "@cyclonedx/cdxgen-plugins-bin-linux-amd64": "1.8.0", "@cyclonedx/cdxgen-plugins-bin-linux-arm": "1.8.0", "@cyclonedx/cdxgen-plugins-bin-linux-arm64": "1.8.0", "@cyclonedx/cdxgen-plugins-bin-linux-ppc64": "1.8.0", "@cyclonedx/cdxgen-plugins-bin-linuxmusl-amd64": "1.8.0", "@cyclonedx/cdxgen-plugins-bin-linuxmusl-arm64": "1.8.0", "@cyclonedx/cdxgen-plugins-bin-windows-amd64": "1.8.0", "@cyclonedx/cdxgen-plugins-bin-windows-arm64": "1.8.0", "body-parser": "2.2.2", "compression": "1.8.1", "connect": "3.7.0", "jsonata": "2.1.0", "sqlite3": "npm:@appthreat/sqlite3@7.0.2" }, "bin": { "cbom": "bin/cdxgen.js", "cdx-verify": "bin/verify.js", "cdxgen": "bin/cdxgen.js", "cdxgen-secure": "bin/cdxgen.js", "cdxi": "bin/repl.js", "evinse": "bin/evinse.js", "obom": "bin/cdxgen.js", "saasbom": "bin/cdxgen.js" } }, "cdxgen-cdxgen-ed1928d"],
+    "@cdxgen/cdx-proto": ["@cdxgen/cdx-proto@2.0.3", "", { "dependencies": { "@bufbuild/protobuf": "2.12.0" } }, "sha512-B8OMpVoFB2YECPlrJYf9/FJodcnqPGKEy4qb096Mj6iAuz6QObWjg/WFGXLtpvbHjwVNp175vLwGyEFr8c42Dg=="],
 
-    "@cyclonedx/cdxgen-plugins-bin": ["@cyclonedx/cdxgen-plugins-bin@1.8.0", "", { "cpu": "x64" }, "sha512-nwhh2yUdpfbwbvvSWVigXF74SKfLEC0ue5D1DZR+ECAL9ASP8XjOkO00x4bJgKRo70SHMGlJuAZtGdWv58bz/A=="],
+    "@cdxgen/cdxgen-plugins-bin": ["@cdxgen/cdxgen-plugins-bin@2.5.1", "", {}, "sha512-hzp2v5+pDC0hpW/sB4Dez0GcDdqTp9g6JzuBw+rOdDtkGuWjhAzkiqN6KSjGJbliypVN4BU/jwF+4zofnUtyLg=="],
 
-    "@cyclonedx/cdxgen-plugins-bin-darwin-amd64": ["@cyclonedx/cdxgen-plugins-bin-darwin-amd64@1.8.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-0c4+VXkRtq0zNWXsKEt8Qv4PFeWAS3j4TL+yeaDXmcpLEu42UvjVtNZg7k00T5ijlV05rIWsz9mavuq+G3wOGw=="],
+    "@cdxgen/cdxgen-plugins-bin-darwin-amd64": ["@cdxgen/cdxgen-plugins-bin-darwin-amd64@2.5.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-f1XFP66ioCOo/xe+gCnZhbCU8DFV+uBPRC+meneQo+lrr325ih8R7QVup86LpSkIhS8fzJP+wVAVEUwWQFblQA=="],
 
-    "@cyclonedx/cdxgen-plugins-bin-darwin-arm64": ["@cyclonedx/cdxgen-plugins-bin-darwin-arm64@1.8.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Yakqu//KVUCXMlCNJDO1pSPQoEkbBnhjJgJTlx1MOBcJRUAwezRy3SAFWBcaLgWSoTSknO7LAPtLqzQKKOwn+g=="],
+    "@cdxgen/cdxgen-plugins-bin-darwin-arm64": ["@cdxgen/cdxgen-plugins-bin-darwin-arm64@2.5.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BHFq06qcZXxxQbkcbZ+aDgBqOFnkmCXhhkhxCwRSvLCKLVGL4EtGx0u7zr5D4T7+3lpuciXD+qpy6PiGgxdCWQ=="],
 
-    "@cyclonedx/cdxgen-plugins-bin-linux-amd64": ["@cyclonedx/cdxgen-plugins-bin-linux-amd64@1.8.0", "", { "os": "linux", "cpu": "x64" }, "sha512-CWez/Pn234bppZDxljNQbI6Juk3Q37A898/Yxu6AZGAA6ObXHg57jik78tpoVznvgdxV8m6D3JZHX5RfLk3XmA=="],
+    "@cdxgen/cdxgen-plugins-bin-linux-amd64": ["@cdxgen/cdxgen-plugins-bin-linux-amd64@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-OUinsO0g/DYmxkfxhzGU/T84QaUftPA4WN9rcab7h3grG5nJZ/ntQDBdj+LcbcvYKPQIEnNjYlXe31heyS4R4A=="],
 
-    "@cyclonedx/cdxgen-plugins-bin-linux-arm": ["@cyclonedx/cdxgen-plugins-bin-linux-arm@1.8.0", "", { "os": "linux", "cpu": "arm" }, "sha512-+VIqa+YzxHZIPvwnol8/i2TGQ0Z16k02F0K2R/JsRVjTJnm0cfsxVxiVtpW1oAL7jAc/UUz33qfuXeL0n8UFjg=="],
+    "@cdxgen/cdxgen-plugins-bin-linux-arm": ["@cdxgen/cdxgen-plugins-bin-linux-arm@2.5.1", "", { "os": "linux", "cpu": "arm" }, "sha512-I3LtLJ/DvKRvwnz4apFLAO+9/fJMPU9RB4WxwBqTjVa7sFcbnpRHE9EMjsuu0MsYAEIDoich0Qk6/83PrGe5zA=="],
 
-    "@cyclonedx/cdxgen-plugins-bin-linux-arm64": ["@cyclonedx/cdxgen-plugins-bin-linux-arm64@1.8.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-3FGOZd1dp9SOMcNMCTOU7E5LLazVeBL6xfMh2otQn41koYL1l7sHsu6tXK5+bBAiCedi99Z0lMdUrHFgjZDSOg=="],
+    "@cdxgen/cdxgen-plugins-bin-linux-arm64": ["@cdxgen/cdxgen-plugins-bin-linux-arm64@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-NjxXYNzqMAv0M5lBDNZZniYvJRgzJlHVsucR2R2DNK7lHzALBWeYdY6FhBSztX6SmK3Ictq8T7g+w1k0vMnxoA=="],
 
-    "@cyclonedx/cdxgen-plugins-bin-linux-ppc64": ["@cyclonedx/cdxgen-plugins-bin-linux-ppc64@1.8.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-KCZVGPh8XPPIvKQwPIYvfHb+jjCMKmPtGd9lC2LH5QfrC8jvDsu+4n+8GKTzBOYxbk18sSy+W6XjHzIcHMSvpg=="],
+    "@cdxgen/cdxgen-plugins-bin-linux-ppc64": ["@cdxgen/cdxgen-plugins-bin-linux-ppc64@2.5.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9vWIQ63HLTAuezn3qT9OlBgh4bJVEF3WX69omF0VeovHzn0FRDKp8xKSpV/OZoBFrX4JjKc7DrC/ZTFpbPPCqg=="],
 
-    "@cyclonedx/cdxgen-plugins-bin-linuxmusl-amd64": ["@cyclonedx/cdxgen-plugins-bin-linuxmusl-amd64@1.8.0", "", { "os": "linux", "cpu": "x64" }, "sha512-FO3bQ6LWKrf6iYpa2qgUmSTl1Yi7T1cPTizXfOnzqg3dBxmksb0RjKFiCKeLNULfFT/vbQcz7065JKAt0oE/5w=="],
+    "@cdxgen/cdxgen-plugins-bin-linuxmusl-amd64": ["@cdxgen/cdxgen-plugins-bin-linuxmusl-amd64@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-jBjaqRicd1OmdexiMJq9+JfR6cN+5wzJyidI/muRD4Ug3g6hJm5DlanGd+0YdPNT0dygbWzNJThHdTYT10xElA=="],
 
-    "@cyclonedx/cdxgen-plugins-bin-linuxmusl-arm64": ["@cyclonedx/cdxgen-plugins-bin-linuxmusl-arm64@1.8.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-l2Cui2PK58RDS84cWIqSb4BA5VO25o/Npilg9xVaGLXjpGFe9dQVtJIGkPmkFN7qtM2oUcn314dGTt+hOxxdCg=="],
+    "@cdxgen/cdxgen-plugins-bin-linuxmusl-arm64": ["@cdxgen/cdxgen-plugins-bin-linuxmusl-arm64@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-8OsShzF20WUHxL0zJ8+mMLFoxnVctnJLUeC2f6PLUIxH91iiKX9FsZAZGZzBmaZSAoaQ+Jk2ewLG5YAYrTgQ9Q=="],
 
-    "@cyclonedx/cdxgen-plugins-bin-windows-amd64": ["@cyclonedx/cdxgen-plugins-bin-windows-amd64@1.8.0", "", { "os": "win32", "cpu": "x64" }, "sha512-DlU31Zan05YlsLHZFtAO3360NQHe9RNu/G5OK3bhSvmWoyhSxihh7x2RrxAiVePpENPQnun7HPyWOJc9ty9tIQ=="],
+    "@cdxgen/cdxgen-plugins-bin-windows-amd64": ["@cdxgen/cdxgen-plugins-bin-windows-amd64@2.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-iXeBq5/PQ/zGlRwjK2M27D8J75qQbY7s2pcGrBE9sdwTNq72fttAGzTVyn0vsoZ2xaIddne5IpKUKVKzJY1uBg=="],
 
-    "@cyclonedx/cdxgen-plugins-bin-windows-arm64": ["@cyclonedx/cdxgen-plugins-bin-windows-arm64@1.8.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-se4fgWbHbe+SbHzuJIi0q10QK9S7wc2tkujEytXUX7AwrYnFsgOhSi+yeyRGg1UscNeFSKNDxLp27mf6x5zJZQ=="],
+    "@cdxgen/cdxgen-plugins-bin-windows-arm64": ["@cdxgen/cdxgen-plugins-bin-windows-arm64@2.5.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-D8N0e/lZyFptLQmSz/ObfnWqdQHAwpJkP4D3xcLXFsNMdQj2P5ijhdOiHh8C6HssL16aN1XDNwmfCH2a4iNxgA=="],
+
+    "@cdxgen/safer-exec": ["@cdxgen/safer-exec@0.15.0", "", { "optionalDependencies": { "@cdxgen/safer-exec-darwin-amd64": "0.15.0", "@cdxgen/safer-exec-darwin-arm64": "0.15.0", "@cdxgen/safer-exec-linux-amd64": "0.15.0", "@cdxgen/safer-exec-linux-arm64": "0.15.0" }, "bin": { "safer-exec": "src/cli.js" } }, "sha512-f0/NDt07AgfvK5uOcU7XFw7g8VirQdCVs8/01bZ0juTGujx7ByPxWBlpDRqt/cuxn//Hcn7pgsUDqzTZq54UcQ=="],
+
+    "@cdxgen/safer-exec-darwin-amd64": ["@cdxgen/safer-exec-darwin-amd64@0.15.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-xCl/eenMrnk/76GQyHGVUE9DclkkC+idplBBYznLkVqyJSdBoRSkk6mxfUPQeCihnH2eSf6X7pykNGWqLzWQGQ=="],
+
+    "@cdxgen/safer-exec-darwin-arm64": ["@cdxgen/safer-exec-darwin-arm64@0.15.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BZZ7BX7RWa3XDxZr4JaSy3pPaLhHF5h6uhQiNlTOXLuijUrhEUiVADCJeChOyMXiTr/YY6GfE7+CE72eGq2MPg=="],
+
+    "@cdxgen/safer-exec-linux-amd64": ["@cdxgen/safer-exec-linux-amd64@0.15.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Q6HbKjKpcUgcEnzzMXaROVI55gisU1TaAKb77APraZEj9ZxSTBh4NoC+aouPKCs+0kkcVwD08loQplJ3I1aPzw=="],
+
+    "@cdxgen/safer-exec-linux-arm64": ["@cdxgen/safer-exec-linux-arm64@0.15.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-NRfsNnFcl3qUbxWTNNJltrFAagJcYumTGhK9Ad9BxzFu6l2FS2wozr4pr9KRzSrEXFCiEqm2unAtDgyAGx/nbw=="],
+
+    "@cyclonedx/cdxgen": ["@cyclonedx/cdxgen@github:cyclonedx/cdxgen#a8f5853", { "dependencies": { "@babel/parser": "7.29.7", "@babel/traverse": "7.29.7", "@iarna/toml": "2.2.5", "@isaacs/string-locale-compare": "1.1.0", "@npmcli/fs": "5.0.0", "@npmcli/map-workspaces": "5.0.3", "@npmcli/name-from-folder": "4.0.0", "@npmcli/package-json": "7.0.5", "ajv": "8.20.0", "ajv-formats": "3.0.1", "bin-links": "6.0.2", "cheerio": "1.2.0", "common-ancestor-path": "1.0.1", "edn-data": "1.1.2", "glob": "13.0.6", "got": "14.6.6", "iconv-lite": "0.7.2", "json-stringify-nice": "1.1.4", "keyv": "5.6.0", "node-stream-zip": "1.15.0", "npm-package-arg": "13.0.2", "packageurl-js": "1.0.2", "parse-conflict-json": "5.0.1", "properties-reader": "3.0.1", "read-package-json-fast": "5.0.0", "semver": "7.8.5", "ssri": "13.0.1", "tar": "7.5.16", "treeverse": "3.0.0", "uuid": "14.0.1", "walk-up-path": "4.0.0", "xml-js": "1.6.11", "yaml": "2.9.0", "yargs": "18.0.0", "yoctocolors": "2.1.2" }, "optionalDependencies": { "@appthreat/atom": "2.5.6", "@appthreat/atom-parsetools": "1.2.2", "@bufbuild/protobuf": "2.12.0", "@cdxgen/cdx-hbom": "0.5.1", "@cdxgen/cdx-proto": "2.0.3", "@cdxgen/cdxgen-plugins-bin": "2.5.1", "@cdxgen/cdxgen-plugins-bin-darwin-amd64": "2.5.1", "@cdxgen/cdxgen-plugins-bin-darwin-arm64": "2.5.1", "@cdxgen/cdxgen-plugins-bin-linux-amd64": "2.5.1", "@cdxgen/cdxgen-plugins-bin-linux-arm": "2.5.1", "@cdxgen/cdxgen-plugins-bin-linux-arm64": "2.5.1", "@cdxgen/cdxgen-plugins-bin-linux-ppc64": "2.5.1", "@cdxgen/cdxgen-plugins-bin-linuxmusl-amd64": "2.5.1", "@cdxgen/cdxgen-plugins-bin-linuxmusl-arm64": "2.5.1", "@cdxgen/cdxgen-plugins-bin-windows-amd64": "2.5.1", "@cdxgen/cdxgen-plugins-bin-windows-arm64": "2.5.1", "@cdxgen/safer-exec": "0.15.0", "body-parser": "2.3.0", "compression": "1.8.1", "connect": "3.7.0", "jsonata": "2.2.1" }, "bin": { "aibom": "bin/cdxgen.js", "cbom": "bin/cdxgen.js", "cdx-audit": "bin/audit.js", "cdx-convert": "bin/convert.js", "cdx-validate": "bin/validate.js", "cdx-verify": "bin/verify.js", "cdx-sign": "bin/sign.js", "cdxgen": "bin/cdxgen.js", "cdxgen-secure": "bin/cdxgen.js", "cdxi": "bin/repl.js", "evinse": "bin/evinse.js", "hbom": "bin/hbom.js", "obom": "bin/cdxgen.js", "tracebom": "bin/tracebom.js", "saasbom": "bin/cdxgen.js", "spdxgen": "bin/cdxgen.js" } }, "cdxgen-cdxgen-a8f5853"],
 
     "@iarna/toml": ["@iarna/toml@2.2.5", "", {}, "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="],
 
@@ -88,7 +99,7 @@
 
     "@keyv/serialize": ["@keyv/serialize@1.1.1", "", {}, "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA=="],
 
-    "@npmcli/agent": ["@npmcli/agent@4.0.0", "", { "dependencies": { "agent-base": "^7.1.0", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.1", "lru-cache": "^11.2.1", "socks-proxy-agent": "^8.0.3" } }, "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA=="],
+    "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
 
     "@npmcli/fs": ["@npmcli/fs@5.0.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og=="],
 
@@ -98,7 +109,7 @@
 
     "@npmcli/name-from-folder": ["@npmcli/name-from-folder@4.0.0", "", {}, "sha512-qfrhVlOSqmKM8i6rkNdZzABj8MKEITGFAY+4teqBziksCQAOLutiAxM1wY2BKEd8KjUSpWmWCYxvXr0y4VTlPg=="],
 
-    "@npmcli/package-json": ["@npmcli/package-json@7.0.4", "", { "dependencies": { "@npmcli/git": "^7.0.0", "glob": "^13.0.0", "hosted-git-info": "^9.0.0", "json-parse-even-better-errors": "^5.0.0", "proc-log": "^6.0.0", "semver": "^7.5.3", "validate-npm-package-license": "^3.0.4" } }, "sha512-0wInJG3j/K40OJt/33ax47WfWMzZTm6OQxB9cDhTt5huCP2a9g2GnlsxmfN+PulItNPIpPrZ+kfwwUil7eHcZQ=="],
+    "@npmcli/package-json": ["@npmcli/package-json@7.0.5", "", { "dependencies": { "@npmcli/git": "^7.0.0", "glob": "^13.0.0", "hosted-git-info": "^9.0.0", "json-parse-even-better-errors": "^5.0.0", "proc-log": "^6.0.0", "semver": "^7.5.3", "spdx-expression-parse": "^4.0.0" } }, "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ=="],
 
     "@npmcli/promise-spawn": ["@npmcli/promise-spawn@9.0.1", "", { "dependencies": { "which": "^6.0.0" } }, "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q=="],
 
@@ -112,43 +123,29 @@
 
     "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
-    "abbrev": ["abbrev@4.0.0", "", {}, "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA=="],
-
-    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
-
-    "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
-    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
-    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
-    "astral-regex": ["astral-regex@2.0.0", "", {}, "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="],
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+    "bin-links": ["bin-links@6.0.2", "", { "dependencies": { "cmd-shim": "^8.0.0", "npm-normalize-package-bin": "^5.0.0", "proc-log": "^6.0.0", "read-cmd-shim": "^6.0.0", "write-file-atomic": "^7.0.0" } }, "sha512-frE1t78WOwJ45PKV2cF2tNPjTcs9L1J9s6VkrV59wanRP4GlaomuxYPVma7BwthMg8WnfSory4w5PTE6FZZ81w=="],
 
-    "bin-links": ["bin-links@6.0.0", "", { "dependencies": { "cmd-shim": "^8.0.0", "npm-normalize-package-bin": "^5.0.0", "proc-log": "^6.0.0", "read-cmd-shim": "^6.0.0", "write-file-atomic": "^7.0.0" } }, "sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w=="],
-
-    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
-
-    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
-    "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
-
-    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
-
-    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
 
     "byte-counter": ["byte-counter@0.1.0", "", {}, "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
-
-    "cacache": ["cacache@20.0.3", "", { "dependencies": { "@npmcli/fs": "^5.0.0", "fs-minipass": "^3.0.0", "glob": "^13.0.0", "lru-cache": "^11.1.0", "minipass": "^7.0.3", "minipass-collect": "^2.0.1", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "p-map": "^7.0.2", "ssri": "^13.0.0", "unique-filename": "^5.0.0" } }, "sha512-3pUp4e8hv07k1QlijZu6Kn7c9+ZpWWk4j3F8N3xPuCExULobqJydKYOTj1FTq58srkJsXvO7LbGAH4C0ZU3WGw=="],
 
     "cacheable-lookup": ["cacheable-lookup@7.0.0", "", {}, "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w=="],
 
@@ -158,7 +155,7 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
-    "cheerio": ["cheerio@1.1.2", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.0.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.12.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg=="],
+    "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
 
     "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-select": "^5.1.0", "css-what": "^6.1.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
 
@@ -168,10 +165,6 @@
 
     "cmd-shim": ["cmd-shim@8.0.0", "", {}, "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA=="],
 
-    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
-
-    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
     "common-ancestor-path": ["common-ancestor-path@1.0.1", "", {}, "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w=="],
 
     "compressible": ["compressible@2.0.18", "", { "dependencies": { "mime-db": ">= 1.43.0 < 2" } }, "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg=="],
@@ -180,7 +173,7 @@
 
     "connect": ["connect@3.7.0", "", { "dependencies": { "debug": "2.6.9", "finalhandler": "1.1.2", "parseurl": "~1.3.3", "utils-merge": "1.0.1" } }, "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ=="],
 
-    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+    "content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
 
@@ -190,17 +183,7 @@
 
     "decompress-response": ["decompress-response@10.0.0", "", { "dependencies": { "mimic-response": "^4.0.0" } }, "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q=="],
 
-    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
-
-    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
-
-    "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
-
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
-
-    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
-
-    "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -212,25 +195,17 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
-    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
-
     "edn-data": ["edn-data@1.1.2", "", {}, "sha512-RI1i17URvOrBtSNEccbsXkuUZdc67QUBMqXGF62KPek85EdFGS2UKw76hNhOBl5kK4h7V4d32Ut15b/XVwKEXA=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
-    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
 
-    "encoding": ["encoding@0.1.13", "", { "dependencies": { "iconv-lite": "^0.6.2" } }, "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A=="],
-
     "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
 
-    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
-
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
-
-    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "err-code": ["err-code@2.0.3", "", {}, "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="],
 
@@ -240,31 +215,17 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
-    "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
-
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
-
-    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
-
-    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
-
-    "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
-    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
-
     "finalhandler": ["finalhandler@1.1.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "on-finished": "~2.3.0", "parseurl": "~1.3.3", "statuses": "~1.5.0", "unpipe": "~1.0.0" } }, "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA=="],
 
     "form-data-encoder": ["form-data-encoder@4.1.0", "", {}, "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw=="],
-
-    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
-
-    "fs-minipass": ["fs-minipass@3.0.3", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -278,57 +239,37 @@
 
     "get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
-    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
-
-    "glob": ["glob@13.0.0", "", { "dependencies": { "minimatch": "^10.1.1", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA=="],
-
-    "global-agent": ["global-agent@3.0.0", "", { "dependencies": { "boolean": "^3.0.1", "es6-error": "^4.1.1", "matcher": "^3.0.0", "roarr": "^2.15.3", "semver": "^7.3.2", "serialize-error": "^7.0.1" } }, "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q=="],
-
-    "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "got": ["got@14.6.6", "", { "dependencies": { "@sindresorhus/is": "^7.0.1", "byte-counter": "^0.1.0", "cacheable-lookup": "^7.0.0", "cacheable-request": "^13.0.12", "decompress-response": "^10.0.0", "form-data-encoder": "^4.0.2", "http2-wrapper": "^2.2.1", "keyv": "^5.5.3", "lowercase-keys": "^3.0.0", "p-cancelable": "^4.0.1", "responselike": "^4.0.2", "type-fest": "^4.26.1" } }, "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg=="],
 
-    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
-
-    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
-
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
-    "hermes-estree": ["hermes-estree@0.33.3", "", {}, "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg=="],
+    "hermes-estree": ["hermes-estree@0.36.1", "", {}, "sha512-guv1nQ6IJ7S83NRFPWc3SA7IBZrdNC9kapwOq6uXvF4wP+sDCgjzQbKPCoyYmoyZRzztF/n/c36l/rccCZSiCw=="],
 
-    "hermes-parser": ["hermes-parser@0.33.3", "", { "dependencies": { "hermes-estree": "0.33.3" } }, "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA=="],
+    "hermes-parser": ["hermes-parser@0.36.1", "", { "dependencies": { "hermes-estree": "0.36.1" } }, "sha512-GApNk4zLHi2UWoWZZkx7LNCOSzLSc5lB55pZ/PhK7ycFeg7u5LcF88p/WbpIi1XUDtE0MpHE3uRR3u3KB7TjSQ=="],
 
     "hosted-git-info": ["hosted-git-info@9.0.2", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg=="],
 
-    "htmlparser2": ["htmlparser2@10.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.1", "entities": "^6.0.0" } }, "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g=="],
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
-    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
-
     "http2-wrapper": ["http2-wrapper@2.2.1", "", { "dependencies": { "quick-lru": "^5.1.1", "resolve-alpn": "^1.2.0" } }, "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ=="],
 
-    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
-
-    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
-
-    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
-
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
 
@@ -344,29 +285,17 @@
 
     "json-stringify-nice": ["json-stringify-nice@1.1.4", "", {}, "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw=="],
 
-    "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
-
-    "jsonata": ["jsonata@2.1.0", "", {}, "sha512-OCzaRMK8HobtX8fp37uIVmL8CY1IGc/a6gLsDqz3quExFR09/U78HUzWYr7T31UEB6+Eu0/8dkVD5fFDOl9a8w=="],
+    "jsonata": ["jsonata@2.2.1", "", {}, "sha512-xd1uwUrKeIcJbsWhaoS3qAX4Ea8m0Mw0G5nlnAQvPT7TbZ5qaPdzBVTQia9KfyuyQm+nenfyjvzUDTRYHsC2sw=="],
 
     "just-diff": ["just-diff@6.0.2", "", {}, "sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA=="],
 
     "just-diff-apply": ["just-diff-apply@5.5.0", "", {}, "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw=="],
 
-    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
-
-    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
-
-    "keyv": ["keyv@5.5.5", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ=="],
-
-    "lodash.truncate": ["lodash.truncate@4.4.2", "", {}, "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="],
+    "keyv": ["keyv@5.6.0", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw=="],
 
     "lowercase-keys": ["lowercase-keys@3.0.0", "", {}, "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ=="],
 
     "lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
-
-    "make-fetch-happen": ["make-fetch-happen@15.0.3", "", { "dependencies": { "@npmcli/agent": "^4.0.0", "cacache": "^20.0.1", "http-cache-semantics": "^4.1.1", "minipass": "^7.0.2", "minipass-fetch": "^5.0.0", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^1.0.0", "proc-log": "^6.0.0", "promise-retry": "^2.0.1", "ssri": "^13.0.0" } }, "sha512-iyyEpDty1mwW3dGlYXAJqC/azFn5PPvgKVwXayOGBSmKLxhKZ9fg4qIan2ePpp1vJIwfFiO34LAPZgq9SZW9Aw=="],
-
-    "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -380,41 +309,17 @@
 
     "minimatch": ["minimatch@10.1.1", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ=="],
 
-    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
-
-    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
-
-    "minipass-collect": ["minipass-collect@2.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw=="],
-
-    "minipass-fetch": ["minipass-fetch@5.0.0", "", { "dependencies": { "minipass": "^7.0.3", "minipass-sized": "^1.0.3", "minizlib": "^3.0.1" }, "optionalDependencies": { "encoding": "^0.1.13" } }, "sha512-fiCdUALipqgPWrOVTz9fw0XhcazULXOSU6ie40DDbX1F49p1dBrSRBuswndTx1x3vEb/g0FT7vC4c4C2u/mh3A=="],
-
-    "minipass-flush": ["minipass-flush@1.0.5", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw=="],
-
-    "minipass-pipeline": ["minipass-pipeline@1.2.4", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A=="],
-
-    "minipass-sized": ["minipass-sized@1.0.3", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g=="],
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
-    "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
-
-    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
+    "mkdirp": ["mkdirp@3.0.1", "", { "bin": { "mkdirp": "dist/cjs/src/bin.js" } }, "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
-
     "negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
 
-    "node-abi": ["node-abi@3.85.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg=="],
-
-    "node-addon-api": ["node-addon-api@8.5.0", "", {}, "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A=="],
-
-    "node-gyp": ["node-gyp@12.1.0", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "graceful-fs": "^4.2.6", "make-fetch-happen": "^15.0.0", "nopt": "^9.0.0", "proc-log": "^6.0.0", "semver": "^7.3.5", "tar": "^7.5.2", "tinyglobby": "^0.2.12", "which": "^6.0.0" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-W+RYA8jBnhSr2vrTtlPYPc1K+CSjGpVDRZxcqJcERZ8ND3A1ThWPHRwctTx3qC3oW99jt726jhdz3Y6ky87J4g=="],
-
     "node-stream-zip": ["node-stream-zip@1.15.0", "", {}, "sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw=="],
-
-    "nopt": ["nopt@9.0.0", "", { "dependencies": { "abbrev": "^4.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw=="],
 
     "normalize-url": ["normalize-url@8.1.1", "", {}, "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ=="],
 
@@ -430,17 +335,11 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
-
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "on-headers": ["on-headers@1.1.0", "", {}, "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A=="],
 
-    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
-
     "p-cancelable": ["p-cancelable@4.0.1", "", {}, "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg=="],
-
-    "p-map": ["p-map@7.0.4", "", {}, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
 
     "packageurl-js": ["packageurl-js@1.0.2", "", {}, "sha512-fWC4ZPxo80qlh3xN5FxfIoQD3phVY4+EyzTIqyksjhKNDmaicdpxSvkWwIrYTtv9C1/RcUN6pxaTwGmj2NzS6A=="],
 
@@ -454,37 +353,25 @@
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
-    "path-scurry": ["path-scurry@2.0.1", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA=="],
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
-
-    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
-
-    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 
     "proc-log": ["proc-log@6.1.0", "", {}, "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ=="],
 
     "promise-retry": ["promise-retry@2.0.1", "", { "dependencies": { "err-code": "^2.0.2", "retry": "^0.12.0" } }, "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g=="],
 
-    "properties-reader": ["properties-reader@2.3.0", "", { "dependencies": { "mkdirp": "^1.0.4" } }, "sha512-z597WicA7nDZxK12kZqHr2TcvwNU1GCfA5UwfDY/HDp3hXPoPlb5rlEx9bwGTiJnc0OqbBTkU975jDToth8Gxw=="],
+    "properties-reader": ["properties-reader@3.0.1", "", { "dependencies": { "@kwsites/file-exists": "^1.1.1", "mkdirp": "^3.0.1" } }, "sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g=="],
 
-    "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
-
-    "qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ=="],
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
 
     "quick-lru": ["quick-lru@5.1.1", "", {}, "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="],
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
-    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
-
     "read-cmd-shim": ["read-cmd-shim@6.0.0", "", {}, "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A=="],
 
     "read-package-json-fast": ["read-package-json-fast@5.0.0", "", { "dependencies": { "json-parse-even-better-errors": "^5.0.0", "npm-normalize-package-bin": "^5.0.0" } }, "sha512-S16VePJnQcfmk6HIZAiP8TXW/VDlDtZfzVndRDE8lhZNA4YvAiwAjgvhoyf6+soofEH/vrZnOUctSt+jYE2tkg=="],
-
-    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
-
-    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
@@ -494,25 +381,19 @@
 
     "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
-    "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
-
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "sax": ["sax@1.4.3", "", {}, "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ=="],
 
-    "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
-
-    "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
-
-    "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
-    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
 
-    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
 
     "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
 
@@ -520,79 +401,43 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
-    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
-
-    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
-
-    "slice-ansi": ["slice-ansi@4.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "astral-regex": "^2.0.0", "is-fullwidth-code-point": "^3.0.0" } }, "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ=="],
-
-    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
-
-    "socks": ["socks@2.8.7", "", { "dependencies": { "ip-address": "^10.0.1", "smart-buffer": "^4.2.0" } }, "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A=="],
-
-    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
-
     "spdx-correct": ["spdx-correct@3.2.0", "", { "dependencies": { "spdx-expression-parse": "^3.0.0", "spdx-license-ids": "^3.0.0" } }, "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA=="],
 
     "spdx-exceptions": ["spdx-exceptions@2.5.0", "", {}, "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="],
 
-    "spdx-expression-parse": ["spdx-expression-parse@3.0.1", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q=="],
+    "spdx-expression-parse": ["spdx-expression-parse@4.0.0", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ=="],
 
     "spdx-license-ids": ["spdx-license-ids@3.0.22", "", {}, "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ=="],
 
-    "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
-
-    "sqlite3": ["@appthreat/sqlite3@7.0.2", "", { "dependencies": { "node-addon-api": "^8.5.0", "prebuild-install": "^7.1.3" }, "optionalDependencies": { "node-gyp": "12.x" } }, "sha512-AMsplY4Z/whvQfcML8bucKtVzSb2KUygvG3rQ0Qn0WjheL8j+cmfA4n0c4jACs5GaEbm25ElnXGlR7afi5ceYg=="],
-
-    "ssri": ["ssri@13.0.0", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-yizwGBpbCn4YomB2lzhZqrHLJoqFGXihNbib3ozhqF/cIp5ue+xSmOQrjNasEE62hFxsCcg/V/z23t4n8jMEng=="],
+    "ssri": ["ssri@13.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
-    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
-    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
-    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
-
-    "table": ["table@6.9.0", "", { "dependencies": { "ajv": "^8.0.1", "lodash.truncate": "^4.4.2", "slice-ansi": "^4.0.0", "string-width": "^4.2.3", "strip-ansi": "^6.0.1" } }, "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A=="],
-
-    "tar": ["tar@7.5.2", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg=="],
-
-    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
-
-    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
-
-    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+    "tar": ["tar@7.5.16", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "treeverse": ["treeverse@3.0.0", "", {}, "sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ=="],
 
-    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
-
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
-    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "undici": ["undici@7.18.2", "", {}, "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw=="],
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
-    "unique-filename": ["unique-filename@5.0.0", "", { "dependencies": { "unique-slug": "^6.0.0" } }, "sha512-2RaJTAvAb4owyjllTfXzFClJ7WsGxlykkPvCr9pA//LD9goVq+m4PPAeBgNodGZ7nSrntT/auWpJ6Y5IFXcfjg=="],
-
-    "unique-slug": ["unique-slug@6.0.0", "", { "dependencies": { "imurmurhash": "^0.1.4" } }, "sha512-4Lup7Ezn8W3d52/xBhZBVdx323ckxa7DEvd9kPQHppTkLoJXw6ltrBCyj5pnrxj0qKDxYMJ56CoxNuFCscdTiw=="],
-
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
-
-    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
 
-    "uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
 
@@ -610,8 +455,6 @@
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
-    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
-
     "write-file-atomic": ["write-file-atomic@7.0.0", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^4.0.1" } }, "sha512-YnlPC6JqnZl6aO4uRc+dx5PHguiR9S6WeoLtpxNT9wIG+BDya7ZNE1q7KOjVgaA73hKhKLpVPgJ5QA9THQ5BRg=="],
 
     "xml-js": ["xml-js@1.6.11", "", { "dependencies": { "sax": "^1.2.4" }, "bin": { "xml-js": "./bin/cli.js" } }, "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g=="],
@@ -620,7 +463,7 @@
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
-    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
 
@@ -628,21 +471,25 @@
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
-    "@appthreat/atom-parsetools/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
+    "@appthreat/atom-parsetools/typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
-    "@appthreat/atom-parsetools/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+    "@isaacs/fs-minipass/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
-    "@appthreat/cdx-proto/@bufbuild/protobuf": ["@bufbuild/protobuf@2.10.1", "", {}, "sha512-ckS3+vyJb5qGpEYv/s1OebUHDi/xSNtfgw1wqKZo7MR9F2z+qXr0q5XagafAG/9O0QPVIUfST0smluYSTpYFkg=="],
+    "@npmcli/fs/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
-    "cliui/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "@npmcli/git/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
-    "cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+    "@npmcli/map-workspaces/@npmcli/package-json": ["@npmcli/package-json@7.0.4", "", { "dependencies": { "@npmcli/git": "^7.0.0", "glob": "^13.0.0", "hosted-git-info": "^9.0.0", "json-parse-even-better-errors": "^5.0.0", "proc-log": "^6.0.0", "semver": "^7.5.3", "validate-npm-package-license": "^3.0.4" } }, "sha512-0wInJG3j/K40OJt/33ax47WfWMzZTm6OQxB9cDhTt5huCP2a9g2GnlsxmfN+PulItNPIpPrZ+kfwwUil7eHcZQ=="],
+
+    "@npmcli/map-workspaces/glob": ["glob@13.0.0", "", { "dependencies": { "minimatch": "^10.1.1", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA=="],
+
+    "ajv-formats/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "cacheable-request/keyv": ["keyv@5.5.5", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ=="],
 
     "compression/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
-
-    "encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
@@ -652,72 +499,42 @@
 
     "finalhandler/statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
 
-    "htmlparser2/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "glob/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
-    "make-fetch-happen/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+    "got/keyv": ["keyv@5.5.5", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ=="],
 
-    "minipass-flush/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+    "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
-    "minipass-pipeline/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+    "minizlib/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
-    "minipass-sized/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+    "npm-install-checks/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "npm-package-arg/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "npm-pick-manifest/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "raw-body/iconv-lite": ["iconv-lite@0.7.1", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw=="],
 
-    "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+    "spdx-correct/spdx-expression-parse": ["spdx-expression-parse@3.0.1", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q=="],
 
-    "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
+    "tar/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
-    "simple-get/decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
-
-    "tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
+    "validate-npm-package-license/spdx-expression-parse": ["spdx-expression-parse@3.0.1", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q=="],
 
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
-    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+    "@npmcli/map-workspaces/@npmcli/package-json/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
-    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "@npmcli/map-workspaces/glob/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
-    "wrap-ansi/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
-    "yargs/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
-
-    "@appthreat/atom-parsetools/@babel/parser/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
-
-    "@appthreat/atom-parsetools/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
-
-    "@appthreat/atom-parsetools/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
-
-    "cliui/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
-
-    "cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "@npmcli/map-workspaces/glob/path-scurry": ["path-scurry@2.0.1", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA=="],
 
     "compression/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "connect/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
-
-    "minipass-flush/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
-
-    "minipass-pipeline/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
-
-    "minipass-sized/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
-
-    "simple-get/decompress-response/mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
-
-    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
-
-    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "yargs/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
-
-    "yargs/string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
-    "@appthreat/atom-parsetools/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
   }
 }

--- a/sbomify_action/_upload/__init__.py
+++ b/sbomify_action/_upload/__init__.py
@@ -39,7 +39,7 @@ from .destinations import (
     SbomifyDestination,
 )
 from .orchestrator import UploadOrchestrator, create_registry_with_sbomify
-from .protocol import Destination, DestinationConfig, SBOMFormat, UploadInput
+from .protocol import VALID_BOM_TYPES, Destination, DestinationConfig, SBOMFormat, UploadInput
 from .registry import VALID_DESTINATIONS, DestinationRegistry
 from .result import UploadResult
 
@@ -47,6 +47,7 @@ __all__ = [
     # Core types
     "SBOMFormat",
     "UploadInput",
+    "VALID_BOM_TYPES",
     "UploadResult",
     "Destination",
     "DestinationConfig",

--- a/sbomify_action/_upload/destinations/sbomify.py
+++ b/sbomify_action/_upload/destinations/sbomify.py
@@ -133,6 +133,7 @@ class SbomifyDestination:
                 component_id=str(self._component_id),
                 sbom_payload=upload_data,
                 sbom_format=input.sbom_format,
+                bom_type=input.bom_type,
                 content_encoding=content_encoding,
             )
         except AuthError as e:

--- a/sbomify_action/_upload/protocol.py
+++ b/sbomify_action/_upload/protocol.py
@@ -14,6 +14,10 @@ if TYPE_CHECKING:
 # Supported SBOM formats (same as generation)
 SBOMFormat = Literal["cyclonedx", "spdx"]
 
+# Artifact types the sbomify backend accepts via the ?bom_type= query param.
+# None/"sbom" is the default plain SBOM upload; the others are uploaded as-is.
+VALID_BOM_TYPES = ("sbom", "vex", "cbom", "hbom")
+
 
 @dataclass
 class UploadInput:
@@ -23,6 +27,8 @@ class UploadInput:
     Attributes:
         sbom_file: Path to the SBOM file to upload
         sbom_format: Format of the SBOM ("cyclonedx" or "spdx")
+        bom_type: Artifact type to record on upload (sbom/vex/cbom/hbom). None
+            uploads as a plain SBOM; non-SBOM types are sent verbatim.
         component_name: Name of the component (used by destinations like Dependency Track)
         component_version: Version of the component (used by destinations like Dependency Track)
         validate_before_upload: Whether to validate SBOM before uploading
@@ -30,6 +36,7 @@ class UploadInput:
 
     sbom_file: str
     sbom_format: SBOMFormat
+    bom_type: Optional[str] = None
     component_name: Optional[str] = None
     component_version: Optional[str] = None
     validate_before_upload: bool = True
@@ -40,6 +47,8 @@ class UploadInput:
             raise ValueError("sbom_file is required")
         if self.sbom_format not in ("cyclonedx", "spdx"):
             raise ValueError(f"Invalid sbom_format: {self.sbom_format}")
+        if self.bom_type is not None and self.bom_type not in VALID_BOM_TYPES:
+            raise ValueError(f"Invalid bom_type: {self.bom_type}. Must be one of: {', '.join(VALID_BOM_TYPES)}")
 
 
 class DestinationConfig(ABC):

--- a/sbomify_action/cbom.py
+++ b/sbomify_action/cbom.py
@@ -54,7 +54,10 @@ def _serial_and_version(bom: dict[str, Any]) -> tuple[str, int]:
     if not serial:
         serial = f"urn:uuid:{uuid.uuid4()}"
         bom["serialNumber"] = serial
-    version = int(bom.get("version") or 1)
+    try:
+        version = int(bom.get("version") or 1)
+    except (TypeError, ValueError):
+        version = 1
     bom["version"] = version
     bare_uuid = serial.rsplit(":", 1)[-1]
     return bare_uuid, version

--- a/sbomify_action/cbom.py
+++ b/sbomify_action/cbom.py
@@ -73,11 +73,13 @@ def _add_external_bom_ref(bom: dict[str, Any], url: str, comment: str) -> None:
 
 
 def _mark_incomplete(cbom: dict[str, Any]) -> None:
-    """Record ``aggregate: incomplete`` when the CBOM declares no ``compositions`` of
-    its own, so consumers do not read a scanner-derived CBOM as a complete
-    cryptographic inventory. A composition the generator already set is left as-is."""
-    if not cbom.get("compositions"):
-        cbom["compositions"] = [{"aggregate": "incomplete"}]
+    """Ensure the CBOM carries an ``aggregate: incomplete`` composition so a
+    scanner-derived CBOM is never read as a complete cryptographic inventory.
+    Compositions the generator already declared are preserved; the marker is
+    appended only when no incomplete entry is present. Idempotent."""
+    compositions = cbom.setdefault("compositions", [])
+    if not any(isinstance(c, dict) and c.get("aggregate") == "incomplete" for c in compositions):
+        compositions.append({"aggregate": "incomplete"})
 
 
 def crosslink_sbom_and_cbom(sbom_path: str, cbom_path: str) -> None:

--- a/sbomify_action/cbom.py
+++ b/sbomify_action/cbom.py
@@ -73,8 +73,9 @@ def _add_external_bom_ref(bom: dict[str, Any], url: str, comment: str) -> None:
 
 
 def _mark_incomplete(cbom: dict[str, Any]) -> None:
-    """A scanner-derived CBOM is partial; record ``aggregate: incomplete`` so
-    consumers do not read it as a complete cryptographic inventory."""
+    """Record ``aggregate: incomplete`` when the CBOM declares no ``compositions`` of
+    its own, so consumers do not read a scanner-derived CBOM as a complete
+    cryptographic inventory. A composition the generator already set is left as-is."""
     if not cbom.get("compositions"):
         cbom["compositions"] = [{"aggregate": "incomplete"}]
 

--- a/sbomify_action/cbom.py
+++ b/sbomify_action/cbom.py
@@ -1,0 +1,103 @@
+"""Generate a CBOM (Cryptography Bill of Materials) and cross-link it with the SBOM.
+
+cdxgen's ``--include-crypto`` discovers ``cryptographic-asset`` components
+(algorithms, certificates, protocols, keys) from the source tree. Coverage is
+realistically Java keystores/certificates plus JS/TS source call sites; it does not
+see binary-embedded, dynamically dispatched, or framework/stdlib crypto, so the
+generated CBOM is marked ``compositions: aggregate=incomplete``.
+
+The SBOM and CBOM reference each other through CycloneDX ``externalReferences`` of
+type ``bom`` carrying a BOM-Link URN (``urn:cdx:<serialNumber>/<version>``), so a
+consumer that has one can discover the other.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from typing import Any, Optional
+
+from sbomify_action.exceptions import SBOMGenerationError
+from sbomify_action.logging_config import logger
+
+from ._generation.utils import DEFAULT_TIMEOUT, run_command
+
+CBOM_DEFAULT_SPEC_VERSION = "1.7"
+
+
+def generate_cbom(
+    output_file: str, spec_version: str = CBOM_DEFAULT_SPEC_VERSION, cwd: Optional[str] = None
+) -> Optional[str]:
+    """Generate a CBOM with ``cdxgen --include-crypto``.
+
+    Returns the absolute output path, or ``None`` if generation failed or produced
+    nothing. CBOM generation is best-effort and never fails the overall run.
+    """
+    output_abs = str(Path(output_file).resolve())
+    cmd = ["cdxgen", "-o", output_abs, "--spec-version", spec_version, "--include-crypto", "."]
+    logger.info(f"Generating CBOM with cdxgen --include-crypto (CycloneDX {spec_version})")
+    try:
+        run_command(cmd, "cdxgen (CBOM)", timeout=DEFAULT_TIMEOUT, cwd=cwd, log_errors=False)
+    except SBOMGenerationError as e:
+        logger.warning(f"CBOM generation failed, skipping CBOM: {e}")
+        return None
+    if not Path(output_abs).exists():
+        logger.warning("CBOM generation produced no output, skipping CBOM")
+        return None
+    return output_abs
+
+
+def _serial_and_version(bom: dict[str, Any]) -> tuple[str, int]:
+    """Return ``(bare-uuid, version)`` for a BOM, assigning a serialNumber if absent."""
+    serial = bom.get("serialNumber")
+    if not serial:
+        serial = f"urn:uuid:{uuid.uuid4()}"
+        bom["serialNumber"] = serial
+    version = int(bom.get("version") or 1)
+    bom["version"] = version
+    bare_uuid = serial.rsplit(":", 1)[-1]
+    return bare_uuid, version
+
+
+def _bom_link(bare_uuid: str, version: int) -> str:
+    return f"urn:cdx:{bare_uuid}/{version}"
+
+
+def _add_external_bom_ref(bom: dict[str, Any], url: str, comment: str) -> None:
+    """Idempotently add a top-level ``externalReferences`` entry of type ``bom``."""
+    refs = bom.setdefault("externalReferences", [])
+    if any(isinstance(r, dict) and r.get("type") == "bom" and r.get("url") == url for r in refs):
+        return
+    refs.append({"type": "bom", "url": url, "comment": comment})
+
+
+def _mark_incomplete(cbom: dict[str, Any]) -> None:
+    """A scanner-derived CBOM is partial; record ``aggregate: incomplete`` so
+    consumers do not read it as a complete cryptographic inventory."""
+    if not cbom.get("compositions"):
+        cbom["compositions"] = [{"aggregate": "incomplete"}]
+
+
+def crosslink_sbom_and_cbom(sbom_path: str, cbom_path: str) -> None:
+    """Cross-reference the SBOM and CBOM and write both files back.
+
+    Each BOM gains an ``externalReferences`` entry of type ``bom`` with a BOM-Link
+    URN to the other; the CBOM is also marked ``aggregate: incomplete``. Idempotent.
+    """
+    sbom = json.loads(Path(sbom_path).read_text(encoding="utf-8"))
+    cbom = json.loads(Path(cbom_path).read_text(encoding="utf-8"))
+
+    sbom_uuid, sbom_ver = _serial_and_version(sbom)
+    cbom_uuid, cbom_ver = _serial_and_version(cbom)
+
+    _add_external_bom_ref(
+        sbom, _bom_link(cbom_uuid, cbom_ver), "Cryptography Bill of Materials (CBOM) for this component"
+    )
+    _add_external_bom_ref(
+        cbom, _bom_link(sbom_uuid, sbom_ver), "Software Bill of Materials (SBOM) this CBOM was derived from"
+    )
+    _mark_incomplete(cbom)
+
+    Path(sbom_path).write_text(json.dumps(sbom, indent=2), encoding="utf-8")
+    Path(cbom_path).write_text(json.dumps(cbom, indent=2), encoding="utf-8")

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -1224,6 +1224,7 @@ def _upload_cbom(config: Config, cbom_file: str) -> None:
     """Upload the generated CBOM as a second artifact (bom_type=cbom). Best-effort:
     a CBOM upload failure is logged but does not fail the SBOM run."""
     _log_step_header(5.5, "Uploading CBOM")
+    failed: list[str] = []
     try:
         for destination in config.upload_destinations or []:
             result = upload_sbom(
@@ -1242,10 +1243,14 @@ def _upload_cbom(config: Config, cbom_file: str) -> None:
                 logger.info(f"CBOM upload to {destination} succeeded")
             else:
                 logger.warning(f"CBOM upload to {destination} failed: {result.error_message}")
-        _log_step_end(5.5)
+                failed.append(destination)
     except Exception as e:
         logger.warning(f"CBOM upload failed, continuing: {e}")
         _log_step_end(5.5, success=False)
+        return
+    # Best-effort: a CBOM upload failure does not fail the SBOM run, but the step
+    # is reported as failed so a partial failure is not hidden as success.
+    _log_step_end(5.5, success=not failed)
 
 
 def run_pipeline(config: Config) -> None:

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -142,6 +142,9 @@ SBOMIFY_TOOL_NAME = "sbomify-action"
 SBOMIFY_VENDOR_NAME = "sbomify"
 LOCALHOST_PATTERNS = ["127.0.0.1", "localhost", "0.0.0.0"]
 VALID_SBOM_FORMATS: tuple[str, ...] = ("cyclonedx", "spdx")
+# Artifact types accepted by the backend's ?bom_type= upload param. None/"sbom"
+# is a plain SBOM; "vex"/"cbom"/"hbom" are uploaded verbatim (no finalization).
+VALID_BOM_TYPES: tuple[str, ...] = ("sbom", "vex", "cbom", "hbom")
 NONE_SENTINEL = "none"
 
 # Intermediate SBOM files for pipeline steps
@@ -226,6 +229,7 @@ class Config:
     product_releases: Optional[str | list[str]] = None
     api_base_url: str = SBOMIFY_PRODUCTION_API
     sbom_format: SBOMFormat = "cyclonedx"
+    bom_type: Optional[str] = None
     spec_version: Optional[str] = None
     oidc_audience: str | None = None
     # Set to True at runtime when config.token was obtained via OIDC exchange;
@@ -333,6 +337,12 @@ class Config:
         if self.sbom_format not in VALID_SBOM_FORMATS:
             raise ConfigurationError(
                 f"Invalid SBOM_FORMAT: '{self.sbom_format}'. Must be one of: {', '.join(VALID_SBOM_FORMATS)}"
+            )
+
+        # Validate bom_type (artifact kind recorded on upload)
+        if self.bom_type is not None and self.bom_type not in VALID_BOM_TYPES:
+            raise ConfigurationError(
+                f"Invalid BOM_TYPE: '{self.bom_type}'. Must be one of: {', '.join(VALID_BOM_TYPES)}"
             )
 
         # Validate spec_version against sbom_format
@@ -518,6 +528,7 @@ def build_config(
     product_releases: Optional[str] = None,
     api_base_url: str = SBOMIFY_PRODUCTION_API,
     sbom_format: str = "cyclonedx",
+    bom_type: Optional[str] = None,
     spec_version: Optional[str] = None,
     oidc_audience: Optional[str] = None,
 ) -> Config:
@@ -597,6 +608,7 @@ def build_config(
         product_releases=product_releases,
         api_base_url=api_base_url,
         sbom_format=sbom_format_lower,
+        bom_type=bom_type.lower() if bom_type else None,
         spec_version=spec_version,
         oidc_audience=oidc_audience,
     )
@@ -644,6 +656,7 @@ def load_config() -> Config:
         product_releases=os.getenv("PRODUCT_RELEASE"),
         api_base_url=os.getenv("API_BASE_URL", SBOMIFY_PRODUCTION_API),
         sbom_format=os.getenv("SBOM_FORMAT", "cyclonedx"),
+        bom_type=os.getenv("BOM_TYPE"),
         oidc_audience=os.getenv("OIDC_AUDIENCE"),
     )
 
@@ -1128,6 +1141,24 @@ def _log_step_end(step_num: int | float, success: bool = True) -> None:
     print_step_end(step_num, success)
 
 
+def _finalize_output_content(content: str, bom_type: Optional[str]) -> str:
+    """Return the bytes to upload after format-specific output fixes.
+
+    CycloneDX SBOMs get PURL-encoding repairs and a compositions completeness
+    indicator. Non-SBOM CycloneDX artifacts (VEX, CBOM, ...) are uploaded
+    exactly as authored — sbomify never rewrites a security artifact — so the
+    fixes are skipped. SPDX and other content pass through unchanged.
+    """
+    is_cyclonedx = '"bomFormat"' in content and '"CycloneDX"' in content
+    if not is_cyclonedx:
+        return content
+    if bom_type and bom_type != "sbom":
+        return content
+    content = _fix_purl_encoding_bugs_in_json(content)
+    content = _add_compositions_if_missing(content)
+    return content
+
+
 def run_pipeline(config: Config) -> None:
     """
     Run the SBOM pipeline with the given configuration.
@@ -1574,10 +1605,7 @@ def run_pipeline(config: Config) -> None:
         with open(final_sbom_file, "r") as f:
             content = f.read()
 
-        # Detect format and fix any PURL encoding bugs in CycloneDX
-        if '"bomFormat"' in content and '"CycloneDX"' in content:
-            content = _fix_purl_encoding_bugs_in_json(content)
-            content = _add_compositions_if_missing(content)
+        content = _finalize_output_content(content, config.bom_type)
 
         with open(config.output_file, "w") as f:
             f.write(content)
@@ -1616,6 +1644,7 @@ def run_pipeline(config: Config) -> None:
                     component_version=config.component_version,
                     destination=destination,
                     validate_before_upload=(FORMAT == "cyclonedx"),
+                    bom_type=config.bom_type,
                 )
 
                 if not upload_result.success:
@@ -2355,6 +2384,13 @@ def _parse_upload_destinations_callback(
     help="Output SBOM format.",
 )
 @click.option(
+    "--bom-type",
+    envvar="BOM_TYPE",
+    type=click.Choice(list(VALID_BOM_TYPES), case_sensitive=False),
+    default=None,
+    help="Artifact type recorded on upload (vex/cbom/hbom). Non-SBOM types are uploaded verbatim.",
+)
+@click.option(
     "--spec-version",
     envvar="SPEC_VERSION",
     default=None,
@@ -2414,6 +2450,7 @@ def cli(
     product_releases: Optional[str],
     api_base_url: str,
     sbom_format: str,
+    bom_type: Optional[str],
     spec_version: Optional[str],
     oidc_audience: Optional[str],
     working_dir: str | None,
@@ -2537,6 +2574,7 @@ def cli(
         product_releases=product_releases,
         api_base_url=api_base_url,
         sbom_format=sbom_format,
+        bom_type=bom_type,
         spec_version=spec_version,
         oidc_audience=oidc_audience,
     )

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -2520,7 +2520,7 @@ def _parse_upload_destinations_callback(
     envvar="BOM_TYPE",
     type=click.Choice(list(VALID_BOM_TYPES), case_sensitive=False),
     default=None,
-    help="Artifact type recorded on upload: sbom (default), vex, cbom or hbom. Non-SBOM types are uploaded verbatim.",
+    help="Artifact type recorded on upload: sbom (default), vex, cbom or hbom. Non-SBOM types skip augmentation and enrichment.",
 )
 @click.option(
     "--generate-cbom/--no-generate-cbom",

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -1222,13 +1222,22 @@ def _stamp_cbom_component_version(cbom_file: str, version: str) -> None:
     Path(cbom_file).write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
+# Only sbomify records the bom_type=cbom classification; other destinations
+# (e.g. dependency-track) would ingest the CBOM as a plain project SBOM.
+_CBOM_UPLOAD_DESTINATIONS = frozenset({"sbomify"})
+
+
 def _upload_cbom(config: Config, cbom_file: str) -> None:
     """Upload the generated CBOM as a second artifact (bom_type=cbom). Best-effort:
-    a CBOM upload failure is logged but does not fail the SBOM run."""
+    a CBOM upload failure is logged but does not fail the SBOM run. Only sbomify
+    understands the CBOM classification, so other destinations are skipped."""
     _log_step_header(5.5, "Uploading CBOM")
     failed: list[str] = []
     try:
         for destination in config.upload_destinations or []:
+            if destination not in _CBOM_UPLOAD_DESTINATIONS:
+                logger.info(f"Skipping CBOM upload to {destination}: only sbomify records CBOM artifacts")
+                continue
             result = upload_sbom(
                 sbom_file=cbom_file,
                 sbom_format="cyclonedx",

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -19,7 +19,7 @@ import sentry_sdk
 from cyclonedx.model.bom import Bom
 
 from .. import format_display_name
-from .._upload import VALID_DESTINATIONS
+from .._upload import VALID_BOM_TYPES, VALID_DESTINATIONS
 from ..additional_packages import inject_additional_packages
 from ..augmentation import augment_sbom_from_file
 from ..console import (
@@ -142,9 +142,6 @@ SBOMIFY_TOOL_NAME = "sbomify-action"
 SBOMIFY_VENDOR_NAME = "sbomify"
 LOCALHOST_PATTERNS = ["127.0.0.1", "localhost", "0.0.0.0"]
 VALID_SBOM_FORMATS: tuple[str, ...] = ("cyclonedx", "spdx")
-# Artifact types accepted by the backend's ?bom_type= upload param. None/"sbom"
-# is a plain SBOM; "vex"/"cbom"/"hbom" are uploaded verbatim (no finalization).
-VALID_BOM_TYPES: tuple[str, ...] = ("sbom", "vex", "cbom", "hbom")
 NONE_SENTINEL = "none"
 
 # Intermediate SBOM files for pipeline steps

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -579,9 +579,9 @@ def build_config(
     sbom_format_lower: SBOMFormat = cast(SBOMFormat, sbom_format.lower())
     logger.info(f"SBOM format: {format_display_name(sbom_format_lower)}")
 
-    # Non-SBOM artifacts (VEX, CBOM, ...) are authored elsewhere and uploaded
-    # exactly as written. Augmentation and enrichment rewrite the document, so
-    # they are not applied to them regardless of the flags.
+    # Augmentation and enrichment rewrite the document, so they are turned off
+    # for non-SBOM artifacts (VEX, CBOM, ...) regardless of the flags. Component
+    # overrides and additional-package injection still apply if configured.
     normalized_bom_type = bom_type.lower() if bom_type else None
     if normalized_bom_type and normalized_bom_type != "sbom":
         if augment or enrich:
@@ -1159,9 +1159,9 @@ def _finalize_output_content(content: str, bom_type: Optional[str]) -> str:
     """Return the bytes to upload after format-specific output fixes.
 
     CycloneDX SBOMs get PURL-encoding repairs and a compositions completeness
-    indicator. Non-SBOM CycloneDX artifacts (VEX, CBOM, ...) are uploaded
-    exactly as authored — sbomify never rewrites a security artifact — so the
-    fixes are skipped. SPDX and other content pass through unchanged.
+    indicator. These finalization fixes are skipped for non-SBOM CycloneDX
+    artifacts (VEX, CBOM, ...) so their authored content is preserved here. SPDX
+    and other content pass through unchanged.
     """
     is_cyclonedx = '"bomFormat"' in content and '"CycloneDX"' in content
     if not is_cyclonedx:
@@ -1253,6 +1253,7 @@ def _upload_cbom(config: Config, cbom_file: str) -> None:
     # Best-effort: a CBOM upload failure does not fail the SBOM run, but the step
     # is reported as failed so a partial failure is not hidden as success.
     _log_step_end(5.5, success=not failed)
+
 
 def _finalize_post_upload(results: "AggregateResult") -> None:
     """Log the outcome of each processor that ran and exit non-zero if any failed.

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -577,6 +577,16 @@ def build_config(
     sbom_format_lower: SBOMFormat = cast(SBOMFormat, sbom_format.lower())
     logger.info(f"SBOM format: {format_display_name(sbom_format_lower)}")
 
+    # Non-SBOM artifacts (VEX, CBOM, ...) are authored elsewhere and uploaded
+    # exactly as written. Augmentation and enrichment rewrite the document, so
+    # they are not applied to them regardless of the flags.
+    normalized_bom_type = bom_type.lower() if bom_type else None
+    if normalized_bom_type and normalized_bom_type != "sbom":
+        if augment or enrich:
+            logger.warning(f"BOM_TYPE={normalized_bom_type} is uploaded verbatim; ignoring AUGMENT/ENRICH.")
+        augment = False
+        enrich = False
+
     # Expand paths if provided (skip expansion for "none" sentinel)
     expanded_sbom_file = (
         sbom_file
@@ -608,7 +618,7 @@ def build_config(
         product_releases=product_releases,
         api_base_url=api_base_url,
         sbom_format=sbom_format_lower,
-        bom_type=bom_type.lower() if bom_type else None,
+        bom_type=normalized_bom_type,
         spec_version=spec_version,
         oidc_audience=oidc_audience,
     )

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -1676,10 +1676,14 @@ def run_pipeline(config: Config) -> None:
 
     # Step 3.6: optional CBOM generation + SBOM<->CBOM cross-linking. Runs before
     # finalize so the SBOM carries the cross-reference. CBOMs only make sense for an
-    # SBOM upload, not when uploading a VEX/HBOM verbatim.
+    # SBOM upload, not when uploading a VEX/HBOM verbatim, and the cross-link injects
+    # CycloneDX fields (externalReferences/serialNumber) so the SBOM must be CycloneDX.
     cbom_output_file: Optional[str] = None
     if config.generate_cbom and config.bom_type in (None, "sbom"):
-        cbom_output_file = _generate_cbom_and_crosslink(config)
+        if FORMAT == "cyclonedx":
+            cbom_output_file = _generate_cbom_and_crosslink(config)
+        else:
+            logger.info("CBOM generation skipped: cross-linking requires a CycloneDX SBOM (SBOM_FORMAT is SPDX)")
 
     # Step 4: Finalize output
     _log_step_header(4, "Finalizing SBOM Output")
@@ -2488,7 +2492,7 @@ def _parse_upload_destinations_callback(
     envvar="BOM_TYPE",
     type=click.Choice(list(VALID_BOM_TYPES), case_sensitive=False),
     default=None,
-    help="Artifact type recorded on upload (vex/cbom/hbom). Non-SBOM types are uploaded verbatim.",
+    help="Artifact type recorded on upload: sbom (default), vex, cbom or hbom. Non-SBOM types are uploaded verbatim.",
 )
 @click.option(
     "--generate-cbom/--no-generate-cbom",

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -585,7 +585,7 @@ def build_config(
     normalized_bom_type = bom_type.lower() if bom_type else None
     if normalized_bom_type and normalized_bom_type != "sbom":
         if augment or enrich:
-            logger.warning(f"BOM_TYPE={normalized_bom_type} is uploaded verbatim; ignoring AUGMENT/ENRICH.")
+            logger.warning(f"BOM_TYPE={normalized_bom_type}: skipping augmentation and enrichment.")
         augment = False
         enrich = False
 

--- a/sbomify_action/cli/main.py
+++ b/sbomify_action/cli/main.py
@@ -148,6 +148,7 @@ NONE_SENTINEL = "none"
 STEP_1_FILE = "step_1.json"  # Output of generation/validation
 STEP_2_FILE = "step_2.json"  # Output of augmentation
 STEP_3_FILE = "step_3.json"  # Output of enrichment
+CBOM_FILE = "cbom_output.json"  # Generated CBOM (kept out of the STEP_* cleanup)
 
 
 def _get_current_utc_timestamp() -> str:
@@ -227,6 +228,7 @@ class Config:
     api_base_url: str = SBOMIFY_PRODUCTION_API
     sbom_format: SBOMFormat = "cyclonedx"
     bom_type: Optional[str] = None
+    generate_cbom: bool = False
     spec_version: Optional[str] = None
     oidc_audience: str | None = None
     # Set to True at runtime when config.token was obtained via OIDC exchange;
@@ -526,6 +528,7 @@ def build_config(
     api_base_url: str = SBOMIFY_PRODUCTION_API,
     sbom_format: str = "cyclonedx",
     bom_type: Optional[str] = None,
+    generate_cbom: bool = False,
     spec_version: Optional[str] = None,
     oidc_audience: Optional[str] = None,
 ) -> Config:
@@ -616,6 +619,7 @@ def build_config(
         api_base_url=api_base_url,
         sbom_format=sbom_format_lower,
         bom_type=normalized_bom_type,
+        generate_cbom=generate_cbom,
         spec_version=spec_version,
         oidc_audience=oidc_audience,
     )
@@ -664,6 +668,7 @@ def load_config() -> Config:
         api_base_url=os.getenv("API_BASE_URL", SBOMIFY_PRODUCTION_API),
         sbom_format=os.getenv("SBOM_FORMAT", "cyclonedx"),
         bom_type=os.getenv("BOM_TYPE"),
+        generate_cbom=os.getenv("GENERATE_CBOM", "").strip().lower() in ("true", "1", "yes", "on"),
         oidc_audience=os.getenv("OIDC_AUDIENCE"),
     )
 
@@ -1166,6 +1171,83 @@ def _finalize_output_content(content: str, bom_type: Optional[str]) -> str:
     return content
 
 
+def _generate_cbom_and_crosslink(config: Config) -> Optional[str]:
+    """Generate a CBOM (cdxgen --include-crypto) and cross-link it with the SBOM.
+
+    Returns the CBOM file path, or None when generation was skipped or failed.
+    Best-effort: a CBOM failure is logged and never fails the SBOM run. The SBOM's
+    last-step file is mutated in place to carry the CBOM cross-reference before
+    Step 4 finalizes it.
+    """
+    from sbomify_action.cbom import crosslink_sbom_and_cbom, generate_cbom
+
+    sbom_step_file = get_last_sbom_from_last_step()
+    if not sbom_step_file:
+        logger.warning("No SBOM available to derive a CBOM from; skipping CBOM")
+        return None
+
+    _log_step_header(3.6, "CBOM Generation")
+    try:
+        scan_dir = os.getcwd()
+        if config.lock_file and config.lock_file.lower() != NONE_SENTINEL:
+            scan_dir = str(Path(config.lock_file).resolve().parent)
+
+        cbom_file = generate_cbom(CBOM_FILE, spec_version=config.spec_version or "1.7", cwd=scan_dir)
+        if not cbom_file:
+            _log_step_end(3.6, success=False)
+            return None
+
+        crosslink_sbom_and_cbom(sbom_step_file, cbom_file)
+        if config.component_version:
+            _stamp_cbom_component_version(cbom_file, config.component_version)
+
+        logger.info(f"CBOM generated and cross-linked with the SBOM: {cbom_file}")
+        _log_step_end(3.6)
+        return cbom_file
+    except Exception as e:
+        logger.warning(f"CBOM generation step failed, continuing without a CBOM: {e}")
+        _log_step_end(3.6, success=False)
+        return None
+
+
+def _stamp_cbom_component_version(cbom_file: str, version: str) -> None:
+    """Stamp the CBOM's metadata.component.version so it matches the SBOM's."""
+    import json
+
+    data = json.loads(Path(cbom_file).read_text(encoding="utf-8"))
+    component = data.setdefault("metadata", {}).setdefault("component", {})
+    component["version"] = version
+    Path(cbom_file).write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def _upload_cbom(config: Config, cbom_file: str) -> None:
+    """Upload the generated CBOM as a second artifact (bom_type=cbom). Best-effort:
+    a CBOM upload failure is logged but does not fail the SBOM run."""
+    _log_step_header(5.5, "Uploading CBOM")
+    try:
+        for destination in config.upload_destinations or []:
+            result = upload_sbom(
+                sbom_file=cbom_file,
+                sbom_format="cyclonedx",
+                token=config.token,
+                component_id=config.component_id,
+                api_base_url=config.api_base_url,
+                component_name=config.component_name,
+                component_version=config.component_version,
+                destination=destination,
+                validate_before_upload=False,
+                bom_type="cbom",
+            )
+            if result.success:
+                logger.info(f"CBOM upload to {destination} succeeded")
+            else:
+                logger.warning(f"CBOM upload to {destination} failed: {result.error_message}")
+        _log_step_end(5.5)
+    except Exception as e:
+        logger.warning(f"CBOM upload failed, continuing: {e}")
+        _log_step_end(5.5, success=False)
+
+
 def run_pipeline(config: Config) -> None:
     """
     Run the SBOM pipeline with the given configuration.
@@ -1592,6 +1674,13 @@ def run_pipeline(config: Config) -> None:
         logger.info("SBOM enrichment disabled (ENRICH=false)")
         _log_step_end(3)
 
+    # Step 3.6: optional CBOM generation + SBOM<->CBOM cross-linking. Runs before
+    # finalize so the SBOM carries the cross-reference. CBOMs only make sense for an
+    # SBOM upload, not when uploading a VEX/HBOM verbatim.
+    cbom_output_file: Optional[str] = None
+    if config.generate_cbom and config.bom_type in (None, "sbom"):
+        cbom_output_file = _generate_cbom_and_crosslink(config)
+
     # Step 4: Finalize output
     _log_step_header(4, "Finalizing SBOM Output")
     try:
@@ -1690,6 +1779,10 @@ def run_pipeline(config: Config) -> None:
         _log_step_header(5, "SBOM Upload - SKIPPED")
         logger.info("SBOM upload disabled (UPLOAD=false)")
         _log_step_end(5)
+
+    # Step 5b: upload the generated CBOM as a second artifact (bom_type=cbom).
+    if cbom_output_file and config.upload:
+        _upload_cbom(config, cbom_output_file)
 
     # Step 6: Post-upload Processing (releases, signing, etc.)
     if sbom_id:
@@ -2398,6 +2491,12 @@ def _parse_upload_destinations_callback(
     help="Artifact type recorded on upload (vex/cbom/hbom). Non-SBOM types are uploaded verbatim.",
 )
 @click.option(
+    "--generate-cbom/--no-generate-cbom",
+    envvar="GENERATE_CBOM",
+    default=False,
+    help="Also generate a CBOM (cdxgen --include-crypto) and upload it as bom_type=cbom, cross-linked with the SBOM.",
+)
+@click.option(
     "--spec-version",
     envvar="SPEC_VERSION",
     default=None,
@@ -2458,6 +2557,7 @@ def cli(
     api_base_url: str,
     sbom_format: str,
     bom_type: Optional[str],
+    generate_cbom: bool,
     spec_version: Optional[str],
     oidc_audience: Optional[str],
     working_dir: str | None,
@@ -2582,6 +2682,7 @@ def cli(
         api_base_url=api_base_url,
         sbom_format=sbom_format,
         bom_type=bom_type,
+        generate_cbom=generate_cbom,
         spec_version=spec_version,
         oidc_audience=oidc_audience,
     )

--- a/sbomify_action/sbomify_api.py
+++ b/sbomify_action/sbomify_api.py
@@ -796,9 +796,10 @@ class SbomifyApiClient:
     ) -> requests.Response:
         """POST raw SBOM bytes to ``/api/v1/sboms/artifact/{format}/{id}``.
 
-        ``bom_type`` (sbom/vex/cbom/hbom) is forwarded as the ``?bom_type=``
-        query param when set, so the same endpoint can record a VEX or CBOM
-        rather than a plain SBOM. The destination layer owns
+        ``bom_type`` (vex/cbom/hbom) is forwarded as the ``?bom_type=`` query
+        param when set, so the same endpoint can record a VEX or CBOM rather than
+        a plain SBOM. The default ``sbom`` is left off so it is indistinguishable
+        from an unset upload on the backend. The destination layer owns
         error-to-``UploadResult`` translation, so this method returns the raw
         response (including non-2xx) instead of raising. Network/timeout
         failures still bubble up as ``APIError``.
@@ -807,7 +808,7 @@ class SbomifyApiClient:
         extra: dict[str, str] = {"Content-Type": "application/json"}
         if content_encoding:
             extra["Content-Encoding"] = content_encoding
-        params = {"bom_type": bom_type} if bom_type else None
+        params = {"bom_type": bom_type} if bom_type and bom_type != "sbom" else None
         return self._request(
             "POST",
             path,

--- a/sbomify_action/sbomify_api.py
+++ b/sbomify_action/sbomify_api.py
@@ -790,23 +790,29 @@ class SbomifyApiClient:
         sbom_payload: bytes,
         *,
         sbom_format: str = "cyclonedx",
+        bom_type: str | None = None,
         content_encoding: str | None = None,
         timeout: int | None = None,
     ) -> requests.Response:
         """POST raw SBOM bytes to ``/api/v1/sboms/artifact/{format}/{id}``.
 
-        The destination layer owns error-to-``UploadResult`` translation, so
-        this method returns the raw response (including non-2xx) instead of
-        raising. Network/timeout failures still bubble up as ``APIError``.
+        ``bom_type`` (sbom/vex/cbom/hbom) is forwarded as the ``?bom_type=``
+        query param when set, so the same endpoint can record a VEX or CBOM
+        rather than a plain SBOM. The destination layer owns
+        error-to-``UploadResult`` translation, so this method returns the raw
+        response (including non-2xx) instead of raising. Network/timeout
+        failures still bubble up as ``APIError``.
         """
         path = f"/api/v1/sboms/artifact/{sbom_format}/{component_id}"
         extra: dict[str, str] = {"Content-Type": "application/json"}
         if content_encoding:
             extra["Content-Encoding"] = content_encoding
+        params = {"bom_type": bom_type} if bom_type else None
         return self._request(
             "POST",
             path,
             data=sbom_payload,
+            params=params,
             extra_headers=extra,
             timeout=timeout,
         )

--- a/sbomify_action/upload.py
+++ b/sbomify_action/upload.py
@@ -73,6 +73,8 @@ def upload_sbom(
         component_version: Component version (for Dependency Track project)
         destination: Destination to upload to (default: "sbomify")
         validate_before_upload: Whether to validate SBOM before uploading
+        bom_type: Artifact type recorded on upload (sbom/vex/cbom/hbom). None
+            uploads a plain SBOM; non-SBOM types are sent verbatim.
 
     Returns:
         UploadResult with success status, sbom_id, and metadata
@@ -140,6 +142,8 @@ def upload_to_all(
         component_name: Component name (for Dependency Track)
         component_version: Component version (for Dependency Track)
         validate_before_upload: Whether to validate SBOM before uploading
+        bom_type: Artifact type recorded on upload (sbom/vex/cbom/hbom). None
+            uploads a plain SBOM; non-SBOM types are sent verbatim.
 
     Returns:
         List of UploadResult from each configured destination

--- a/sbomify_action/upload.py
+++ b/sbomify_action/upload.py
@@ -58,6 +58,7 @@ def upload_sbom(
     component_version: Optional[str] = None,
     destination: str = "sbomify",
     validate_before_upload: bool = True,
+    bom_type: Optional[str] = None,
 ) -> UploadResult:
     """
     Upload an SBOM to a specific destination.
@@ -97,6 +98,7 @@ def upload_sbom(
     input_params = UploadInput(
         sbom_file=sbom_file,
         sbom_format=sbom_format,  # type: ignore[arg-type]
+        bom_type=bom_type,
         component_name=component_name,
         component_version=component_version,
         validate_before_upload=validate_before_upload,
@@ -120,6 +122,7 @@ def upload_to_all(
     component_name: Optional[str] = None,
     component_version: Optional[str] = None,
     validate_before_upload: bool = True,
+    bom_type: Optional[str] = None,
 ) -> List[UploadResult]:
     """
     Upload an SBOM to all configured destinations.
@@ -157,6 +160,7 @@ def upload_to_all(
     input_params = UploadInput(
         sbom_file=sbom_file,
         sbom_format=sbom_format,  # type: ignore[arg-type]
+        bom_type=bom_type,
         component_name=component_name,
         component_version=component_version,
         validate_before_upload=validate_before_upload,

--- a/tests/test_cbom.py
+++ b/tests/test_cbom.py
@@ -1,0 +1,100 @@
+"""Tests for CBOM generation and SBOM<->CBOM cross-linking."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from sbomify_action.cbom import crosslink_sbom_and_cbom, generate_cbom
+from sbomify_action.exceptions import SBOMGenerationError
+
+# --- generate_cbom -----------------------------------------------------------
+
+
+def test_generate_cbom_builds_include_crypto_command(tmp_path: Path) -> None:
+    out = str(tmp_path / "cbom.json")
+    with patch("sbomify_action.cbom.run_command") as run, patch("pathlib.Path.exists", return_value=True):
+        result = generate_cbom(out, spec_version="1.7", cwd="/repo")
+    cmd = run.call_args.args[0]
+    assert cmd[0] == "cdxgen"
+    assert "--include-crypto" in cmd
+    assert cmd[cmd.index("--spec-version") + 1] == "1.7"
+    assert cmd[-1] == "."
+    assert run.call_args.kwargs["cwd"] == "/repo"
+    assert result == str(Path(out).resolve())
+
+
+def test_generate_cbom_returns_none_on_failure(tmp_path: Path) -> None:
+    with patch("sbomify_action.cbom.run_command", side_effect=SBOMGenerationError("boom")):
+        assert generate_cbom(str(tmp_path / "cbom.json")) is None
+
+
+def test_generate_cbom_returns_none_when_no_output(tmp_path: Path) -> None:
+    with patch("sbomify_action.cbom.run_command"), patch("pathlib.Path.exists", return_value=False):
+        assert generate_cbom(str(tmp_path / "cbom.json")) is None
+
+
+# --- crosslink_sbom_and_cbom -------------------------------------------------
+
+
+def _write(p: Path, doc: dict) -> str:
+    p.write_text(json.dumps(doc), encoding="utf-8")
+    return str(p)
+
+
+def _bom(serial: str | None = None) -> dict:
+    d: dict = {"bomFormat": "CycloneDX", "specVersion": "1.7", "version": 1}
+    if serial:
+        d["serialNumber"] = serial
+    return d
+
+
+def _bom_refs(path: str) -> list[dict]:
+    return [r for r in json.loads(Path(path).read_text())["externalReferences"] if r["type"] == "bom"]
+
+
+def test_crosslink_adds_bidirectional_bom_refs(tmp_path: Path) -> None:
+    sbom = _write(tmp_path / "sbom.json", _bom("urn:uuid:11111111-1111-1111-1111-111111111111"))
+    cbom = _write(tmp_path / "cbom.json", _bom("urn:uuid:22222222-2222-2222-2222-222222222222"))
+
+    crosslink_sbom_and_cbom(sbom, cbom)
+
+    sbom_ref = _bom_refs(sbom)[0]
+    cbom_ref = _bom_refs(cbom)[0]
+    assert sbom_ref["url"] == "urn:cdx:22222222-2222-2222-2222-222222222222/1"  # SBOM -> CBOM
+    assert cbom_ref["url"] == "urn:cdx:11111111-1111-1111-1111-111111111111/1"  # CBOM -> SBOM
+
+
+def test_crosslink_marks_cbom_incomplete(tmp_path: Path) -> None:
+    sbom = _write(tmp_path / "sbom.json", _bom("urn:uuid:11111111-1111-1111-1111-111111111111"))
+    cbom = _write(tmp_path / "cbom.json", _bom("urn:uuid:22222222-2222-2222-2222-222222222222"))
+
+    crosslink_sbom_and_cbom(sbom, cbom)
+
+    assert json.loads(Path(cbom).read_text())["compositions"] == [{"aggregate": "incomplete"}]
+
+
+def test_crosslink_assigns_serial_when_missing(tmp_path: Path) -> None:
+    sbom = _write(tmp_path / "sbom.json", _bom())  # no serialNumber
+    cbom = _write(tmp_path / "cbom.json", _bom())
+
+    crosslink_sbom_and_cbom(sbom, cbom)
+
+    sbom_doc = json.loads(Path(sbom).read_text())
+    assert sbom_doc["serialNumber"].startswith("urn:uuid:")
+    # the CBOM's back-reference points at the SBOM's freshly assigned serial
+    bare = sbom_doc["serialNumber"].rsplit(":", 1)[-1]
+    assert _bom_refs(cbom)[0]["url"] == f"urn:cdx:{bare}/1"
+
+
+def test_crosslink_is_idempotent(tmp_path: Path) -> None:
+    sbom = _write(tmp_path / "sbom.json", _bom("urn:uuid:11111111-1111-1111-1111-111111111111"))
+    cbom = _write(tmp_path / "cbom.json", _bom("urn:uuid:22222222-2222-2222-2222-222222222222"))
+
+    crosslink_sbom_and_cbom(sbom, cbom)
+    crosslink_sbom_and_cbom(sbom, cbom)
+
+    assert len(_bom_refs(sbom)) == 1
+    assert len(_bom_refs(cbom)) == 1
+    assert len(json.loads(Path(cbom).read_text())["compositions"]) == 1

--- a/tests/test_cbom.py
+++ b/tests/test_cbom.py
@@ -107,6 +107,20 @@ def test_crosslink_marks_incomplete_when_generator_set_other_compositions(tmp_pa
     assert len(incomplete) == 1
 
 
+def test_crosslink_survives_malformed_version(tmp_path: Path) -> None:
+    # A best-effort cross-link must not abort on a non-integer version field.
+    good = _bom("urn:uuid:11111111-1111-1111-1111-111111111111")
+    bad = _bom("urn:uuid:22222222-2222-2222-2222-222222222222")
+    bad["version"] = "not-a-number"
+    sbom = _write(tmp_path / "sbom.json", good)
+    cbom = _write(tmp_path / "cbom.json", bad)
+
+    crosslink_sbom_and_cbom(sbom, cbom)  # must not raise
+
+    assert json.loads(Path(cbom).read_text())["version"] == 1
+    assert _bom_refs(sbom)[0]["url"] == "urn:cdx:22222222-2222-2222-2222-222222222222/1"
+
+
 def test_crosslink_is_idempotent(tmp_path: Path) -> None:
     sbom = _write(tmp_path / "sbom.json", _bom("urn:uuid:11111111-1111-1111-1111-111111111111"))
     cbom = _write(tmp_path / "cbom.json", _bom("urn:uuid:22222222-2222-2222-2222-222222222222"))

--- a/tests/test_cbom.py
+++ b/tests/test_cbom.py
@@ -88,6 +88,25 @@ def test_crosslink_assigns_serial_when_missing(tmp_path: Path) -> None:
     assert _bom_refs(cbom)[0]["url"] == f"urn:cdx:{bare}/1"
 
 
+def test_crosslink_marks_incomplete_when_generator_set_other_compositions(tmp_path: Path) -> None:
+    # cdxgen could emit its own compositions without an incomplete marker; the
+    # safety marker must still be added, and the generator's entry preserved.
+    sbom = _write(tmp_path / "sbom.json", _bom("urn:uuid:11111111-1111-1111-1111-111111111111"))
+    cbom_doc = _bom("urn:uuid:22222222-2222-2222-2222-222222222222")
+    cbom_doc["compositions"] = [{"aggregate": "complete", "assemblies": ["ref-a"]}]
+    cbom = _write(tmp_path / "cbom.json", cbom_doc)
+
+    crosslink_sbom_and_cbom(sbom, cbom)
+
+    compositions = json.loads(Path(cbom).read_text())["compositions"]
+    assert {"aggregate": "complete", "assemblies": ["ref-a"]} in compositions
+    assert any(c.get("aggregate") == "incomplete" for c in compositions)
+    # idempotent: a second pass adds no duplicate incomplete entry
+    crosslink_sbom_and_cbom(sbom, cbom)
+    incomplete = [c for c in json.loads(Path(cbom).read_text())["compositions"] if c.get("aggregate") == "incomplete"]
+    assert len(incomplete) == 1
+
+
 def test_crosslink_is_idempotent(tmp_path: Path) -> None:
     sbom = _write(tmp_path / "sbom.json", _bom("urn:uuid:11111111-1111-1111-1111-111111111111"))
     cbom = _write(tmp_path / "cbom.json", _bom("urn:uuid:22222222-2222-2222-2222-222222222222"))

--- a/tests/test_cbom_pipeline.py
+++ b/tests/test_cbom_pipeline.py
@@ -1,0 +1,73 @@
+"""Tests for the CBOM pipeline glue in cli/main.py (generate+crosslink, upload)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from sbomify_action.cli.main import _generate_cbom_and_crosslink, _upload_cbom
+
+# String-target patches below resolve the module via importlib; we cannot bind the
+# module directly because cli/__init__.py re-exports the `main` function, shadowing
+# the `sbomify_action.cli.main` submodule attribute.
+MOD = "sbomify_action.cli.main"
+
+
+def _cfg(**kw):
+    base = dict(
+        lock_file=None,
+        spec_version=None,
+        component_version=None,
+        token="t",
+        component_id="c",
+        api_base_url="https://api.test",
+        component_name=None,
+        upload_destinations=["sbomify"],
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def test_generate_cbom_and_crosslink_wires_generate_and_link() -> None:
+    with (
+        patch(f"{MOD}.get_last_sbom_from_last_step", return_value="step_3.json"),
+        patch("sbomify_action.cbom.generate_cbom", return_value="/abs/cbom.json") as gen,
+        patch("sbomify_action.cbom.crosslink_sbom_and_cbom") as link,
+    ):
+        out = _generate_cbom_and_crosslink(_cfg())
+
+    assert out == "/abs/cbom.json"
+    gen.assert_called_once()
+    link.assert_called_once_with("step_3.json", "/abs/cbom.json")
+
+
+def test_generate_cbom_and_crosslink_none_when_generation_fails() -> None:
+    with (
+        patch(f"{MOD}.get_last_sbom_from_last_step", return_value="step_3.json"),
+        patch("sbomify_action.cbom.generate_cbom", return_value=None),
+        patch("sbomify_action.cbom.crosslink_sbom_and_cbom") as link,
+    ):
+        assert _generate_cbom_and_crosslink(_cfg()) is None
+        link.assert_not_called()
+
+
+def test_generate_cbom_and_crosslink_none_without_sbom() -> None:
+    with patch(f"{MOD}.get_last_sbom_from_last_step", return_value=None):
+        assert _generate_cbom_and_crosslink(_cfg()) is None
+
+
+def test_upload_cbom_uses_bom_type_cbom() -> None:
+    result = Mock(success=True, sbom_id="cbom-1")
+    with patch(f"{MOD}.upload_sbom", return_value=result) as up:
+        _upload_cbom(_cfg(), "/abs/cbom.json")
+
+    kwargs = up.call_args.kwargs
+    assert kwargs["bom_type"] == "cbom"
+    assert kwargs["sbom_file"] == "/abs/cbom.json"
+    assert kwargs["sbom_format"] == "cyclonedx"
+
+
+def test_upload_cbom_swallows_failure() -> None:
+    # A CBOM upload failure must not raise (never fails the SBOM run).
+    with patch(f"{MOD}.upload_sbom", side_effect=RuntimeError("boom")):
+        _upload_cbom(_cfg(), "/abs/cbom.json")  # no exception

--- a/tests/test_cbom_pipeline.py
+++ b/tests/test_cbom_pipeline.py
@@ -67,6 +67,15 @@ def test_upload_cbom_uses_bom_type_cbom() -> None:
     assert kwargs["sbom_format"] == "cyclonedx"
 
 
+def test_upload_cbom_skips_non_sbomify_destinations() -> None:
+    # CBOM classification is sbomify-specific; DT would ingest it as a plain SBOM.
+    result = Mock(success=True, sbom_id="cbom-1")
+    with patch(f"{MOD}.upload_sbom", return_value=result) as up:
+        _upload_cbom(_cfg(upload_destinations=["sbomify", "dependency-track"]), "/abs/cbom.json")
+    destinations = [c.kwargs["destination"] for c in up.call_args_list]
+    assert destinations == ["sbomify"]
+
+
 def test_upload_cbom_swallows_failure() -> None:
     # A CBOM upload failure must not raise (never fails the SBOM run).
     with patch(f"{MOD}.upload_sbom", side_effect=RuntimeError("boom")):

--- a/tests/test_cbom_pipeline.py
+++ b/tests/test_cbom_pipeline.py
@@ -71,3 +71,11 @@ def test_upload_cbom_swallows_failure() -> None:
     # A CBOM upload failure must not raise (never fails the SBOM run).
     with patch(f"{MOD}.upload_sbom", side_effect=RuntimeError("boom")):
         _upload_cbom(_cfg(), "/abs/cbom.json")  # no exception
+
+
+def test_upload_cbom_reports_step_failure_on_partial_failure() -> None:
+    # A failed destination is non-fatal but the step is reported as failed, not hidden.
+    failed = Mock(success=False, error_message="nope")
+    with patch(f"{MOD}.upload_sbom", return_value=failed), patch(f"{MOD}._log_step_end") as step_end:
+        _upload_cbom(_cfg(upload_destinations=["sbomify"]), "/abs/cbom.json")  # no raise
+    step_end.assert_called_with(5.5, success=False)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -898,9 +898,8 @@ class TestBuildConfig(unittest.TestCase):
             self.assertEqual(config.api_base_url, "https://custom.api.com")
             self.assertEqual(config.sbom_format, "spdx")
 
-    def test_build_config_non_sbom_bom_type_forces_verbatim(self):
-        """A non-SBOM bom_type (VEX/CBOM) disables augment/enrich so the
-        artifact is uploaded exactly as authored."""
+    def test_build_config_non_sbom_bom_type_disables_augment_enrich(self):
+        """A non-SBOM bom_type (VEX/CBOM) forces augment and enrich off."""
         from sbomify_action.cli.main import build_config
 
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -918,6 +918,19 @@ class TestBuildConfig(unittest.TestCase):
             self.assertFalse(config.augment)
             self.assertFalse(config.enrich)
 
+    def test_build_config_generate_cbom_flag(self):
+        """build_config carries the GENERATE_CBOM flag onto Config."""
+        from sbomify_action.cli.main import build_config
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            sbom_file = Path(tmp_dir) / "sbom.cdx.json"
+            sbom_file.write_text('{"bomFormat": "CycloneDX", "specVersion": "1.6"}')
+
+            on = build_config(sbom_file=str(sbom_file), upload=False, generate_cbom=True)
+            off = build_config(sbom_file=str(sbom_file), upload=False)
+            self.assertTrue(on.generate_cbom)
+            self.assertFalse(off.generate_cbom)
+
     def test_build_config_sbom_keeps_augment_enrich(self):
         """A plain SBOM upload still augments and enriches."""
         from sbomify_action.cli.main import build_config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -898,6 +898,44 @@ class TestBuildConfig(unittest.TestCase):
             self.assertEqual(config.api_base_url, "https://custom.api.com")
             self.assertEqual(config.sbom_format, "spdx")
 
+    def test_build_config_non_sbom_bom_type_forces_verbatim(self):
+        """A non-SBOM bom_type (VEX/CBOM) disables augment/enrich so the
+        artifact is uploaded exactly as authored."""
+        from sbomify_action.cli.main import build_config
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            vex_file = Path(tmp_dir) / "x.vex.cdx.json"
+            vex_file.write_text('{"bomFormat": "CycloneDX", "specVersion": "1.6"}')
+
+            config = build_config(
+                sbom_file=str(vex_file),
+                upload=False,
+                augment=True,
+                enrich=True,
+                bom_type="vex",
+            )
+            self.assertEqual(config.bom_type, "vex")
+            self.assertFalse(config.augment)
+            self.assertFalse(config.enrich)
+
+    def test_build_config_sbom_keeps_augment_enrich(self):
+        """A plain SBOM upload still augments and enriches."""
+        from sbomify_action.cli.main import build_config
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            sbom_file = Path(tmp_dir) / "sbom.cdx.json"
+            sbom_file.write_text('{"bomFormat": "CycloneDX", "specVersion": "1.6"}')
+
+            config = build_config(
+                sbom_file=str(sbom_file),
+                upload=False,
+                augment=True,
+                enrich=True,
+            )
+            self.assertTrue(config.augment)
+            self.assertTrue(config.enrich)
+            self.assertIsNone(config.bom_type)
+
     def test_build_config_defaults(self):
         """Test build_config uses correct defaults."""
         from sbomify_action.cli.main import SBOMIFY_PRODUCTION_API, build_config

--- a/tests/test_finalize_bom_type.py
+++ b/tests/test_finalize_bom_type.py
@@ -1,0 +1,34 @@
+"""Output finalization must leave non-SBOM artifacts (e.g. VEX) untouched."""
+
+from __future__ import annotations
+
+from sbomify_action.cli.main import _finalize_output_content
+
+CYCLONEDX = '{"bomFormat": "CycloneDX", "specVersion": "1.6", "components": []}'
+
+
+def test_sbom_gets_compositions_injected() -> None:
+    out = _finalize_output_content(CYCLONEDX, None)
+    assert '"compositions"' in out
+
+
+def test_explicit_sbom_bom_type_still_finalized() -> None:
+    out = _finalize_output_content(CYCLONEDX, "sbom")
+    assert '"compositions"' in out
+
+
+def test_vex_is_uploaded_verbatim() -> None:
+    # A VEX is an immutable security artifact: no composition injection, no
+    # PURL rewriting, byte-for-byte what was authored.
+    out = _finalize_output_content(CYCLONEDX, "vex")
+    assert out == CYCLONEDX
+
+
+def test_cbom_is_uploaded_verbatim() -> None:
+    out = _finalize_output_content(CYCLONEDX, "cbom")
+    assert out == CYCLONEDX
+
+
+def test_non_cyclonedx_passthrough() -> None:
+    spdx = '{"spdxVersion": "SPDX-2.3", "name": "x"}'
+    assert _finalize_output_content(spdx, None) == spdx

--- a/tests/test_finalize_bom_type.py
+++ b/tests/test_finalize_bom_type.py
@@ -1,4 +1,4 @@
-"""Output finalization must leave non-SBOM artifacts (e.g. VEX) untouched."""
+"""Output finalization skips its fixes for non-SBOM artifacts (e.g. VEX, CBOM)."""
 
 from __future__ import annotations
 
@@ -17,14 +17,14 @@ def test_explicit_sbom_bom_type_still_finalized() -> None:
     assert '"compositions"' in out
 
 
-def test_vex_is_uploaded_verbatim() -> None:
-    # A VEX is an immutable security artifact: no composition injection, no
-    # PURL rewriting, byte-for-byte what was authored.
+def test_vex_skips_finalization_fixes() -> None:
+    # Finalization adds no composition and does no PURL rewriting for a VEX, so
+    # this step returns the content unchanged (earlier pipeline steps are separate).
     out = _finalize_output_content(CYCLONEDX, "vex")
     assert out == CYCLONEDX
 
 
-def test_cbom_is_uploaded_verbatim() -> None:
+def test_cbom_skips_finalization_fixes() -> None:
     out = _finalize_output_content(CYCLONEDX, "cbom")
     assert out == CYCLONEDX
 

--- a/tests/test_sbomify_api.py
+++ b/tests/test_sbomify_api.py
@@ -503,6 +503,20 @@ def test_upload_sbom_does_not_raise_on_non_2xx() -> None:
     assert response.status_code == 409
 
 
+def test_upload_sbom_sends_bom_type_param() -> None:
+    client, session = _client_with([_FakeResponse(200, {"sbom_id": "s1"})])
+    client.upload_sbom("c1", b"{}", sbom_format="cyclonedx", bom_type="vex")
+    call = session.request.call_args
+    assert call.kwargs["params"] == {"bom_type": "vex"}
+
+
+def test_upload_sbom_omits_bom_type_param_by_default() -> None:
+    client, session = _client_with([_FakeResponse(200, {"sbom_id": "s1"})])
+    client.upload_sbom("c1", b"{}", sbom_format="cyclonedx")
+    call = session.request.call_args
+    assert call.kwargs["params"] is None
+
+
 # ----------------------------------------------------------------------
 # OIDC trusted publishing
 

--- a/tests/test_sbomify_api.py
+++ b/tests/test_sbomify_api.py
@@ -517,6 +517,13 @@ def test_upload_sbom_omits_bom_type_param_by_default() -> None:
     assert call.kwargs["params"] is None
 
 
+def test_upload_sbom_omits_bom_type_param_for_default_sbom() -> None:
+    client, session = _client_with([_FakeResponse(200, {"sbom_id": "s1"})])
+    client.upload_sbom("c1", b"{}", sbom_format="cyclonedx", bom_type="sbom")
+    call = session.request.call_args
+    assert call.kwargs["params"] is None
+
+
 # ----------------------------------------------------------------------
 # OIDC trusted publishing
 

--- a/tests/test_upload_module.py
+++ b/tests/test_upload_module.py
@@ -64,6 +64,22 @@ class TestUploadInput(unittest.TestCase):
             UploadInput(sbom_file="sbom.json", sbom_format="invalid")  # type: ignore
         self.assertIn("Invalid sbom_format", str(ctx.exception))
 
+    def test_bom_type_defaults_to_none(self):
+        """bom_type is optional and defaults to None (plain SBOM upload)."""
+        input = UploadInput(sbom_file="sbom.json", sbom_format="cyclonedx")
+        self.assertIsNone(input.bom_type)
+
+    def test_bom_type_accepted(self):
+        """A valid bom_type is stored."""
+        input = UploadInput(sbom_file="sbom.json", sbom_format="cyclonedx", bom_type="vex")
+        self.assertEqual(input.bom_type, "vex")
+
+    def test_invalid_bom_type_raises(self):
+        """An unknown bom_type is rejected before any upload is attempted."""
+        with self.assertRaises(ValueError) as ctx:
+            UploadInput(sbom_file="sbom.json", sbom_format="cyclonedx", bom_type="nope")
+        self.assertIn("Invalid bom_type", str(ctx.exception))
+
 
 class TestUploadResult(unittest.TestCase):
     """Tests for UploadResult dataclass."""
@@ -272,6 +288,35 @@ class TestSbomifyDestination(unittest.TestCase):
             call_kwargs = mock_client.upload_sbom.call_args.kwargs
             self.assertEqual(call_kwargs["component_id"], "my-component")
             self.assertEqual(call_kwargs["sbom_format"], "cyclonedx")
+            # No bom_type by default → plain SBOM upload.
+            self.assertIsNone(call_kwargs.get("bom_type"))
+        finally:
+            Path(sbom_file).unlink()
+
+    @patch("sbomify_action._upload.destinations.sbomify.SbomifyApiClient")
+    def test_upload_threads_bom_type(self, mock_client_cls):
+        """bom_type from the input reaches the API client (e.g. for VEX)."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"bomFormat": "CycloneDX", "specVersion": "1.6"}, f)
+            sbom_file = f.name
+
+        try:
+            mock_response = Mock()
+            mock_response.ok = True
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"sbom_id": "vex-1"}
+            mock_response.headers = {}
+            mock_client = Mock()
+            mock_client.upload_sbom.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            dest = SbomifyDestination(token="test-token", component_id="my-component")
+            input = UploadInput(sbom_file=sbom_file, sbom_format="cyclonedx", bom_type="vex")
+
+            result = dest.upload(input)
+
+            self.assertTrue(result.success)
+            self.assertEqual(mock_client.upload_sbom.call_args.kwargs["bom_type"], "vex")
         finally:
             Path(sbom_file).unlink()
 


### PR DESCRIPTION
## What

Generate a CBOM (Cryptography Bill of Materials) in CI and cross-link it with the SBOM.

**Stacked on #255** (the BOM_TYPE upload plumbing). The bottom three commits are #255; review and merge that first. They drop out of this diff once it lands, leaving this PR's own change (the top commit).

## How it works

`GENERATE_CBOM=true` (or `--generate-cbom` / the `generate-cbom` action input) runs `cdxgen --include-crypto` after the SBOM is built, then uploads the result as a second `bom_type=cbom` artifact, cross-linked with the SBOM.

- Generation (`sbomify_action/cbom.py`): `generate_cbom` shells `cdxgen --include-crypto` (CycloneDX 1.7 by default) via the existing `run_command`. Best-effort: a CBOM failure logs and never fails the SBOM run.
- Cross-referencing: `crosslink_sbom_and_cbom` adds a CycloneDX `externalReferences` entry of type `bom` with a BOM-Link URN (`urn:cdx:<serialNumber>/<version>`) to each document, so a consumer holding one can discover the other. The CBOM is marked `compositions: aggregate=incomplete`.
- Pipeline: a new Step 3.6 generates + cross-links before finalize (so the SBOM carries the reference and the temp files survive cleanup); the CBOM uploads after the SBOM through the `bom_type=cbom` path from #255. Gated to SBOM uploads; ignored when uploading a VEX/HBOM.

## Coverage

cdxgen `--include-crypto` detects crypto from Java keystores/certificates and JS/TS source call sites only. Binary-embedded, dynamically dispatched, and framework/stdlib crypto (TLS, etc.) are missed, hence `aggregate=incomplete`. Binary/container crypto (cbomkit-theia) and signed/attested CBOMs are deliberate deferrals.

## Tests

`tests/test_cbom.py` (generation command, bidirectional cross-link, incomplete marker, idempotence) and `tests/test_cbom_pipeline.py` (pipeline glue + `bom_type=cbom` upload). Full suite green; ruff and `uv run mypy` clean.