### PR TITLE
fix(wizard): sort product and component pickers alphabetically

### DIFF
--- a/sbomify_action/cli/wizard/screens/components.py
+++ b/sbomify_action/cli/wizard/screens/components.py
@@ -38,6 +38,12 @@ class ComponentsScreen(WizardScreen):
         from rich.markup import escape as _esc
 
         existing = self.wizard.state.workspace.components if self.wizard.state.workspace else []
+        # The API returns components in no particular order — sort by
+        # name (case-insensitive) so the picker reads alphabetically.
+        existing = sorted(
+            existing,
+            key=lambda c: str(c.get("name") or c.get("id") or "(unnamed)").casefold(),
+        )
         # Escape API-supplied names before passing them as picker
         # labels — PickOrCreate's OptionList renders labels as Rich
         # markup, so a component literally named "widget [pre-release]"

--- a/sbomify_action/cli/wizard/screens/components.py
+++ b/sbomify_action/cli/wizard/screens/components.py
@@ -42,7 +42,10 @@ class ComponentsScreen(WizardScreen):
         # name (case-insensitive) so the picker reads alphabetically.
         existing = sorted(
             existing,
-            key=lambda c: str(c.get("name") or c.get("id") or "(unnamed)").casefold(),
+            key=lambda c: (
+                str(c.get("name") or c.get("id") or "(unnamed)").casefold(),
+                str(c.get("id") or ""),
+            ),
         )
         # Escape API-supplied names before passing them as picker
         # labels — PickOrCreate's OptionList renders labels as Rich

--- a/sbomify_action/cli/wizard/screens/product.py
+++ b/sbomify_action/cli/wizard/screens/product.py
@@ -28,6 +28,14 @@ class ProductScreen(WizardScreen):
         from rich.markup import escape as _esc
 
         products = self.wizard.state.workspace.products if self.wizard.state.workspace else []
+        # The API returns products in no particular order — sort by name
+        # (case-insensitive) so the picker reads alphabetically. Sorting
+        # before the pre-select below keeps the pre-selected product the
+        # first visible row.
+        products = sorted(
+            products,
+            key=lambda p: str(p.get("name") or p.get("id") or "(unnamed)").casefold(),
+        )
         panel = Vertical(classes="wizard-panel")
         panel.border_title = "◆  Pick a product"
         panel.border_subtitle = f"{len(products)} existing"

--- a/sbomify_action/cli/wizard/screens/product.py
+++ b/sbomify_action/cli/wizard/screens/product.py
@@ -34,7 +34,10 @@ class ProductScreen(WizardScreen):
         # first visible row.
         products = sorted(
             products,
-            key=lambda p: str(p.get("name") or p.get("id") or "(unnamed)").casefold(),
+            key=lambda p: (
+                str(p.get("name") or p.get("id") or "(unnamed)").casefold(),
+                str(p.get("id") or ""),
+            ),
         )
         panel = Vertical(classes="wizard-panel")
         panel.border_title = "◆  Pick a product"

