### PR TITLE
ci: build Docker images natively per-arch via matrix

### DIFF
--- a/.github/workflows/sbomify.yaml
+++ b/.github/workflows/sbomify.yaml
@@ -1045,20 +1045,18 @@ jobs:
             augmented-sbom.spdx.json
           retention-days: 7
 
-  push-images:
-    name: Push Docker Images
+  docker-meta:
+    name: Docker Build Metadata
     runs-on: ubuntu-latest
-    needs:
-      - sanity-checks
-      - integration-tests
-      - container-tests
-      - license-db-integration-test
-      - cle-integration-test
-      - augmentation-integration-test
     if: github.event_name == 'push'
     permissions:
-      packages: write
       contents: read
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      image_tag: ${{ steps.meta.outputs.image_tag }}
+      ghcr_repo: ${{ steps.meta.outputs.ghcr_repo }}
+      dockerhub_repo: ${{ steps.meta.outputs.dockerhub_repo }}
+      build_date: ${{ steps.meta.outputs.build_date }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -1097,8 +1095,32 @@ jobs:
             echo "build_date=${BUILD_DATE}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+  build-images:
+    name: Build Docker Image (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    needs:
+      - sanity-checks
+      - integration-tests
+      - container-tests
+      - license-db-integration-test
+      - cle-integration-test
+      - augmentation-integration-test
+      - docker-meta
+    if: github.event_name == 'push'
+    permissions:
+      packages: write
+      contents: read
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            slug: linux-amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            slug: linux-arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -1116,36 +1138,108 @@ jobs:
           username: sbomifyhub
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push multi-arch image
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
+          platforms: ${{ matrix.platform }}
           provenance: false
-          tags: |
-            ${{ steps.meta.outputs.ghcr_repo }}:${{ steps.meta.outputs.image_tag }}
-            ${{ steps.meta.outputs.dockerhub_repo }}:${{ steps.meta.outputs.image_tag }}
           labels: |
             runnumber=${{ github.run_id }}
           build-args: |
-            VERSION=${{ steps.meta.outputs.version }}
+            VERSION=${{ needs.docker-meta.outputs.version }}
             COMMIT_SHA=${{ github.sha }}
-            BUILD_DATE=${{ steps.meta.outputs.build_date }}
+            BUILD_DATE=${{ needs.docker-meta.outputs.build_date }}
             VCS_REF=${{ github.ref_name }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          outputs: type=image,"name=${{ needs.docker-meta.outputs.ghcr_repo }},${{ needs.docker-meta.outputs.dockerhub_repo }}",push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=build-${{ matrix.slug }}
+          cache-to: type=gha,mode=max,scope=build-${{ matrix.slug }}
+
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          touch "${{ runner.temp }}/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-${{ matrix.slug }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 7
+
+  push-images:
+    name: Push Docker Images
+    runs-on: ubuntu-latest
+    needs:
+      - docker-meta
+      - build-images
+    if: github.event_name == 'push'
+    permissions:
+      packages: write
+      contents: read
+    env:
+      GHCR_REPO: ${{ needs.docker-meta.outputs.ghcr_repo }}
+      DOCKERHUB_REPO: ${{ needs.docker-meta.outputs.dockerhub_repo }}
+      IMAGE_TAG: ${{ needs.docker-meta.outputs.image_tag }}
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          username: sbomifyhub
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifests
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          shopt -s nullglob
+          digests=(*)
+          if [ "${#digests[@]}" -eq 0 ]; then
+            echo "::error::No digest files found. The digests-* artifacts may have expired" \
+              "(retention is 7 days) — re-run all jobs, not just this one."
+            exit 1
+          fi
+          echo "Found ${#digests[@]} digest(s): ${digests[*]}"
+          docker buildx imagetools create -t "${GHCR_REPO}:${IMAGE_TAG}" \
+            $(printf -- "${GHCR_REPO}@sha256:%s " "${digests[@]}")
+          docker buildx imagetools create -t "${DOCKERHUB_REPO}:${IMAGE_TAG}" \
+            $(printf -- "${DOCKERHUB_REPO}@sha256:%s " "${digests[@]}")
+
+      - name: Inspect manifests
+        run: |
+          docker buildx imagetools inspect "${GHCR_REPO}:${IMAGE_TAG}"
+          docker buildx imagetools inspect "${DOCKERHUB_REPO}:${IMAGE_TAG}"
 
       - name: Image summary
-        env:
-          GHCR_REF: ${{ steps.meta.outputs.ghcr_repo }}:${{ steps.meta.outputs.image_tag }}
-          DOCKERHUB_REF: ${{ steps.meta.outputs.dockerhub_repo }}:${{ steps.meta.outputs.image_tag }}
         run: |
+          PLATFORMS=$(docker buildx imagetools inspect "${GHCR_REPO}:${IMAGE_TAG}" \
+            --format '{{range .Manifest.Manifests}}{{.Platform.OS}}/{{.Platform.Architecture}} {{end}}')
           {
             echo '```'
-            echo "Primary:   ${GHCR_REF}"
-            echo "Mirror:    ${DOCKERHUB_REF}"
-            echo "Platforms: linux/amd64, linux/arm64"
+            echo "Primary:   ${GHCR_REPO}:${IMAGE_TAG}"
+            echo "Mirror:    ${DOCKERHUB_REPO}:${IMAGE_TAG}"
+            echo "Platforms: ${PLATFORMS}"
             echo '```'
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ additional_packages.txt
 node_modules
 sbomify.json
 sbomify.json.bak
+.claude


### PR DESCRIPTION
## Summary

The **Push Docker Images** job built `linux/amd64,linux/arm64` in a single job on an amd64 runner, so the arm64 half ran under QEMU emulation (typically 5–10x slower than native) and serialized with the amd64 build. Since this repo is public, GitHub's free native arm64 runners (`ubuntu-24.04-arm`) are available, so this PR splits the build into the standard digest-based matrix pattern:

- **`docker-meta`** — computes version/tag/repo metadata once; runs in parallel with the test jobs, adding no wall-clock time.
- **`build-images`** — a two-leg matrix (`linux/amd64` on `ubuntu-latest`, `linux/arm64` on `ubuntu-24.04-arm`). Each leg builds natively, pushes by digest to both GHCR and Docker Hub, and uploads its digest as an artifact. Same gating as before: all six test jobs must pass, `push` events only. Build caches are now scoped per platform.
- **`push-images`** — downloads the digests and creates the multi-arch manifest lists with `docker buildx imagetools create`, so the final tags (`latest`/version) only appear once both arches succeeded.

Behavior preserved: `provenance: false`, same tags/labels/build-args. `BUILD_DATE` is now computed once, so both arch images carry identical metadata. Also adds `.claude` to `.gitignore`.

## Robustness (from code review)

- Digest artifacts use `overwrite: true` and 7-day retention so same-run re-runs work.
- The manifest step fails with an explicit error (instead of a cryptic `@sha256:*` reference error) if digest artifacts are missing/expired.
- The run-summary platform list is derived from the pushed manifest instead of being hardcoded.

## Accepted trade-offs

- The arm64 leg depends on the `ubuntu-24.04-arm` hosted runner label (free for public repos). If the repo ever goes private on a plan without arm runners, this needs revisiting.
- GHCR and Docker Hub manifests are pushed sequentially, so a mid-step failure can leave the mirror one release behind the primary — same exposure as the previous single `build-push-action` step, and the failure is fatal and visible per #272.

## Expected impact

Job wall-clock drops from amd64 + emulated arm64 to roughly max(native amd64, native arm64) — typically minutes instead of tens of minutes. First run after merge starts with cold per-platform caches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)