### PR TITLE
chore(deps): cover bun, uv, and docker in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,31 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "bun"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      bun:
+        patterns:
+          - "*"
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      uv:
+        patterns:
+          - "*"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Dependabot only watched GitHub Actions here — `bun.lock`, `uv.lock`, and the `Dockerfile` were not receiving any updates
- Add native `bun` and `uv` ecosystem entries (not npm/pip, so the correct lockfiles get regenerated)
- Add a `docker` entry for base-image updates
- Group updates per ecosystem (one PR each), matching the main sbomify repo's convention, keeping the weekly cadence

🤖 Generated with [Claude Code](https://claude.com/claude-code)