### PR TITLE
fix: make partial release failures fatal

### DIFF
--- a/sbomify_action/_processors/processors/releases.py
+++ b/sbomify_action/_processors/processors/releases.py
@@ -113,7 +113,11 @@ class SbomifyReleasesProcessor:
                 errors.append(f"Error processing {release_spec}: {str(e)}")
                 logger.error(f"Error processing release {release_spec}: {e}")
 
-        if failed > 0 and processed == 0:
+        # Any failed release is fatal, including partial success (some
+        # succeeded, some failed) — a silently missing release must fail the run.
+        if failed > 0:
+            if processed > 0:
+                logger.warning(f"Partial failure: {processed} release(s) processed, {failed} failed")
             return ProcessorResult.failure_result(
                 processor_name=self.name,
                 error_message="; ".join(errors),
@@ -122,19 +126,10 @@ class SbomifyReleasesProcessor:
                 metadata={"release_ids": release_ids},
             )
 
-        # Log warning for partial success (some succeeded, some failed)
-        if failed > 0 and processed > 0:
-            logger.warning(
-                f"Partial success: {processed} release(s) processed, {failed} failed. Errors: {'; '.join(errors)}"
-            )
-
         return ProcessorResult.success_result(
             processor_name=self.name,
             processed_items=processed,
-            metadata={
-                "release_ids": release_ids,
-                "errors": errors if errors else None,
-            },
+            metadata={"release_ids": release_ids},
         )
 
     def _process_single_release(

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -41,6 +41,21 @@ class TestFinalizePostUpload(unittest.TestCase):
         results = AggregateResult(results=[ProcessorResult.skipped_result("sbomify_releases")])
         _finalize_post_upload(results)  # skipped is not a failure
 
+    def test_partial_failure_exits_nonzero(self):
+        results = AggregateResult(
+            results=[
+                ProcessorResult.failure_result(
+                    "sbomify_releases",
+                    "Error processing product:v1.0.0: [403] - Only owners and admins can create releases",
+                    processed_items=1,
+                    failed_items=1,
+                )
+            ]
+        )
+        with self.assertRaises(SystemExit) as ctx:
+            _finalize_post_upload(results)
+        self.assertEqual(ctx.exception.code, 1)
+
 
 class TestProcessorInput(unittest.TestCase):
     """Test ProcessorInput dataclass."""
@@ -506,6 +521,34 @@ class TestSbomifyReleasesProcessor(unittest.TestCase):
 
         self.assertFalse(result.success)
         self.assertIn("API connection failed", result.error_message)
+
+    @patch("sbomify_action._processors.releases_api._client")
+    def test_process_partial_failure_is_failure(self, mock_client_factory):
+        """One release succeeding must not mask another one failing."""
+        client = Mock()
+        client.check_release_exists.return_value = False
+        client.create_release.side_effect = [
+            "new-release-id",
+            APIError("[403] - Only owners and admins can create releases"),
+        ]
+        client.tag_sbom_with_release.return_value = None
+        client.get_release_details.return_value = None
+        mock_client_factory.return_value = client
+
+        input_obj = ProcessorInput(
+            sbom_id="sbom-123",
+            product_releases=["product-a:v1.0.0", "product-b:v1.0.0"],
+            api_base_url="https://api.test.com",
+            token="test-token",
+        )
+
+        result = self.processor.process(input_obj)
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.processed_items, 1)
+        self.assertEqual(result.failed_items, 1)
+        self.assertIn("Only owners and admins", result.error_message)
+        self.assertIn("new-release-id", result.metadata["release_ids"])
 
 
 class TestProcessorOrchestrator(unittest.TestCase):


### PR DESCRIPTION
## Summary

Follow-up to #261 / #260. That fix made post-upload processor failures fatal, but a **partial** failure — some releases tagged, others failing (e.g. a 403 on one product) — still returned a `success_result` and the job went green.

Now any `failed > 0` in the releases processor returns a `failure_result` (keeping the processed/failed counts, joined errors, and the release IDs that did succeed), so `_finalize_post_upload` exits non-zero. A warning still logs how many releases succeeded before the failure.

Side effect: the success-path metadata no longer includes the `"errors"` key — it could only ever be non-empty when something failed, which is now always a failure result. Nothing consumed it.

## Tests

- `test_process_partial_failure_is_failure`: two releases, second create raises a 403 → result is a failure with `processed_items=1, failed_items=1`.
- `test_partial_failure_exits_nonzero`: `_finalize_post_upload` raises `SystemExit(1)` for a partial-failure result.

Full suite: 2415 passed, 4 skipped. Lint and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)