### PR TITLE
fix(wizard): default augmentation to the recommended contact-profile option

### DIFF
--- a/sbomify_action/cli/wizard/screens/configure_sbom.py
+++ b/sbomify_action/cli/wizard/screens/configure_sbom.py
@@ -53,6 +53,12 @@ class ConfigureSbomScreen(WizardScreen):
         # breaking the Enter→Escape→Enter loop documented in the
         # earlier code review.
         self._json_form_visited = False
+        # Same idea for CreateProfileScreen: with "profile" as the
+        # default augmentation strategy, a zero-profile workspace can
+        # reach an Enter→Escape→Enter loop through the "+ Create new"
+        # sentinel. on_screen_resume reads this to detect the cancel
+        # and route the user out of the loop.
+        self._create_profile_visited = False
 
     def compose_body(self) -> ComposeResult:
         enrich = Vertical(classes="wizard-panel")
@@ -98,21 +104,30 @@ class ConfigureSbomScreen(WizardScreen):
                 "produces.[/]",
                 classes="wizard-help",
             )
+            # Recommended option first + default-pressed, matching every
+            # other radio group on this screen — RadioSet also parks its
+            # keyboard cursor on the first button at mount, so recommended-
+            # first keeps cursor and pressed state on the same row.
             with RadioSet(id="augmentation"):
-                yield StatefulRadioButton("Skip — leave metadata blank for now", id="aug-skip", value=True)
                 yield StatefulRadioButton(
                     "Use a contact profile (saved to sbomify)  [#86EFAC]✓ recommended[/]",
                     id="aug-profile",
+                    value=True,
                 )
                 yield StatefulRadioButton(
                     "Write a sbomify.json file (saved to the repo)",
                     id="aug-json_config",
                 )
+                yield StatefulRadioButton("Skip — leave metadata blank for now", id="aug-skip")
             picker = OptionList(
                 *self._picker_options(),
                 id="profile-picker",
             )
-            picker.display = False
+            # Visible from the start because "profile" is the initial
+            # selection — the constructor-set radio value suppresses
+            # RadioSet.Changed (Textual's ToggleButton contract), so
+            # on_radio_set_changed can't do this reveal for us.
+            picker.display = True
             yield picker
             help_text = Static(
                 "[#5E5E5E]Same profile binds to every component; re-run the wizard to change it. "
@@ -120,7 +135,7 @@ class ConfigureSbomScreen(WizardScreen):
                 id="profile-help",
                 markup=True,
             )
-            help_text.display = False
+            help_text.display = True
             yield help_text
             # Status / "Edit fields…" affordance shown only when the
             # user has selected the json_config radio. Tells them
@@ -222,6 +237,12 @@ class ConfigureSbomScreen(WizardScreen):
 
     def on_mount(self) -> None:
         self.query_one("#enrich", RadioSet).focus()
+        # Seed the picker highlight for the default "profile" strategy —
+        # on_radio_set_changed never fires for a constructor-set radio
+        # value, so its default-highlight logic doesn't run at mount.
+        # First REAL profile when one exists; with zero profiles index 0
+        # is the "+ Create new" sentinel, the bootstrap path.
+        self.query_one("#profile-picker", OptionList).highlighted = 1 if self._profiles else 0
 
     def on_screen_resume(self) -> None:
         """Called when the screen becomes active again after a sub-screen
@@ -230,7 +251,10 @@ class ConfigureSbomScreen(WizardScreen):
         auto-select it via the id CreateProfileScreen stashed on the
         plan. If ConfigureSbomifyJsonScreen was pushed and the user
         cancelled (no data on the plan), flip the augmentation back
-        to Skip so the user isn't trapped in a re-push loop.
+        to Skip so the user isn't trapped in a re-push loop. A
+        cancelled CreateProfileScreen gets the same treatment: move
+        the highlight off the "+ Create new" sentinel (or revert to
+        Skip when the workspace has zero profiles to fall back on).
         """
         workspace = self.wizard.state.workspace
         if workspace is None:
@@ -264,6 +288,7 @@ class ConfigureSbomScreen(WizardScreen):
             # Auto-select the freshly-created profile if CreateProfile
             # stashed its id; flip the augmentation radio so the user
             # sees the success directly.
