### PR TITLE
fix(wizard): use full relative path to disambiguate suggested component names

### DIFF
--- a/sbomify_action/cli/wizard/discovery.py
+++ b/sbomify_action/cli/wizard/discovery.py
@@ -179,12 +179,14 @@ def discover(repo_root: Path, *, repo_name: str | None = None) -> list[Discovere
 
     # Same ecosystem in several directories (eg. ``bun.lock`` +
     # ``website/bun.lock``) collides on the plain ``<repo>-<ecosystem>``
-    # suggestion — qualify the colliding ones with their directory.
+    # suggestion — qualify the colliding ones with their full relative
+    # directory path (not just the basename, which itself collides for
+    # eg. ``apps/web`` + ``packages/web``; slugify turns ``/`` into ``-``).
     name_counts = Counter(lf.suggested_name for lf in found)
     found = [
         replace(
             lf,
-            suggested_name=_suggested_name(repo_name, lf.rel_path.name, dir_name=lf.rel_path.parent.name),
+            suggested_name=_suggested_name(repo_name, lf.rel_path.name, dir_name=str(lf.rel_path.parent)),
         )
         if name_counts[lf.suggested_name] > 1 and lf.rel_path.parent != Path(".")
         else lf

--- a/tests/test_wizard_discovery.py
+++ b/tests/test_wizard_discovery.py
@@ -74,6 +74,21 @@ def test_discover_disambiguates_colliding_suggested_names(tmp_path: Path) -> Non
     }
 
 
+def test_discover_disambiguates_with_full_relative_path(tmp_path: Path) -> None:
+    # Two nested dirs sharing a basename (apps/web + packages/web) must not
+    # collide — the full relative path goes into the suggestion.
+    for parent in ("apps", "packages"):
+        (tmp_path / parent / "web").mkdir(parents=True)
+        (tmp_path / parent / "web" / "bun.lock").write_text("")
+
+    found = discover(tmp_path, repo_name="anthias")
+    names = {str(lf.rel_path): lf.suggested_name for lf in found}
+    assert names == {
+        os.path.join("apps", "web", "bun.lock"): "anthias-apps-web-javascript",
+        os.path.join("packages", "web", "bun.lock"): "anthias-packages-web-javascript",
+    }
+
+
 def test_discover_recurses_into_subdirs(tmp_path: Path) -> None:
     (tmp_path / "backend").mkdir()
     (tmp_path / "backend" / "uv.lock").write_text("")


### PR DESCRIPTION
## Problem

Follow-up to #277, which was merged before its Copilot review round landed. Copilot [flagged](https://github.com/sbomify/sbomify-action/pull/277#discussion_r3595794295) that the suggested-name collision disambiguation used only the immediate directory basename, so nested directories sharing a basename (`apps/web/bun.lock` + `packages/web/bun.lock`) would still both suggest `<repo>-web-javascript`.

## Fix

Qualify colliding suggestions with the full relative parent path instead of the basename — `slugify` normalizes the path separators, yielding `anthias-apps-web-javascript` vs `anthias-packages-web-javascript`. Root-level entries still keep the plain `<repo>-<ecosystem>` name.

## Testing

- New regression test for the shared-basename collision case
- Wizard discovery suite passes; ruff check/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)