--- a/tests/test_wizard_textual.py
+++ b/tests/test_wizard_textual.py
@@ -379,6 +379,95 @@ async def test_escape_from_components_goes_back_in_any_focus_state(
         assert isinstance(app.screen, ProductScreen), "Escape on Input must pop to Product"
 
 
+async def test_components_picker_lists_existing_alphabetically(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Existing components render alphabetically (case-insensitive) in the
+    picker regardless of the order the API returned them in."""
+    from textual.widgets import OptionList
+
+    lockfiles = [
+        DiscoveredLockfile(
+            path=tmp_path / "uv.lock",
+            rel_path=Path("uv.lock"),
+            ecosystem="python",
+            suggested_name="widget-py",
+        )
+    ]
+    _stub_discovery(monkeypatch, lockfiles)
+    _stub_client(
+        monkeypatch,
+        products=[{"id": "p1", "name": "alpha"}],
+        components=[
+            {"id": "c-zeta", "name": "zeta"},
+            {"id": "c-alpha", "name": "Alpha"},
+            {"id": "c-mid", "name": "midway"},
+        ],
+    )
+
+    app = WizardApp(_opts(tmp_path))
+    async with app.run_test() as pilot:
+        await pilot.press("enter")  # Welcome -> Discover
+        await pilot.pause()
+        await pilot.press("space")  # select lockfile
+        await pilot.pause()
+        await pilot.press("enter")  # Discover -> Authenticate (auto-auth)
+        await pilot.pause(1.0)  # wait for auth + auto-push to Product
+        await pilot.press("enter")  # Product -> Components
+        await pilot.pause()
+
+        from sbomify_action.cli.wizard.screens.components import ComponentsScreen
+        from sbomify_action.cli.wizard.widgets import NEW_SENTINEL
+
+        assert isinstance(app.screen, ComponentsScreen)
+        picker = app.screen.query_one("#component-0-list", OptionList)
+        option_ids = [picker.get_option_at_index(i).id for i in range(picker.option_count)]
+        assert option_ids == [NEW_SENTINEL, "c-alpha", "c-mid", "c-zeta"]
+
+
+async def test_product_picker_lists_existing_alphabetically(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Existing products render alphabetically (case-insensitive) in the
+    picker regardless of the order the API returned them in, and the
+    pre-selected product is the first visible row."""
+    from textual.widgets import OptionList
+
+    lockfiles = [
+        DiscoveredLockfile(
+            path=tmp_path / "uv.lock",
+            rel_path=Path("uv.lock"),
+            ecosystem="python",
+            suggested_name="widget-py",
+        )
+    ]
+    _stub_discovery(monkeypatch, lockfiles)
+    _stub_client(
+        monkeypatch,
+        products=[
+            {"id": "p-zeta", "name": "zeta"},
+            {"id": "p-alpha", "name": "Alpha"},
+            {"id": "p-mid", "name": "midway"},
+        ],
+    )
+
+    app = WizardApp(_opts(tmp_path))
+    async with app.run_test() as pilot:
+        await pilot.press("enter")  # Welcome -> Discover
+        await pilot.pause()
+        await pilot.press("space")  # select lockfile
+        await pilot.pause()
+        await pilot.press("enter")  # Discover -> Authenticate (auto-auth)
+        await pilot.pause(1.0)  # wait for auth + auto-push to Product
+
+        from sbomify_action.cli.wizard.screens.product import ProductScreen
+        from sbomify_action.cli.wizard.widgets import NEW_SENTINEL, PickOrCreate
+
+        assert isinstance(app.screen, ProductScreen)
+        picker = app.screen.query_one("#product-picker-list", OptionList)
+        option_ids = [picker.get_option_at_index(i).id for i in range(picker.option_count)]
+        assert option_ids == [NEW_SENTINEL, "p-alpha", "p-mid", "p-zeta"]
+        # Pre-selection tracks the sorted order: the alphabetically first
+        # product, not whichever the API happened to return first.
+        assert app.screen.query_one("#product-picker", PickOrCreate).picked_id == "p-alpha"
+
+
 async def test_enter_on_create_profile_sentinel_pushes_create_screen(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

The sbomify API returns products and components in no particular order, and the wizard's Product and Components screens passed them straight into their `PickOrCreate` pickers, so the lists rendered in arbitrary order.

- Sort both lists by name (case-insensitive, falling back to id for unnamed entries) before building the picker entries. Sorting happens on the raw names, not the markup-escaped labels, so escaping stays a pure rendering concern.
- On the Product screen the sort runs before the first-row pre-select, so the pre-selected product is now the alphabetically first one — matching the first visible row — rather than whichever the API happened to return first.
- The "➕ Create new" sentinel row stays pinned at the top of both pickers.

## Testing

- Added `test_components_picker_lists_existing_alphabetically` and `test_product_picker_lists_existing_alphabetically`, which walk the wizard to each screen with API results stubbed in `zeta, Alpha, midway` order and assert the picker rows come out alphabetical (mixed case verifies the sort is case-insensitive); the product test also asserts the pre-selection lands on the first sorted entry.
- `uv run pytest tests/test_wizard_textual.py` — 11 passed; ruff lint and format checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)