### PR TITLE
chore(deps): exclude test-data fixtures from Dependabot scans

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    exclude-paths:
+      - "tests/test-data/**"
     groups:
       bun:
         patterns:
@@ -21,6 +23,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    exclude-paths:
+      - "tests/test-data/**"
     groups:
       uv:
         patterns:
@@ -29,6 +33,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    exclude-paths:
+      - "tests/test-data/**"
     groups:
       docker:
         patterns:


### PR DESCRIPTION
## Summary

Mirrors sbomify/sbomify#1140: the lockfile fixtures under `tests/test-data/` (`uv.lock`, `Cargo.lock`, `Pipfile.lock`, `requirements.txt`, etc.) generate Dependabot noise. This adds `exclude-paths: ["tests/test-data/**"]` to the `bun`, `uv`, and `docker` update blocks in `.github/dependabot.yml` so test fixtures are skipped during version-update scans.

The `github-actions` block is untouched since it only scans `.github/workflows`.

Note: `exclude-paths` applies to Dependabot version updates. For the uv dependency graph (which drives the security alerts) there is an open upstream bug where the graph builder ignores `exclude-paths` (dependabot/dependabot-core#15102), and `Cargo.lock` is parsed server-side by the dependency graph, so existing alerts on the fixtures may persist until that is fixed or the alerts are dismissed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)