+            self._create_profile_visited = False
             for idx, opt in enumerate(self._picker_options()):
                 if opt.id == target_id:
                     picker.highlighted = idx
@@ -278,6 +303,32 @@ class ConfigureSbomScreen(WizardScreen):
                 if opt.id == previous_highlighted_id:
                     picker.highlighted = idx
                     break
+
+        # Handle a cancelled CreateProfileScreen (Escape without saving).
+        # With "profile" as the default strategy, a zero-profile
+        # workspace reaches Enter→CreateProfile→Escape→Enter straight
+        # from the screen's defaults — break the loop the same way the
+        # sbomify.json form does below.
+        pressed_after_create = aug.pressed_button
+        if (
+            self._create_profile_visited
+            and not target_id
+            and pressed_after_create is not None
+            and pressed_after_create.id == "aug-profile"
+        ):
+            self._create_profile_visited = False
+            if self._profiles:
+                # Real profiles exist — move the highlight off the
+                # "+ Create new" sentinel so the next Enter advances
+                # with a real profile instead of re-pushing the form.
+                picker.highlighted = 1
+            else:
+                self._set_radio_value(aug, target_id="aug-skip")
+                self.notify(
+                    "Cancelled — augmentation reverted to Skip. Pick the radio again to retry.",
+                    title="Contact profile",
+                    severity="information",
+                )
 
         # Handle the sbomify.json form return: detect cancel-without-
         # save and flip back to Skip so the user isn't trapped in a
@@ -405,6 +456,7 @@ class ConfigureSbomScreen(WizardScreen):
             if self._picker_sentinel_highlighted():
                 from sbomify_action.cli.wizard.screens.create_profile import CreateProfileScreen
 
+                self._create_profile_visited = True
                 self.wizard.push_screen(CreateProfileScreen())
                 return
             plan.contact_profile_id = self._selected_profile_id()

