### PR TITLE
fix(wizard): skip AI agent worktree dirs during lockfile discovery

### DIFF
--- a/sbomify_action/cli/wizard/discovery.py
+++ b/sbomify_action/cli/wizard/discovery.py
@@ -42,6 +42,19 @@ _SKIP_DIRS = frozenset(
         ".ruff_cache",
         ".idea",
         ".vscode",
+        # AI coding-agent config dirs. Claude Code keeps agent worktrees
+        # (full repo copies) at .claude/worktrees/, so recursing would
+        # double-count every lockfile in the repo. The others hold only
+        # tool config today, but skipping them is harmless and guards
+        # against the same worktree pattern landing there.
+        ".claude",
+        ".cursor",
+        ".codex",
+        ".gemini",
+        # Common in-repo worktree conventions used by parallel-agent
+        # orchestrators (ccmanager, agent-deck, ...) and humans alike.
+        ".worktrees",
+        ".trees",
     }
 )
 

--- a/tests/test_wizard_discovery.py
+++ b/tests/test_wizard_discovery.py
@@ -61,6 +61,19 @@ def test_discover_skips_node_modules_and_dotgit(tmp_path: Path) -> None:
     assert [str(lf.rel_path) for lf in found] == ["package.json"]
 
 
+def test_discover_skips_agent_worktree_dirs(tmp_path: Path) -> None:
+    # Claude Code keeps full repo copies under .claude/worktrees/ — those
+    # lockfiles are duplicates of the real ones and must not be discovered.
+    for agent_dir in (".claude", ".cursor", ".codex", ".gemini", ".worktrees", ".trees"):
+        nested = tmp_path / agent_dir / "worktrees" / "some-branch"
+        nested.mkdir(parents=True)
+        (nested / "uv.lock").write_text("")
+    (tmp_path / "uv.lock").write_text("")
+
+    found = discover(tmp_path)
+    assert [str(lf.rel_path) for lf in found] == ["uv.lock"]
+
+
 def test_discover_suggested_name_includes_repo_and_ecosystem(tmp_path: Path) -> None:
     (tmp_path / "uv.lock").write_text("")
     found = discover(tmp_path, repo_name="My Widget!")


### PR DESCRIPTION
## Summary

The wizard's lockfile discovery walk recursed into `.claude/worktrees/`, where Claude Code keeps full repo copies as git worktrees — so every lockfile in the repo was discovered twice (or more, with multiple worktrees).

This adds the following names to the discovery skip list (`_SKIP_DIRS`, matched at any depth):

- `.claude` — Claude Code config; covers `.claude/worktrees/` in-repo agent worktrees
- `.cursor`, `.codex`, `.gemini` — Cursor / OpenAI Codex / Gemini CLI project config dirs (their worktrees default to the home directory today, but skipping is harmless and future-proofs against in-repo layouts)
- `.worktrees`, `.trees` — common in-repo worktree conventions used by parallel-agent orchestrators (ccmanager, agent-deck) and manual worktree workflows

A bare non-hidden `worktrees/` name is deliberately **not** skipped, since it could plausibly be real source.

Wizard discovery is the only repo-wide walker — the main pipeline takes explicit lockfile paths — so no other code needs the exclusion.

## Test plan

- New `test_discover_skips_agent_worktree_dirs` covering all six new names
- `uv run pytest tests/test_wizard_discovery.py` — 40 passed
- ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)