--- a/tests/test_wizard_textual.py
+++ b/tests/test_wizard_textual.py
@@ -219,8 +219,12 @@ async def test_enter_on_focused_radio_set_toggles_radio(tmp_path: Path, monkeypa
     radio, so the inline profile picker never appeared. ``route_enter``
     on ``WizardScreen`` now detects RadioSet focus and toggles the
     highlighted button instead of forwarding.
+
+    Also pins the augmentation defaults: the recommended 'Use a contact
+    profile' radio is pressed at mount, the picker is visible, and the
+    first REAL profile (not the '+ Create new' sentinel) is highlighted.
     """
-    from textual.widgets import OptionList, RadioButton, RadioSet
+    from textual.widgets import OptionList, RadioSet
 
     lockfiles = [
         DiscoveredLockfile(
@@ -279,35 +283,54 @@ async def test_enter_on_focused_radio_set_toggles_radio(tmp_path: Path, monkeypa
 
         assert isinstance(app.screen, ConfigureSbomScreen)
 
-        # Focus the augmentation RadioSet; arrow down to highlight the
-        # profile radio; press Enter to commit. Without route_enter's
-        # RadioSet branch this advances to Review and the profile
-        # picker never becomes visible. RadioSet's own bindings consume
-        # Down (move) and Enter (commit highlighted) while the screen's
-        # Enter binding falls through via route_enter.
+        # Defaults: the recommended profile radio is pressed at mount,
+        # the picker is visible, and the highlight sits on the first
+        # REAL profile — index 0 is the "+ Create new" sentinel.
         aug = app.screen.query_one("#augmentation", RadioSet)
+        pressed = aug.pressed_button
+        assert pressed is not None and pressed.id == "aug-profile", (
+            f"Recommended aug-profile must be the default, got {pressed.id if pressed else None}"
+        )
+        picker = app.screen.query_one("#profile-picker", OptionList)
+        assert picker.display is True, "Profile picker must be visible for the default profile radio"
+        assert picker.highlighted == 1, "First REAL profile must be highlighted by default, not the sentinel"
+        # Picker shows the two stub profiles plus the "+ Create new"
+        # sentinel row that hands off to CreateProfileScreen.
+        assert picker.option_count == 3
+
+        # Focus the augmentation RadioSet; arrow down twice to highlight
+        # the Skip radio; press Enter to commit. Without route_enter's
+        # RadioSet branch this advances to Review instead of toggling.
+        # RadioSet's own bindings consume Down (move) while the screen's
+        # Enter binding falls through via route_enter.
         aug.focus()
         await pilot.pause()
-        await pilot.press("down")
+        await pilot.press("down")  # -> aug-json_config
+        await pilot.pause()
+        await pilot.press("down")  # -> aug-skip
         await pilot.pause()
         await pilot.press("enter")
         await pilot.pause()
-        # Drop the unused RadioButton import warning by referencing it.
-        _ = RadioButton
 
         assert isinstance(app.screen, ConfigureSbomScreen), (
             "Enter on focused RadioSet must NOT advance — should toggle radio"
         )
         pressed = aug.pressed_button
-        assert pressed is not None and pressed.id == "aug-profile", (
-            f"Expected aug-profile after down+enter, got {pressed.id if pressed else None}"
+        assert pressed is not None and pressed.id == "aug-skip", (
+            f"Expected aug-skip after down+down+enter, got {pressed.id if pressed else None}"
         )
+        assert picker.display is False, "Profile picker must hide when Skip is selected"
 
-        picker = app.screen.query_one("#profile-picker", OptionList)
-        assert picker.display is True, "Profile picker must appear after selecting profile radio"
-        # Picker shows the two stub profiles plus the "+ Create new"
-        # sentinel row that hands off to CreateProfileScreen.
-        assert picker.option_count == 3
+        # Arrow back up to the profile radio — the picker reappears.
+        await pilot.press("up")
+        await pilot.pause()
+        await pilot.press("up")
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        pressed = aug.pressed_button
+        assert pressed is not None and pressed.id == "aug-profile"
+        assert picker.display is True, "Profile picker must reappear after re-selecting profile radio"
 
 
 async def test_escape_from_components_goes_back_in_any_focus_state(
@@ -527,18 +550,13 @@ async def test_enter_on_create_profile_sentinel_pushes_create_screen(
 
         assert isinstance(app.screen, ConfigureSbomScreen)
 
-        # Toggle augmentation radio to "Use a contact profile" so the
-        # picker becomes visible; highlight the + Create new sentinel
+        # "Use a contact profile" is the default radio, so the picker
+        # is already visible; highlight the + Create new sentinel
         # (index 0) and press Enter.
         aug = app.screen.query_one("#augmentation", RadioSet)
-        aug.focus()
-        await pilot.pause()
-        await pilot.press("down")  # move to aug-profile
-        await pilot.pause()
-        await pilot.press("enter")  # commit the radio
-        await pilot.pause()
-
+        assert aug.pressed_button is not None and aug.pressed_button.id == "aug-profile"
         picker = app.screen.query_one("#profile-picker", OptionList)
+        assert picker.display is True
         picker.highlighted = 0  # + Create new sentinel
         await pilot.pause()
         # Move focus to the Next button so route_enter advances via _advance
@@ -551,6 +569,86 @@ async def test_enter_on_create_profile_sentinel_pushes_create_screen(
         assert isinstance(app.screen, CreateProfileScreen), (
             "Enter with the + Create new sentinel highlighted must push CreateProfileScreen, not advance to Review"
         )
+
+
+async def test_augmentation_default_with_no_profiles_bootstraps_create_and_cancel_reverts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With zero workspace profiles, the default recommended 'profile'
+    strategy highlights the '+ Create new' sentinel, so Enter routes to
+    CreateProfileScreen (the bootstrap path). Cancelling that form must
+    revert augmentation to Skip — otherwise the screen's own defaults
+    put the user in an Enter→Escape→Enter loop.
+    """
+    from textual.widgets import Button, OptionList, RadioSet
+
+    lockfiles = [
+        DiscoveredLockfile(
+            path=tmp_path / "uv.lock",
+            rel_path=Path("uv.lock"),
+            ecosystem="python",
+            suggested_name="widget-py",
+        )
+    ]
+    _stub_discovery(monkeypatch, lockfiles)
+    _stub_client(
+        monkeypatch,
+        products=[{"id": "p1", "name": "alpha"}],
+        components=[{"id": "c1", "name": "widget-py"}],
+        profiles=[],
+    )
+
+    app = WizardApp(_opts(tmp_path))
+    async with app.run_test(size=(120, 60)) as pilot:
+        # Walk to ConfigureSbom.
+        await pilot.press("enter")  # Welcome -> Discover
+        await pilot.pause()
+        await pilot.press("space")
+        await pilot.pause()
+        await pilot.press("enter")  # Discover -> Auth (auto-auth)
+        await pilot.pause(1.0)
+        await pilot.press("enter")  # Product -> Components
+        await pilot.pause()
+        await pilot.press("enter")  # Components -> ConfigureWorkflow
+        await pilot.pause()
+
+        from sbomify_action.cli.wizard.screens.configure_workflow import (
+            ConfigureWorkflowScreen,
+        )
+
+        assert isinstance(app.screen, ConfigureWorkflowScreen)
+        app.screen.query_one("#next", Button).focus()
+        await pilot.pause()
+        await pilot.press("enter")  # ConfigureWorkflow -> ConfigureSbom
+        await pilot.pause()
+
+        from sbomify_action.cli.wizard.screens.configure_sbom import ConfigureSbomScreen
+        from sbomify_action.cli.wizard.screens.create_profile import CreateProfileScreen
+
+        assert isinstance(app.screen, ConfigureSbomScreen)
+        configure_screen = app.screen
+        picker = configure_screen.query_one("#profile-picker", OptionList)
+        # Zero profiles: only the sentinel row exists, and it's highlighted.
+        assert picker.option_count == 1
+        assert picker.highlighted == 0
+
+        # Advance — the sentinel routes to CreateProfileScreen.
+        configure_screen.query_one("#next", Button).focus()
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.screen, CreateProfileScreen)
+
+        # Cancel the form — back on ConfigureSbom, augmentation must
+        # have reverted to Skip so Enter doesn't re-push the form.
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.screen is configure_screen
+        pressed = configure_screen.query_one("#augmentation", RadioSet).pressed_button
+        assert pressed is not None and pressed.id == "aug-skip", (
+            f"Cancelled CreateProfile must revert augmentation to Skip, got {pressed.id if pressed else None}"
+        )
+        assert picker.display is False
 
 
 async def test_enter_on_focused_back_button_goes_back(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

The wizard tags several options as **✓ recommended**, but the Augmentation group on Configure (SBOM) was the one group whose default didn't match its label — it defaulted to **Skip** while **Use a contact profile** carried the recommended tag. (Enrichment, formats, credentials, release strategy, and lifecycle phase already default to their recommended options; Build provenance deliberately defaults to Skip on private repos where attestation would fail without GHEC.)

## Changes

- **Reorder the augmentation radios** so "Use a contact profile ✓ recommended" is first and pressed by default (then sbomify.json, then Skip). Textual's `RadioSet` parks its keyboard cursor on the first button regardless of which is pressed, and every other group already lists recommended-first, so this keeps cursor and selection on the same row.
- **Reveal the profile picker at compose/mount.** Textual suppresses `RadioSet.Changed` for constructor-set values, so the event handler that normally shows the picker never fires for the default — without the static reveal, pressing Next would silently downgrade the visible "profile" selection to skip. The first real profile is highlighted at mount.
- **Break the new Enter-trap.** With zero workspace profiles the "+ Create new" sentinel is highlighted, so Enter bootstraps a profile via CreateProfileScreen. Cancelling that form now reverts augmentation to Skip with a notification, breaking the Enter→Escape→Enter loop the new default would otherwise make reachable (mirrors the existing sbomify.json-form cancel handling). When real profiles exist, a cancel just moves the highlight off the sentinel.

## Tests

- Updated the two Pilot tests that navigated by the old radio order; one now also pins the new defaults (profile pressed at mount, picker visible, first real profile highlighted).
- New test covering the zero-profiles bootstrap path and the cancel-revert-to-Skip behaviour.
- Full suite: 2441 passed, 4 skipped; ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)